### PR TITLE
Added two reports examples

### DIFF
--- a/examples/reports-multi-threaded/README.md
+++ b/examples/reports-multi-threaded/README.md
@@ -1,0 +1,3 @@
+# Reports - Multi-Threaded Scenarios
+
+This example demonstrates report writing for several scenarios running in parallel.

--- a/examples/reports-multi-threaded/main.rs
+++ b/examples/reports-multi-threaded/main.rs
@@ -1,0 +1,24 @@
+use ixa::context::Context;
+use std::thread;
+
+fn main() {
+    let scenarios = vec!["Illinois", "Wisconsin", "Arizona", "California"];
+    let mut handles = vec![];
+
+    for scenario in scenarios {
+        let scenario = scenario.to_string();
+        let handle = thread::spawn(move || {
+            // Replace this with the actual example code, similar to the simple
+            // example in examples/reports/main.rs
+            let mut context = Context::new();
+            println!("Scenario: {}", scenario);
+
+            context.execute();
+        });
+        handles.push(handle);
+    }
+
+    for handle in handles {
+        handle.join().unwrap();
+    }
+}

--- a/examples/reports/README.md
+++ b/examples/reports/README.md
@@ -1,4 +1,4 @@
 # Reports - Simple Example
 
 This example demonstrates creating two types of reports (incidence and death),
-and writing the reports from plans.
+and writing rows to each report from a plan.

--- a/examples/reports/README.md
+++ b/examples/reports/README.md
@@ -1,0 +1,4 @@
+# Reports - Simple Example
+
+This example demonstrates creating two types of reports (incidence and death),
+and writing the reports from plans.

--- a/examples/reports/main.rs
+++ b/examples/reports/main.rs
@@ -1,0 +1,33 @@
+use ixa::context::Context;
+
+fn main() {
+    let mut context = Context::new();
+
+    #[cfg(feature = "reports")]
+    context.add_report::<Incidence>("incidence");
+    #[cfg(feature = "reports")]
+    context.add_report::<Death>("death");
+
+    context.add_plan(1.0, |context| {
+        #[cfg(feature = "reports")]
+        context.send_report(Incidence {
+            person_id: 1,
+            t: context.get_current_time(),
+        });
+        println!(
+            "Person 1 was infected at time {}",
+            context.get_current_time()
+        );
+    });
+
+    context.add_plan(2.0, |context| {
+        #[cfg(feature = "reports")]
+        context.send_report(Death {
+            person_id: 1,
+            t: context.get_current_time(),
+        });
+        println!("Person 1 died at time {}", context.get_current_time());
+    });
+
+    context.execute();
+}


### PR DESCRIPTION
This PR adds a skeleton for report writing examples which will support Ranya's work in https://github.com/CDCgov/ixa/issues/22, which will implement a report writing module.

You can run examples with `cargo run --example reports` etc.