### PR TITLE
Derived properties

### DIFF
--- a/examples/load-people/logger.rs
+++ b/examples/load-people/logger.rs
@@ -3,27 +3,20 @@ use crate::{
     sir::DiseaseStatusType,
     vaccine::{VaccineDoses, VaccineEfficacy, VaccineType},
 };
-use ixa::{
-    context::Context,
-    people::{ContextPeopleExt, PersonCreatedEvent, PersonPropertyChangeEvent},
-};
+use ixa::{context::Context, people::ContextPeopleExt};
 
 pub fn init(context: &mut Context) {
     // This subscribes to the disease status change events
     // Note that no event gets fired when the property is set the first time
-    context.subscribe_to_event(
-        |_context, event: PersonPropertyChangeEvent<DiseaseStatusType>| {
-            let person = event.person_id;
-            println!(
-                "{:?} changed disease status from {:?} to {:?}",
-                person, event.previous, event.current,
-            );
-        },
-    );
+    context.subscribe_to_person_property_changed(DiseaseStatusType, |_context, data| {
+        println!(
+            "{:?} changed disease status from {:?} to {:?}",
+            data.person_id, data.previous, data.current
+        );
+    });
 
     // Logs when a person is created
-    context.subscribe_to_event(|context, event: PersonCreatedEvent| {
-        let person = event.person_id;
+    context.subscribe_to_person_created(|context, person| {
         println!(
             "{:?} age: {}, {} vaccine doses, vaccine {:?} ({})",
             person,

--- a/examples/load-people/population_loader.rs
+++ b/examples/load-people/population_loader.rs
@@ -54,11 +54,7 @@ mod tests {
         population_loader::Age,
         vaccine::{VaccineDoses, VaccineEfficacy, VaccineType, VaccineTypeValue},
     };
-    use ixa::{
-        context::Context,
-        people::{PersonCreatedEvent, PersonPropertyChangeEvent},
-        random::ContextRandomExt,
-    };
+    use ixa::{context::Context, random::ContextRandomExt};
 
     const EXPECTED_ROWS: usize = 5;
 
@@ -85,21 +81,18 @@ mod tests {
 
         // Subscribe to person property change event
         let flag_clone = Rc::clone(&flag);
-        context.subscribe_to_event(
-            move |_context, _event: PersonPropertyChangeEvent<VaccineEfficacy>| {
-                *flag_clone.borrow_mut() = true;
-            },
-        );
+        context.subscribe_to_person_property_changed(VaccineEfficacy, move |_context, _data| {
+            *flag_clone.borrow_mut() = true;
+        });
 
         let counter = Rc::new(RefCell::new(0));
         let expected_computed = Rc::new(expected_computed);
 
-        context.subscribe_to_event({
+        context.subscribe_to_person_created({
             let counter = Rc::clone(&counter);
             let expected_computed = Rc::clone(&expected_computed);
 
-            move |context, event: PersonCreatedEvent| {
-                let person = event.person_id;
+            move |context, person| {
                 let current_count = *counter.borrow();
                 let (age, risk_category, vaccine_type, efficacy, doses) =
                     expected_computed[current_count];
@@ -131,7 +124,7 @@ mod tests {
         // Execute the context
         context.execute();
 
-        // Make sure PersonPropertyChangeEvent didn't fire
+        // Make sure change event didn't didn't fire
         assert!(!*flag.borrow());
     }
 }

--- a/examples/load-people/sir.rs
+++ b/examples/load-people/sir.rs
@@ -1,7 +1,6 @@
 use ixa::{
-    context::Context,
-    define_person_property, define_person_property_with_default,
-    people::{ContextPeopleExt, PersonCreatedEvent},
+    context::Context, define_person_property, define_person_property_with_default,
+    people::ContextPeopleExt,
 };
 
 #[derive(Copy, Clone, PartialEq, Eq, Debug)]
@@ -14,8 +13,7 @@ pub enum DiseaseStatus {
 define_person_property_with_default!(DiseaseStatusType, DiseaseStatus, DiseaseStatus::S);
 
 pub fn init(context: &mut Context) {
-    context.subscribe_to_event(move |context, event: PersonCreatedEvent| {
-        let person = event.person_id;
+    context.subscribe_to_person_created(move |context, person| {
         context.add_plan(1.0, move |context| {
             context.set_person_property(person, DiseaseStatusType, DiseaseStatus::I);
         });
@@ -28,7 +26,7 @@ pub fn init(context: &mut Context) {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use ixa::{context::Context, people::PersonPropertyChangeEvent};
+    use ixa::context::Context;
 
     #[test]
     fn test_disease_status() {
@@ -44,17 +42,14 @@ mod tests {
         );
 
         // At 1.0, people should be in the I state
-        context.subscribe_to_event(
-            |context, event: PersonPropertyChangeEvent<DiseaseStatusType>| {
-                let person = event.person_id;
-                if context.get_current_time() == 1.0 {
-                    assert_eq!(
-                        context.get_person_property(person, DiseaseStatusType),
-                        DiseaseStatus::I
-                    );
-                }
-            },
-        );
+        context.subscribe_to_person_property_changed(DiseaseStatusType, |context, data| {
+            if context.get_current_time() == 1.0 {
+                assert_eq!(
+                    context.get_person_property(data.person_id, DiseaseStatusType),
+                    DiseaseStatus::I
+                );
+            }
+        });
 
         context.execute();
 


### PR DESCRIPTION
This PR adds derived properties, for example:

```rust
define_derived_person_property!(
    MastersRunner,
    bool,
    [Age, IsRunner],
    |age, is_runner| age >= 40 && is_runner
);
```

The macro takes a list of dependent properties and a closure which computes the property from those dependencies.

Derived properties can be used as other properties (with `get_person_property`) etc.; they are recomputed whenever a dependency changes (and will also emit a change event).

As a side effect of needing to do some lazy registration of dependencies if the property is derived, I needed to introduce a wrapper around subscribing to person property changes, which I think is not ideal: 

```rust
  context.subscribe_to_person_property_changed(
        DiseaseStatusType,
        |_context, person, current, previous| {
            println!("{person:?} changed disease status from {previous:?} to {current:?}");
        },
    );
```
In particular, I think it's probably pretty easy to mess up the order of current and previous. 

Open to suggestions on how to handle this better
