### PR TITLE
Run pedantic clippy in CI

### DIFF
--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -18,3 +18,5 @@ jobs:
       run: cargo build --verbose
     - name: Run tests
       run: cargo test --verbose
+    - name: Run pedantic clippy
+      run: cargo clippy -- -D warnings -W clippy::pedantic

--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -18,5 +18,3 @@ jobs:
       run: cargo build --verbose
     - name: Run tests
       run: cargo test --verbose
-    - name: Run pedantic clippy
-      run: cargo clippy -- -D warnings -W clippy::pedantic

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,3 +13,4 @@ repos:
     hooks:
     -   id: fmt
     -   id: clippy
+        args: ["--", "-D", "warnings", "-W", "clippy::pedantic"]


### PR DESCRIPTION
I often find the clippy `pedantic` argument to be helpful. Feel free to ignore and close this PR.

This *would* be better as a pre-commit, but I could not for the life of me figure out how to pass in the `-W clippy::pedantic` argument to the pre-commit config; it just kept skipping over it, or saying it got an unexpected argument. I figured "better late (in the PR process) than never" applied here.