### PR TITLE
Added random module

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ homepage = "https://github.com/CDCgov/ixa"
 
 [dependencies]
 fxhash = "0.2.1"
+paste = "1.0.15"
 rand = "0.8.5"
 
 [dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,3 +10,6 @@ homepage = "https://github.com/CDCgov/ixa"
 [dependencies]
 fxhash = "0.2.1"
 rand = "0.8.5"
+
+[dev-dependencies]
+rand_distr = "0.4.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,3 +8,5 @@ license = "Apache-2.0"
 homepage = "https://github.com/CDCgov/ixa"
 
 [dependencies]
+fxhash = "0.2.1"
+rand = "0.8.5"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,3 +28,4 @@
 //!   person trying to infect susceptible people in the population.
 pub mod context;
 pub mod plan;
+pub mod random;

--- a/src/random.rs
+++ b/src/random.rs
@@ -104,6 +104,7 @@ mod test {
     use crate::context::Context;
     use crate::random::ContextRandomExt;
     use rand::RngCore;
+    use rand_distr::{Distribution, Exp};
 
     define_rng!(FooRng);
     define_rng!(BarRng);
@@ -150,6 +151,15 @@ mod test {
 
         let mut bar_rng = context.get_rng::<BarRng>();
         bar_rng.next_u64();
+    }
+
+    #[test]
+    fn usage_with_distribution() {
+        let mut context = Context::new();
+        context.init_random(42);
+        let mut rng = context.get_rng::<FooRng>();
+        let dist = Exp::new(1.0).unwrap();
+        assert_ne!(dist.sample(&mut *rng), dist.sample(&mut *rng));
     }
 
     #[test]

--- a/src/random.rs
+++ b/src/random.rs
@@ -1,0 +1,171 @@
+use crate::context::Context;
+use rand::SeedableRng;
+use std::any::{Any, TypeId};
+use std::cell::{RefCell, RefMut};
+use std::collections::HashMap;
+
+/// Use this to define a unique type which will be used as a key to retrieve
+/// an independent rng instance when calling `.get_rng`.
+#[macro_export]
+macro_rules! define_rng {
+    ($random_id:ident) => {
+        struct $random_id {}
+
+        impl $crate::random::RngId for $random_id {
+            // TODO: This is hardcoded to StdRng; we should replace this
+            type RngType = rand::rngs::StdRng;
+
+            fn get_name() -> &'static str {
+                stringify!($random_id)
+            }
+        }
+    };
+}
+pub use define_rng;
+
+pub trait RngId: Any {
+    type RngType: SeedableRng;
+    fn get_name() -> &'static str;
+}
+
+// This is a wrapper which allows for future support for different types of
+// random number generators (anything that implements SeedableRng is valid).
+struct RngHolder {
+    rng: Box<dyn Any>,
+}
+
+struct RngData {
+    base_seed: u64,
+    rng_holders: RefCell<HashMap<TypeId, RngHolder>>,
+}
+
+crate::context::define_data_plugin!(
+    RngPlugin,
+    RngData,
+    RngData {
+        base_seed: 0,
+        rng_holders: RefCell::new(HashMap::new()),
+    }
+);
+
+#[allow(clippy::module_name_repetitions)]
+pub trait RandomContext {
+    fn set_base_random_seed(&mut self, base_seed: u64);
+
+    fn get_rng<R: RngId>(&self) -> RefMut<'_, R::RngType>;
+}
+
+impl RandomContext for Context {
+    /// Initializes the `RngPlugin` data container to store rngs as well as a base
+    /// seed. Note that rngs are created lazily when `get_rng` is called.
+    fn set_base_random_seed(&mut self, base_seed: u64) {
+        let data_container = self.get_data_container_mut::<RngPlugin>();
+        data_container.base_seed = base_seed;
+
+        // Clear any existing Rngs to ensure they get re-seeded when `get_rng` is called
+        let mut rng_map = data_container.rng_holders.try_borrow_mut().unwrap();
+        rng_map.clear();
+    }
+
+    /// Gets a mutable reference to the random number generator associated with the given
+    /// `RngId`. If the Rng has not been used before, one will be created with the base seed
+    /// you defined in `set_base_random_seed`. Note that this will panic if `set_base_random_seed` was not called yet.
+    fn get_rng<R: RngId>(&self) -> RefMut<'_, R::RngType> {
+        let data_container = self
+            .get_data_container::<RngPlugin>()
+            .expect("You must initialize the random number generator with a base seed");
+        let random_holders = data_container.rng_holders.try_borrow_mut().unwrap();
+
+        let random_holder = RefMut::map(random_holders, |random_holders| {
+            random_holders.entry(TypeId::of::<R>()).or_insert_with(|| {
+                let base_seed = data_container.base_seed;
+                let seed_offset = fxhash::hash64(R::get_name());
+                RngHolder {
+                    rng: Box::new(R::RngType::seed_from_u64(base_seed + seed_offset)),
+                }
+            })
+        });
+
+        RefMut::map(random_holder, |random_holder| {
+            random_holder.rng.downcast_mut::<R::RngType>().unwrap()
+        })
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use crate::context::Context;
+    use crate::random::RandomContext;
+    use rand::RngCore;
+
+    define_rng!(FooRng);
+    define_rng!(BarRng);
+
+    #[test]
+    fn get_rng_basic() {
+        let mut context = Context::new();
+        context.set_base_random_seed(42);
+
+        let mut foo_rng = context.get_rng::<FooRng>();
+        assert_eq!(foo_rng.next_u64(), 5113542052170610017);
+        assert_eq!(foo_rng.next_u64(), 8640506012583485895);
+        assert_eq!(foo_rng.next_u64(), 16699691489468094833);
+    }
+
+    #[test]
+    #[should_panic(expected = "You must initialize the random number generator with a base seed")]
+    fn panic_if_not_initialized() {
+        let context = Context::new();
+        context.get_rng::<FooRng>();
+    }
+
+    #[test]
+    #[should_panic]
+    fn get_rng_one_ref_per_rng_id() {
+        let mut context = Context::new();
+        context.set_base_random_seed(42);
+        let mut foo_rng = context.get_rng::<FooRng>();
+
+        // This should panic because we already have a mutable reference to FooRng
+        let mut foo_rng_2 = context.get_rng::<BarRng>();
+        foo_rng.next_u64();
+        foo_rng_2.next_u64();
+    }
+
+    #[test]
+    fn get_rng_two_types() {
+        let mut context = Context::new();
+        context.set_base_random_seed(42);
+
+        let mut foo_rng = context.get_rng::<FooRng>();
+        foo_rng.next_u64();
+        drop(foo_rng);
+
+        let mut bar_rng = context.get_rng::<BarRng>();
+        bar_rng.next_u64();
+    }
+
+    #[test]
+    fn reset_seed() {
+        let mut context = Context::new();
+        context.set_base_random_seed(42);
+
+        let mut foo_rng = context.get_rng::<FooRng>();
+        let run_0 = foo_rng.next_u64();
+        let run_1 = foo_rng.next_u64();
+        drop(foo_rng);
+
+        // Reset with same seed, ensure we get the same values
+        context.set_base_random_seed(42);
+        let mut foo_rng = context.get_rng::<FooRng>();
+        assert_eq!(run_0, foo_rng.next_u64());
+        assert_eq!(run_1, foo_rng.next_u64());
+        drop(foo_rng);
+
+        // Reset with different seed, ensure we get different values
+        context.set_base_random_seed(88);
+        let mut foo_rng = context.get_rng::<FooRng>();
+        assert_ne!(run_0, foo_rng.next_u64());
+        assert_ne!(run_1, foo_rng.next_u64());
+    }
+}

--- a/src/random.rs
+++ b/src/random.rs
@@ -294,7 +294,6 @@ mod test {
     fn sample_bool() {
         let mut context = Context::new();
         context.init_random(42);
-        let result = context.sample_bool(FooRng, 0.5);
-        assert!(result == true || result == false);
+        let _r: bool = context.sample_bool(FooRng, 0.5);
     }
 }

--- a/src/random.rs
+++ b/src/random.rs
@@ -23,7 +23,7 @@ macro_rules! define_rng {
 }
 pub use define_rng;
 
-pub trait RngId: Any {
+pub trait RngId {
     type RngType: SeedableRng;
     fn get_name() -> &'static str;
 }
@@ -57,7 +57,7 @@ crate::context::define_data_plugin!(
 pub trait ContextRandomExt {
     fn init_random(&mut self, base_seed: u64);
 
-    fn get_rng<R: RngId>(&self) -> RefMut<R::RngType>;
+    fn get_rng<R: RngId + 'static>(&self) -> RefMut<R::RngType>;
 }
 
 impl ContextRandomExt for Context {

--- a/src/random.rs
+++ b/src/random.rs
@@ -22,9 +22,11 @@ macro_rules! define_rng {
         }
 
         // This ensures that you can't define two RngIds with the same name
-        #[doc(hidden)]
-        #[no_mangle]
-        pub static $random_id: () = ();
+        paste::paste! {
+            #[doc(hidden)]
+            #[no_mangle]
+            pub static [<rng_name_duplication_guard_ $random_id>]: () = ();
+        }
     };
 }
 pub use define_rng;

--- a/src/random.rs
+++ b/src/random.rs
@@ -206,7 +206,7 @@ mod test {
     }
 
     #[test]
-    fn multiple_references_with_drop() {
+    fn multiple_rng_types() {
         let mut context = Context::new();
         context.init_random(42);
 

--- a/src/random.rs
+++ b/src/random.rs
@@ -99,7 +99,7 @@ pub trait ContextRandomExt {
     /// Note that this will panic if `set_base_random_seed` was not called yet.
     fn sample<R: RngId + 'static, T>(
         &self,
-        _rang_type: R,
+        _rng_type: R,
         sampler: impl FnOnce(&mut R::RngType) -> T,
     ) -> T;
 

--- a/src/random.rs
+++ b/src/random.rs
@@ -19,6 +19,11 @@ macro_rules! define_rng {
                 stringify!($random_id)
             }
         }
+
+        // This ensures that you can't define two RngIds with the same name
+        #[doc(hidden)]
+        #[no_mangle]
+        pub static $random_id: () = ();
     };
 }
 pub use define_rng;

--- a/src/random.rs
+++ b/src/random.rs
@@ -12,7 +12,7 @@ use std::collections::HashMap;
 #[macro_export]
 macro_rules! define_rng {
     ($random_id:ident) => {
-        struct $random_id {}
+        struct $random_id;
 
         impl $crate::random::RngId for $random_id {
             // TODO(ryl8@cdc.gov): This is hardcoded to StdRng; we should replace this
@@ -107,7 +107,7 @@ pub trait ContextRandomExt {
     where
         R::RngType: Rng;
 
-    fn sample_range<R: RngId + 'static, S, T>(&self, range: S) -> T
+    fn sample_range<R: RngId + 'static, S, T>(&self, rng_type: R, range: S) -> T
     where
         R::RngType: Rng,
         S: SampleRange<T>,
@@ -139,7 +139,7 @@ impl ContextRandomExt for Context {
         distribution.sample::<R::RngType>(&mut rng)
     }
 
-    fn sample_range<R: RngId + 'static, S, T>(&self, range: S) -> T
+    fn sample_range<R: RngId + 'static, S, T>(&self, _rng_id: R, range: S) -> T
     where
         R::RngType: Rng,
         S: SampleRange<T>,
@@ -259,7 +259,7 @@ mod test {
     fn sample_range() {
         let mut context = Context::new();
         context.init_random(42);
-
-        context.sample_range::<FooRng, std::ops::Range<usize>, usize>(0..10);
+        let result = context.sample_range(FooRng, 0..10);
+        assert!(result >= 0 && result < 10);
     }
 }

--- a/src/random.rs
+++ b/src/random.rs
@@ -120,6 +120,10 @@ pub trait ContextRandomExt {
         R::RngType: Rng,
         S: SampleRange<T>,
         T: SampleUniform;
+
+    fn sample_bool<R: RngId + 'static>(&self, rng_id: R, p: f64) -> bool
+    where
+        R::RngType: Rng;
 }
 
 impl ContextRandomExt for Context {
@@ -162,6 +166,13 @@ impl ContextRandomExt for Context {
         T: SampleUniform,
     {
         self.sample(rng_id, |rng| rng.gen_range(range))
+    }
+
+    fn sample_bool<R: RngId + 'static>(&self, rng_id: R, p: f64) -> bool
+    where
+        R::RngType: Rng,
+    {
+        self.sample(rng_id, |rng| rng.gen_bool(p))
     }
 }
 
@@ -277,5 +288,13 @@ mod test {
         context.init_random(42);
         let result = context.sample_range(FooRng, 0..10);
         assert!(result >= 0 && result < 10);
+    }
+
+    #[test]
+    fn sample_bool() {
+        let mut context = Context::new();
+        context.init_random(42);
+        let result = context.sample_bool(FooRng, 0.5);
+        assert!(result == true || result == false);
     }
 }


### PR DESCRIPTION
This PR adds a module to support creating and using random generators. It's implemented as a trait on context, with a `DataPlugin` to store a base random seed and a hashmap of rng instances. The design supports any rng implementation that implements `rand::SeedableRandom`.

The basic idea is you initialize the utility with a base random seed when setting up a `context`:
```rust
context.set_base_random_seed(12345678);
```
In a module that needs an independent random number generator, you use a macro to define an independent type, and then call `context.get_rng::<YourType>()` to retrieve it. For example:

```rust
define_rng!(FooRng)

let mut rng = context.get_rng::<FooRng>();
let value = rng.next_u64();
```
Note that an `rng` needs a mutable reference because it has to store internal state about previous calls in order to be reproducible.

One difference from the eosim implementation here is that I destroy existing rngs if `base_seed` is changed rather than using a flag on the holder. 