### PR TITLE
Add Person Properties

### DIFF
--- a/examples/load-people/README.md
+++ b/examples/load-people/README.md
@@ -1,0 +1,165 @@
+# Example: People and Person Properties
+
+This example demonstrates the following features related to people and their
+related properties:
+
+* Adding people to a simulation
+* Defining person properties and initializing them
+* Loading a population of people and their properties from a csv file
+* Assigning person properties from an external module, including assigning initial (default) values
+* Handling person creation and change events
+
+### People
+
+At a high level, each person in an ixa simulation is represented by an integer in the
+range of `0` to `population - 1`, where `population` is the total number of people.
+
+When you are referring to a person in order to do things with them, you will use a `PersonId`
+struct, which internally stores its automatically assigned `id` (the index in
+the population range):
+
+```rust
+ let person: PersonId = context.add_person();
+ println!("Person {} was created", person.id)
+ ```
+
+### Person Properties
+
+Person properties are a pair of an identifier type and a value type, which represent
+some characteristic or state about a person.
+
+For example, this model implements Age and RiskStatus using
+`the define_person_property!` macro:
+
+```rust
+#[derive(Copy)]
+pub enum RiskCategory { High, Low }
+
+define_person_property!(Age, u8);
+define_person_property!(RiskCategoryType, RiskCategory);
+```
+
+Person property value types **must** implement `Copy` in order to make them efficient
+to be copied around in large numbers. This generally means you need to use simple
+types (e.g., floats, integers, booleans, an enum instead of a string).
+
+Context provides methods to get and set person properties for a given person:
+
+```rust
+let person = context.add_person();
+context.set_person_property(person, Age, 69);
+assert!(context.get_person_property(person, Age), 69);
+```
+
+
+### Initializing person properties
+
+In ixa, every property must be initialized before it is accessed. The preferred
+way to do this is to define an `initializer` which is lazily evaluated,
+but you can also assign initial values manually – several patterns
+are described below, and demonstrated in the example model. You can do this
+using the `define_person_property!` macro.
+
+Note that when initial values are assigned they do *not* trigger a
+`PersonPropertyChangeEvent`.
+
+#### Simple default values
+
+If you want all people to be initialized with the same default value, you can
+simply pass in the value to the the `define_person_property_with_default!` macro.
+
+You can see an example of this in `sir.rs`, which assigns a default disease
+status:
+
+```rust
+#[derive(Copy)]
+pub enum DiseaseStatus { S, I, R }
+define_person_property_with_default!(DiseaseStatusType, DiseaseStatus, DiseaseStatus::S);
+```
+
+#### Custom initializer
+
+If you need custom logic or you have dependencies on other properties to compute
+initial values, you can also define a custom initializer that takes a reference
+to context and a person identifier using `define_person_property!`.
+
+Initializers are called lazily the first time the property is accessed via
+`get_person_property` and do *not* trigger change events.
+
+For example,`vaccine.rs` defines an initializer that computes how many vaccine
+doses someone should be assigned based on their age:
+
+```rust
+define_person_property!(
+    VaccineDoses,
+    u8,
+    |context, person_id| {
+        let age = context.get_person_property(person_id, Age);
+        if (age > 10) { 1 } else { 0 }
+    }
+);
+```
+
+Sometimes properties may need to be initialized with data contributed from somewhere
+else. If that's the case, you can make it available via context:
+
+```rust
+define_person_property!(
+    VaccineType,
+    VaccineTypeValue,
+    |_context, _person_id| {
+        context.get_random_vaccine()
+    }
+);
+
+impl VaccineContextExt for Context {
+    fn get_random_vaccine() {
+        //....
+    }
+}
+```
+
+#### Manual assignment
+
+You can also initialize values manually with `set_person_property`, which will
+override any default initializers on the type. However, you must be careful to
+ensure that this happens before the property is accessed (or the simulation will panic).
+
+One common use case for manual assignment is when you need to load people from a csv file.
+In that case, you can read the properties and assign them a population loader.
+
+You can see an example of this in `population_loader.rs`:
+
+```rust
+let person = context.add_person();
+context.set_person_property(person, Age, record.age);
+context.set_person_property(person, RiskCategoryType, record.risk_category);
+let (vaccine_efficacy, vaccine_type) = context.generate_vaccine_props(record.risk_category);
+context.set_person_property(person, VaccineEfficacy, vaccine_efficacy);
+context.set_person_property(person, VaccineType, vaccine_type);
+```
+
+As long as you assign properties in the same function context as where add_person
+is created, they will be assigned before any other regular `PersonCreated` events
+handlers are called.
+
+### Observing person property changes
+
+Models can subscribe to a `PersonPropertyChangeEvent` in order to observe when
+a person property is changed, such as to output the change to a report. Note
+that when properties are first set, they will *not* emit any change events;
+
+```rust
+ context.subscribe_to_event(
+        |_context, event: PersonPropertyChangeEvent<DiseaseStatusType>| {
+            let person = event.person_id;
+            println!(
+                "Person {} changed disease status from {:?} to {:?}",
+                person.id, event.previous, event.current,
+            );
+        },
+    );
+```
+
+If you want to observe the initial value of a property, you should subscribe to
+the `PersonCreatedEvent` and access the property with `context.get_person_property`.

--- a/examples/load-people/logger.rs
+++ b/examples/load-people/logger.rs
@@ -1,0 +1,36 @@
+use crate::{
+    population_loader::Age,
+    sir::DiseaseStatusType,
+    vaccine::{VaccineDoses, VaccineEfficacy, VaccineType},
+};
+use ixa::{
+    context::Context,
+    people::{ContextPeopleExt, PersonCreatedEvent, PersonPropertyChangeEvent},
+};
+
+pub fn init(context: &mut Context) {
+    // This subscribes to the disease status change events
+    // Note that no event gets fired when the property is set the first time
+    context.subscribe_to_event(
+        |_context, event: PersonPropertyChangeEvent<DiseaseStatusType>| {
+            let person = event.person_id;
+            println!(
+                "{:?} changed disease status from {:?} to {:?}",
+                person, event.previous, event.current,
+            );
+        },
+    );
+
+    // Logs when a person is created
+    context.subscribe_to_event(|context, event: PersonCreatedEvent| {
+        let person = event.person_id;
+        println!(
+            "{:?} age: {}, {} vaccine doses, vaccine {:?} ({})",
+            person,
+            context.get_person_property(person, Age),
+            context.get_person_property(person, VaccineDoses),
+            context.get_person_property(person, VaccineType),
+            context.get_person_property(person, VaccineEfficacy)
+        );
+    });
+}

--- a/examples/load-people/main.rs
+++ b/examples/load-people/main.rs
@@ -1,0 +1,23 @@
+use ixa::{context::Context, random::ContextRandomExt};
+mod logger;
+mod population_loader;
+mod sir;
+mod vaccine;
+
+fn main() {
+    let mut context = Context::new();
+
+    context.init_random(42);
+
+    // Sets up some event listeners on person creation and property changes
+    logger::init(&mut context);
+
+    // This sets up the DiseaseStatus person property and schedules infections/recoveries
+    // when each person is created.
+    sir::init(&mut context);
+
+    // Load people from csv and set up some base properties
+    population_loader::init(&mut context);
+
+    context.execute();
+}

--- a/examples/load-people/people.csv
+++ b/examples/load-people/people.csv
@@ -1,0 +1,6 @@
+id,age,risk_category
+0,24,Low
+1,8,Low
+2,67,High
+3,4,Low
+4,89,High

--- a/examples/load-people/population_loader.rs
+++ b/examples/load-people/population_loader.rs
@@ -1,0 +1,137 @@
+use std::path::Path;
+
+use crate::vaccine::{ContextVaccineExt, VaccineEfficacy, VaccineType};
+use ixa::context::Context;
+use ixa::define_person_property;
+use ixa::people::{ContextPeopleExt, PersonId};
+use serde::Deserialize;
+
+#[derive(Deserialize, Copy, Clone, PartialEq, Eq, Debug)]
+pub enum RiskCategory {
+    High,
+    Low,
+}
+
+#[derive(Deserialize, Debug)]
+struct PeopleRecord {
+    age: u8,
+    risk_category: RiskCategory,
+}
+
+define_person_property!(Age, u8);
+define_person_property!(RiskCategoryType, RiskCategory);
+
+fn create_person_from_record(context: &mut Context, record: &PeopleRecord) -> PersonId {
+    let person = context.add_person();
+    context.set_person_property(person, Age, record.age);
+    context.set_person_property(person, RiskCategoryType, record.risk_category);
+
+    // Set vaccine type and efficacy based on risk category
+    let (t, e) = context.get_vaccine_props(record.risk_category);
+    context.set_person_property(person, VaccineType, t);
+    context.set_person_property(person, VaccineEfficacy, e);
+
+    person
+}
+
+pub fn init(context: &mut Context) {
+    // Load csv and deserialize records
+    let current_dir = Path::new(file!()).parent().unwrap();
+    let mut reader = csv::Reader::from_path(current_dir.join("people.csv")).unwrap();
+
+    for result in reader.deserialize() {
+        let record: PeopleRecord = result.expect("Failed to parse record");
+        create_person_from_record(context, &record);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{cell::RefCell, rc::Rc};
+
+    use super::*;
+    use crate::{
+        population_loader::Age,
+        vaccine::{VaccineDoses, VaccineEfficacy, VaccineType, VaccineTypeValue},
+    };
+    use ixa::{
+        context::Context,
+        people::{PersonCreatedEvent, PersonPropertyChangeEvent},
+        random::ContextRandomExt,
+    };
+
+    const EXPECTED_ROWS: usize = 5;
+
+    #[test]
+    fn test_init_expected_rows() {
+        let mut context = Context::new();
+        context.init_random(42);
+        init(&mut context);
+        assert_eq!(context.get_current_population(), EXPECTED_ROWS);
+    }
+
+    #[test]
+    fn test_creation_event_access_properties() {
+        let flag = Rc::new(RefCell::new(false));
+
+        // Define expected computed values for each person
+        let expected_computed = vec![
+            (20, RiskCategory::Low, VaccineTypeValue::B, 0.8, 1),
+            (80, RiskCategory::High, VaccineTypeValue::A, 0.9, 2),
+        ];
+
+        let mut context = Context::new();
+        context.init_random(42);
+
+        // Subscribe to person property change event
+        let flag_clone = Rc::clone(&flag);
+        context.subscribe_to_event(
+            move |_context, _event: PersonPropertyChangeEvent<VaccineEfficacy>| {
+                *flag_clone.borrow_mut() = true;
+            },
+        );
+
+        let counter = Rc::new(RefCell::new(0));
+        let expected_computed = Rc::new(expected_computed);
+
+        context.subscribe_to_event({
+            let counter = Rc::clone(&counter);
+            let expected_computed = Rc::clone(&expected_computed);
+
+            move |context, event: PersonCreatedEvent| {
+                let person = event.person_id;
+                let current_count = *counter.borrow();
+                let (age, risk_category, vaccine_type, efficacy, doses) =
+                    expected_computed[current_count];
+
+                assert_eq!(context.get_person_property(person, Age), age);
+                assert_eq!(
+                    context.get_person_property(person, RiskCategoryType),
+                    risk_category
+                );
+                assert_eq!(
+                    context.get_person_property(person, VaccineType),
+                    vaccine_type
+                );
+                assert_eq!(
+                    context.get_person_property(person, VaccineEfficacy),
+                    efficacy
+                );
+                assert_eq!(context.get_person_property(person, VaccineDoses), doses);
+
+                *counter.borrow_mut() += 1;
+            }
+        });
+
+        // Create people from records based on expected values
+        for &(age, risk_category, _, _, _) in expected_computed.iter() {
+            create_person_from_record(&mut context, &PeopleRecord { age, risk_category });
+        }
+
+        // Execute the context
+        context.execute();
+
+        // Make sure PersonPropertyChangeEvent didn't fire
+        assert!(!*flag.borrow());
+    }
+}

--- a/examples/load-people/sir.rs
+++ b/examples/load-people/sir.rs
@@ -1,0 +1,67 @@
+use ixa::{
+    context::Context,
+    define_person_property, define_person_property_with_default,
+    people::{ContextPeopleExt, PersonCreatedEvent},
+};
+
+#[derive(Copy, Clone, PartialEq, Eq, Debug)]
+pub enum DiseaseStatus {
+    S,
+    I,
+    R,
+}
+
+define_person_property_with_default!(DiseaseStatusType, DiseaseStatus, DiseaseStatus::S);
+
+pub fn init(context: &mut Context) {
+    context.subscribe_to_event(move |context, event: PersonCreatedEvent| {
+        let person = event.person_id;
+        context.add_plan(1.0, move |context| {
+            context.set_person_property(person, DiseaseStatusType, DiseaseStatus::I);
+        });
+        context.add_plan(2.0, move |context| {
+            context.set_person_property(person, DiseaseStatusType, DiseaseStatus::R);
+        });
+    });
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ixa::{context::Context, people::PersonPropertyChangeEvent};
+
+    #[test]
+    fn test_disease_status() {
+        let mut context = Context::new();
+        init(&mut context);
+
+        let person = context.add_person();
+
+        // People should start in the S state
+        assert_eq!(
+            context.get_person_property(person, DiseaseStatusType),
+            DiseaseStatus::S
+        );
+
+        // At 1.0, people should be in the I state
+        context.subscribe_to_event(
+            |context, event: PersonPropertyChangeEvent<DiseaseStatusType>| {
+                let person = event.person_id;
+                if context.get_current_time() == 1.0 {
+                    assert_eq!(
+                        context.get_person_property(person, DiseaseStatusType),
+                        DiseaseStatus::I
+                    );
+                }
+            },
+        );
+
+        context.execute();
+
+        // People should end up in the R state by the end of the simulation
+        assert_eq!(
+            context.get_person_property(person, DiseaseStatusType),
+            DiseaseStatus::R
+        );
+    }
+}

--- a/examples/load-people/vaccine.rs
+++ b/examples/load-people/vaccine.rs
@@ -1,0 +1,38 @@
+use crate::population_loader::{Age, RiskCategory};
+use ixa::{
+    context::Context, define_person_property, define_rng, people::ContextPeopleExt,
+    random::ContextRandomExt,
+};
+
+define_rng!(VaccineRng);
+
+#[allow(clippy::module_name_repetitions)]
+#[derive(Copy, Clone, PartialEq, Eq, Debug)]
+pub enum VaccineTypeValue {
+    A,
+    B,
+}
+define_person_property!(VaccineType, VaccineTypeValue);
+define_person_property!(VaccineEfficacy, f64);
+define_person_property!(VaccineDoses, u8, |context: &Context, person_id| {
+    let age = context.get_person_property(person_id, Age);
+    if age > 10 {
+        context.sample_range(VaccineRng, 0..5)
+    } else {
+        0
+    }
+});
+
+pub trait ContextVaccineExt {
+    fn get_vaccine_props(&self, risk: RiskCategory) -> (VaccineTypeValue, f64);
+}
+
+impl ContextVaccineExt for Context {
+    fn get_vaccine_props(self: &Context, risk: RiskCategory) -> (VaccineTypeValue, f64) {
+        if risk == RiskCategory::High {
+            (VaccineTypeValue::A, 0.9)
+        } else {
+            (VaccineTypeValue::B, 0.8)
+        }
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,6 +27,7 @@
 //! * A transmission manager that models the process of an infected
 //!   person trying to infect susceptible people in the population.
 pub mod context;
+pub mod people;
 pub mod plan;
 pub mod random;
 pub mod report;

--- a/src/people.rs
+++ b/src/people.rs
@@ -1,0 +1,441 @@
+use crate::{context::Context, define_data_plugin};
+use std::{
+    any::{Any, TypeId},
+    cell::{RefCell, RefMut},
+    collections::HashMap,
+    fmt,
+};
+
+// PeopleData represents each unique person in the simulation with an id ranging
+// from 0 to population - 1. Person properties are associated with a person
+// via their id.
+struct PeopleData {
+    current_population: usize,
+    properties_map: RefCell<HashMap<TypeId, Box<dyn Any>>>,
+}
+
+define_data_plugin!(
+    PeoplePlugin,
+    PeopleData,
+    PeopleData {
+        current_population: 0,
+        properties_map: RefCell::new(HashMap::new())
+    }
+);
+
+// Represents a unique person - the id refers to that person's index in the range
+// 0 to population - 1 in the PeopleData container.
+#[derive(Clone, Copy, Hash, PartialEq, Eq)]
+pub struct PersonId {
+    id: usize,
+}
+
+impl fmt::Debug for PersonId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "Person {}", self.id)
+    }
+}
+
+// Individual characteristics or states related to a person, such as age or
+// disease status, are represented as "person properties". These properties
+// * are represented by a struct type that implements the PersonProperty trait,
+// * specify a Value type to represent the data associated with the property,
+// * specify an initializer, which returns the initial value
+// They may be defined with the define_person_property! macro.
+pub trait PersonProperty: Copy {
+    type Value: Copy;
+    fn initialize(context: &Context, person_id: PersonId) -> Self::Value;
+}
+
+/// Defines a person property with the following parameters:
+/// * `$person_property`: A name for the identifier type of the property
+/// * `$value`: The type of the property's value
+/// * `$initialize`: (Optional) A function that takes a `Context` and `PersonId` and
+///   returns the initial value. If it is not defined, calling `get_person_property`
+///   on the property without explicitly setting a value first will panic.
+#[macro_export]
+macro_rules! define_person_property {
+    ($person_property:ident, $value:ty, $initialize:expr) => {
+        #[derive(Copy, Clone)]
+        pub struct $person_property;
+        impl $crate::people::PersonProperty for $person_property {
+            type Value = $value;
+            fn initialize(
+                _context: &$crate::context::Context,
+                _person: $crate::people::PersonId,
+            ) -> Self::Value {
+                $initialize(_context, _person)
+            }
+        }
+    };
+    ($person_property:ident, $value:ty) => {
+        define_person_property!($person_property, $value, |_context, _person_id| {
+            panic!("Property not initialized");
+        });
+    };
+}
+
+/// Defines a person property with the following parameters:
+/// * `$person_property`: A name for the identifier type of the property
+/// * `$value`: The type of the property's value
+/// * `$default`: An initial value
+#[macro_export]
+macro_rules! define_person_property_with_default {
+    ($person_property:ident, $value:ty, $default:expr) => {
+        define_person_property!($person_property, $value, |_context, _person_id| {
+            $default
+        });
+    };
+}
+
+pub use define_person_property;
+
+impl PeopleData {
+    /// Adds a person and returns a `PersonId` that can be used to reference them.
+    /// This will increment the current population by 1.
+    fn add_person(&mut self) -> PersonId {
+        let id = self.current_population;
+        self.current_population += 1;
+        PersonId { id }
+    }
+
+    /// Retrieves a specific property of a person by their `PersonId`.
+    ///
+    /// Returns `RefMut<Option<T::Value>>`: `Some(value)` if the property exists for the given person,
+    /// or `None` if it doesn't.
+    #[allow(clippy::needless_pass_by_value)]
+    fn get_person_property_ref<T: PersonProperty + 'static>(
+        &self,
+        person: PersonId,
+        _property: T,
+    ) -> RefMut<Option<T::Value>> {
+        let properties_map = self.properties_map.borrow_mut();
+        let index = person.id;
+        RefMut::map(properties_map, |properties_map| {
+            let properties = properties_map
+                .entry(TypeId::of::<T>())
+                .or_insert_with(|| Box::new(Vec::<Option<T::Value>>::with_capacity(index)));
+            let values: &mut Vec<Option<T::Value>> = properties
+                .downcast_mut()
+                .expect("Type mismatch in properties_map");
+            if index >= values.len() {
+                values.resize(index + 1, None);
+            }
+            &mut values[index]
+        })
+    }
+
+    /// Sets the value of a property for a person
+    #[allow(clippy::needless_pass_by_value)]
+    fn set_person_property<T: PersonProperty + 'static>(
+        &self,
+        person_id: PersonId,
+        property: T,
+        value: T::Value,
+    ) {
+        let mut property_ref = self.get_person_property_ref(person_id, property);
+        *property_ref = Some(value);
+    }
+}
+
+// Emitted when a new person is created
+// These should not be emitted outside this module
+#[derive(Clone, Copy)]
+#[allow(clippy::manual_non_exhaustive)]
+pub struct PersonCreatedEvent {
+    pub person_id: PersonId,
+}
+
+// Emitted when a person property is updated
+// These should not be emitted outside this module
+#[derive(Copy, Clone)]
+#[allow(clippy::manual_non_exhaustive)]
+pub struct PersonPropertyChangeEvent<T: PersonProperty> {
+    pub person_id: PersonId,
+    pub current: T::Value,
+    pub previous: T::Value,
+}
+
+pub trait ContextPeopleExt {
+    /// Returns the current population size
+    fn get_current_population(&self) -> usize;
+
+    /// Creates a new person with no assigned person properties
+    fn add_person(&mut self) -> PersonId;
+
+    /// Given a `PersonId` returns the value of a defined person property,
+    /// initializing it if it hasn't been set yet. If no initializer is
+    /// provided, and the property is not set this will panic
+    fn get_person_property<T: PersonProperty + 'static>(
+        &self,
+        person_id: PersonId,
+        _property: T,
+    ) -> T::Value;
+
+    /// Given a `PersonId`, sets the value of a defined person property
+    fn set_person_property<T: PersonProperty + 'static>(
+        &mut self,
+        person_id: PersonId,
+        _property: T,
+        value: T::Value,
+    );
+}
+
+impl ContextPeopleExt for Context {
+    fn get_current_population(&self) -> usize {
+        self.get_data_container(PeoplePlugin)
+            .map_or(0, |data_container| data_container.current_population)
+    }
+
+    fn add_person(&mut self) -> PersonId {
+        let person_id = self.get_data_container_mut(PeoplePlugin).add_person();
+        self.emit_event(PersonCreatedEvent { person_id });
+        person_id
+    }
+
+    fn get_person_property<T: PersonProperty + 'static>(
+        &self,
+        person_id: PersonId,
+        property: T,
+    ) -> T::Value {
+        let data_container = self.get_data_container(PeoplePlugin)
+            .expect("PeoplePlugin is not initialized; make sure you add a person before accessing properties");
+
+        // Attempt to retrieve the existing value
+        if let Some(value) = *data_container.get_person_property_ref(person_id, property) {
+            return value;
+        }
+
+        // Initialize the property. This does not fire a change event
+        let initialized_value = T::initialize(self, person_id);
+        data_container.set_person_property(person_id, property, initialized_value);
+
+        initialized_value
+    }
+
+    fn set_person_property<T: PersonProperty + 'static>(
+        &mut self,
+        person_id: PersonId,
+        property: T,
+        value: T::Value,
+    ) {
+        let data_container = self.get_data_container(PeoplePlugin)
+            .expect("PeoplePlugin is not initialized; make sure you add a person before accessing properties");
+        let current_value = *data_container.get_person_property_ref(person_id, property);
+        match current_value {
+            // The person property is already set, so we emit a change event
+            Some(current_value) => {
+                let change_event: PersonPropertyChangeEvent<T> = PersonPropertyChangeEvent {
+                    person_id,
+                    current: value,
+                    previous: current_value,
+                };
+                data_container.set_person_property(person_id, property, value);
+                self.emit_event(change_event);
+            }
+            // The person property is not yet initialized, so we don't emit any events.
+            None => {
+                data_container.set_person_property(person_id, property, value);
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::{ContextPeopleExt, PersonCreatedEvent, PersonId, PersonPropertyChangeEvent};
+    use crate::{context::Context, people::PeoplePlugin};
+    use std::{cell::RefCell, rc::Rc};
+
+    define_person_property!(Age, u8);
+    #[derive(Copy, Clone, PartialEq, Eq, Debug)]
+    pub enum RiskCategory {
+        High,
+        Low,
+    }
+    define_person_property!(RiskCategoryType, RiskCategory);
+    define_person_property_with_default!(IsRunner, bool, false);
+    define_person_property!(RunningShoes, u8, |context: &Context, person: PersonId| {
+        let is_runner = context.get_person_property(person, IsRunner);
+        if is_runner {
+            4
+        } else {
+            0
+        }
+    });
+
+    #[test]
+    fn observe_person_addition() {
+        let mut context = Context::new();
+
+        let flag = Rc::new(RefCell::new(false));
+        let flag_clone = flag.clone();
+        context.subscribe_to_event(move |_context, event: PersonCreatedEvent| {
+            *flag_clone.borrow_mut() = true;
+            assert_eq!(event.person_id.id, 0);
+        });
+
+        let _ = context.add_person();
+        context.execute();
+        assert!(*flag.borrow());
+    }
+    #[test]
+    fn set_get_properties() {
+        let mut context = Context::new();
+
+        let person = context.add_person();
+        context.set_person_property(person, Age, 42);
+        assert_eq!(context.get_person_property(person, Age), 42);
+    }
+
+    #[allow(clippy::should_panic_without_expect)]
+    #[test]
+    #[should_panic]
+    fn get_uninitialized_property_panics() {
+        let mut context = Context::new();
+        let person = context.add_person();
+        context.get_person_property(person, Age);
+    }
+
+    // Tests that if we try to set or access a property for an index greater than
+    // the current size of the property Vec, the vector will be resized.
+    #[test]
+    fn set_property_resize() {
+        let mut context = Context::new();
+
+        // Add a person and set a property, instantiating the Vec
+        let person = context.add_person();
+        context.set_person_property(person, Age, 8);
+
+        // Create a bunch of people and don't initialize Age
+        for _ in 1..9 {
+            let _person = context.add_person();
+        }
+        let tenth_person = context.add_person();
+
+        // Set a person property for a person > index 0
+        context.set_person_property(tenth_person, Age, 42);
+        // Call an initializer
+        assert!(!context.get_person_property(tenth_person, IsRunner));
+    }
+
+    #[test]
+    fn get_current_population() {
+        let mut context = Context::new();
+        assert_eq!(context.get_current_population(), 0);
+        for _ in 0..3 {
+            context.add_person();
+        }
+        assert_eq!(context.get_current_population(), 3);
+    }
+
+    #[test]
+    fn add_person() {
+        let mut context = Context::new();
+
+        let person_id = context.add_person();
+        context.set_person_property(person_id, Age, 42);
+        context.set_person_property(person_id, RiskCategoryType, RiskCategory::Low);
+        assert_eq!(context.get_person_property(person_id, Age), 42);
+        assert_eq!(
+            context.get_person_property(person_id, RiskCategoryType),
+            RiskCategory::Low
+        );
+    }
+
+    #[test]
+    fn add_person_initializers() {
+        let mut context = Context::new();
+        let person_id = context.add_person();
+
+        assert_eq!(context.get_person_property(person_id, RunningShoes), 0);
+        assert!(!context.get_person_property(person_id, IsRunner));
+    }
+
+    #[test]
+    fn property_initialization_should_not_emit_events() {
+        let mut context = Context::new();
+
+        let flag = Rc::new(RefCell::new(false));
+        let flag_clone = flag.clone();
+        context.subscribe_to_event(
+            move |_context, _event: PersonPropertyChangeEvent<RiskCategoryType>| {
+                *flag_clone.borrow_mut() = true;
+            },
+        );
+
+        let person = context.add_person();
+        // This should not emit a change event
+        context.set_person_property(person, Age, 42);
+        context.get_person_property(person, IsRunner);
+        context.get_person_property(person, RunningShoes);
+
+        context.execute();
+
+        assert!(!*flag.borrow());
+    }
+
+    #[test]
+    fn property_initialization_is_lazy() {
+        let mut context = Context::new();
+        let person = context.add_person();
+        let people_data = context.get_data_container_mut(PeoplePlugin);
+
+        // Verify we haven't initialized the property yet
+        let has_value = *people_data.get_person_property_ref(person, RunningShoes);
+        assert!(has_value.is_none());
+
+        context.set_person_property(person, IsRunner, true);
+
+        // This should initialize it
+        let value = context.get_person_property(person, RunningShoes);
+        assert_eq!(value, 4);
+    }
+
+    #[test]
+    fn observe_person_property_change() {
+        let mut context = Context::new();
+
+        let flag = Rc::new(RefCell::new(false));
+        let flag_clone = flag.clone();
+        context.subscribe_to_event(
+            move |_context, event: PersonPropertyChangeEvent<RiskCategoryType>| {
+                *flag_clone.borrow_mut() = true;
+                assert_eq!(event.person_id.id, 0, "Person id is correct");
+                assert_eq!(
+                    event.previous,
+                    RiskCategory::Low,
+                    "Previous value is correct"
+                );
+                assert_eq!(
+                    event.current,
+                    RiskCategory::High,
+                    "Current value is correct"
+                );
+            },
+        );
+        let person_id = context.add_person();
+        context.set_person_property(person_id, RiskCategoryType, RiskCategory::Low);
+        context.set_person_property(person_id, RiskCategoryType, RiskCategory::High);
+        context.execute();
+        assert!(*flag.borrow());
+    }
+
+    #[test]
+    fn observe_person_property_change_with_initializer() {
+        let mut context = Context::new();
+
+        let flag = Rc::new(RefCell::new(false));
+        let flag_clone = flag.clone();
+        context.subscribe_to_event(
+            move |_context, _event: PersonPropertyChangeEvent<RunningShoes>| {
+                *flag_clone.borrow_mut() = true;
+            },
+        );
+        let person_id = context.add_person();
+        // Innitializer wasn't called, so don't fire an event
+        context.set_person_property(person_id, RunningShoes, 42);
+        context.execute();
+        assert!(!*flag.borrow());
+    }
+}

--- a/src/random.rs
+++ b/src/random.rs
@@ -27,6 +27,7 @@ macro_rules! define_rng {
         paste::paste! {
             #[doc(hidden)]
             #[no_mangle]
+            #[allow(non_upper_case_globals)]
             pub static [<rng_name_duplication_guard_ $random_id>]: () = ();
         }
     };


### PR DESCRIPTION
This is an alternative implementation of people/person properties which primarily uses initializers to assign initial property values during person creation.

The README below has a full explanation of the interfaces (I'd recommend reading that) as demonstrated by an example. 

### Comparison with other implementations
I previously pushed a previous implementation of people/person properties which uses immediate events (you can see in the commit history), where you add `before_person_creation` or `set_default` hooks prior to `add_person` being called. The main downside of this was that you had to be careful about initialization order and it was somewhat counter-intuitive to read:

```rs
context.before_person_added(move |context, person_id| {
    context.set_person_property(person_id, Age, record.age);
    context.set_person_property(person_id, RiskCategoryType, record.risk_category);
});
context.add_person();
```

I also had a version of this that used a builder pattern: https://github.com/CDCgov/ixa/pull/46, which involved chaining/a finalize step.
