### PR TITLE
Report Example for Multi-Threading

### DIFF
--- a/examples/reports-multi-threaded/main.rs
+++ b/examples/reports-multi-threaded/main.rs
@@ -18,16 +18,18 @@ fn main() {
             let people = vec!["1", "2", "3"];
             for person in people {
                 let person = person.to_string();
+                let scenario = scenario.clone();
                 context.add_plan(1.0, {
-                    let person = person.clone();
                     move |context| {
                         #[cfg(feature = "reports")]
                         context.send_report(Incidence {
+                            scenario: scenario,
                             person_id: person.clone(),
                             t: context.get_current_time(),
                         });
                         println!(
-                            "Person {} was infected at time {}.",
+                            "Scenario: {}, Person {} was infected at time {}.",
+                            scenario,
                             person,
                             context.get_current_time()
                         );

--- a/examples/reports-multi-threaded/main.rs
+++ b/examples/reports-multi-threaded/main.rs
@@ -1,6 +1,12 @@
 use ixa::context::Context;
 use std::thread;
 
+struct Incidence {
+    scenario: String,
+    person_id: String,
+    t: f64,
+}
+
 fn main() {
     let scenarios = vec!["Illinois", "Wisconsin", "Arizona", "California"];
     let mut handles = vec![];

--- a/examples/reports-multi-threaded/main.rs
+++ b/examples/reports-multi-threaded/main.rs
@@ -8,10 +8,50 @@ fn main() {
     for scenario in scenarios {
         let scenario = scenario.to_string();
         let handle = thread::spawn(move || {
-            // Replace this with the actual example code, similar to the simple
-            // example in examples/reports/main.rs
             let mut context = Context::new();
+
+            #[cfg(feature = "reports")]
+            context.add_report::<Incidence>("Incidence");
+            #[cfg(feature = "reports")]
+            context.add_report::<Death>("Death");
+
             println!("Scenario: {}", scenario);
+
+            let people = vec!["1", "2", "3"];
+            for person in people {
+                let person = person.to_string();
+                context.add_plan(1.0, {
+                    let person = person.clone();
+                    move |context| {
+                        #[cfg(feature = "reports")]
+                        context.send_report(Incidence {
+                            person_id: person.clone(),
+                            t: context.get_current_time(),
+                        });
+                        println!(
+                            "Person {} was infected at time {}",
+                            person,
+                            context.get_current_time()
+                        );
+                    }
+                });
+
+                context.add_plan(2.0, {
+                    let person = person.clone();
+                    move |context| {
+                        #[cfg(feature = "reports")]
+                        context.send_report(Death {
+                            person_id: person.clone(),
+                            t: context.get_current_time(),
+                        });
+                        println!(
+                            "Person {} died at time {}",
+                            person,
+                            context.get_current_time()
+                        );
+                    }
+                });
+            }
 
             context.execute();
         });

--- a/examples/reports-multi-threaded/main.rs
+++ b/examples/reports-multi-threaded/main.rs
@@ -12,9 +12,7 @@ fn main() {
 
             #[cfg(feature = "reports")]
             context.add_report::<Incidence>("Incidence");
-            #[cfg(feature = "reports")]
-            context.add_report::<Death>("Death");
-
+            
             println!("Scenario: {}", scenario);
 
             let people = vec!["1", "2", "3"];
@@ -30,22 +28,6 @@ fn main() {
                         });
                         println!(
                             "Person {} was infected at time {}",
-                            person,
-                            context.get_current_time()
-                        );
-                    }
-                });
-
-                context.add_plan(2.0, {
-                    let person = person.clone();
-                    move |context| {
-                        #[cfg(feature = "reports")]
-                        context.send_report(Death {
-                            person_id: person.clone(),
-                            t: context.get_current_time(),
-                        });
-                        println!(
-                            "Person {} died at time {}",
                             person,
                             context.get_current_time()
                         );

--- a/examples/reports-multi-threaded/main.rs
+++ b/examples/reports-multi-threaded/main.rs
@@ -12,7 +12,7 @@ fn main() {
 
             #[cfg(feature = "reports")]
             context.add_report::<Incidence>("Incidence");
-            
+
             println!("Scenario: {}", scenario);
 
             let people = vec!["1", "2", "3"];
@@ -27,7 +27,7 @@ fn main() {
                             t: context.get_current_time(),
                         });
                         println!(
-                            "Person {} was infected at time {}",
+                            "Person {} was infected at time {}.",
                             person,
                             context.get_current_time()
                         );


### PR DESCRIPTION
This PR adds a report writing example for multi-threading, which will implement the report writing module.

You can run examples with cargo run --example reports-multi-threaded.