### PR TITLE
Example of time-varying rates

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,8 @@ serde_derive = "1.0"
 serde_json = "1.0.128"
 reikna = "0.12.3"
 roots = "0.0.8"
+strum = "0.26.3"
+strum_macros = "0.26.4"
 ixa-derive = { path = "ixa-derive" }
 
 [dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,8 @@ csv = "1.3"
 serde = { version = "1.0", features = ["derive"] }
 serde_derive = "1.0"
 serde_json = "1.0.128"
+reikna = "0.12.3"
+roots = "0.0.8"
 ixa-derive = { path = "ixa-derive" }
 
 [dev-dependencies]

--- a/examples/time-varying-infection/README.md
+++ b/examples/time-varying-infection/README.md
@@ -301,6 +301,16 @@ the foi is equal to a sin function plus 1). So, recovery must be evaluated
 at the fastest of these two rates -- meaning that the resampling rate
 is their sum, $2 + 1 / \gamma$.
 
+What is described here is not true vanilla rejection sampling. Vanilla rejection
+sampling would have us try to pick the value from our candidate distribution
+a priori through subsequent samples from some parent distribution. But,
+we cannot do that in this case because the target distribution changes over
+time. As such, we need to employ this iterative checking manner. In vanilla
+rejection sampling, the selection of maximum rate is instead replaced
+by a selection of a parent distribution from which draws are taken and then
+compared to the candidate distribution to assess whether the draw is also
+one potentially from the candidate distribution
+
 ### Implementation
 
 ```rust
@@ -332,7 +342,7 @@ fn n_effective_infected(context: &mut Context) -> f64 {
     for usize_id in 0..context.get_current_population() {
         if matches!(context.get_person_property(context.get_person_id(usize_id),
                                        DiseaseStatusType), DiseaseStatus::I) {
-                                        n_infected = n_infected + 1;
+                                        n_infected += 1;
                                        }
     }
     parameters.gamma / n_infected

--- a/examples/time-varying-infection/README.md
+++ b/examples/time-varying-infection/README.md
@@ -136,13 +136,13 @@ use roots::find_root_brent;
 use reikna::integral::*;
 define_rng!(InfectionRng);
 
-pub enum InfectionStatus {
+pub enum DiseaseStatus {
     S, I, R
 }
 
-define_person_property_with_default!(InfectionStatusType,
-                                     InfectionStatus,
-                                     InfectionStatus::S);
+define_person_property_with_default!(DiseaseStatusType,
+                                     DiseaseStatus,
+                                     DiseaseStatus::S);
 
 define_person_property!(InfectionTime, f64);
 
@@ -179,7 +179,7 @@ fn inverse_sampling_infection(context: &mut Context, person_id: PersonID) {
     let t = find_root_brent(0f64, 100f64, // lower and upper bounds for the root finding
                             f_int_shifted).unwrap();
     context.add_plan(t, move |context| {
-        context.set_person_property(person_id, InfectionStatus, InfectionStatusType::I);
+        context.set_person_property(person_id, DiseaseStatus, DiseaseStatusType::I);
         // for reasons that will become apparent with the recovery rate example,
         // we also need to record the time at which a person becomes infected
         context.set_person_property(person_id, InfectionTime, t);
@@ -291,14 +291,14 @@ define_rng!(RecoveryRng);
 
 fn init(context: &mut Context) {
     context.subscribe_to_event(move |context,
-                               event: PersonPropertyChangeEvent<InfectionStatusType>| {
+                               event: PersonPropertyChangeEvent<DiseaseStatusType>| {
         handle_infection_status_change(context, event);
     });
 }
 
 fn handle_infection_status_change(context: &mut Context,
-                                  event: PersonPropertyChangeEvent<InfectionStatusType>) {
-    if matches!(event.current, InfectionStatus::I) {
+                                  event: PersonPropertyChangeEvent<DiseaseStatusType>) {
+    if matches!(event.current, DiseaseStatus::I) {
         evaluate_recovery(context, event.person_id);
     }
 }
@@ -313,7 +313,7 @@ fn n_effective_infected(context: &mut Context) -> f64 {
     let mut n_infected = 0;
     for usize_id in 0..context.get_current_population() {
         if matches!(context.get_person_property(context.get_person_id(usize_id),
-                                       InfectionStatusType), InfectionStatus::I) {
+                                       DiseaseStatusType), DiseaseStatus::I) {
                                         n_infected = n_infected + 1;
                                        }
     }
@@ -327,7 +327,7 @@ fn evaluate_recovery(context: &mut Context, person_id: usize) {
     let recovery_probability = recovery_cdf(context, time_spent_infected);
     if context.sample_bool(RecoveryRng, recovey_probability) {
         // recovery has happened by now
-        context.set_person_property(person_id, InfectionStatus, InfectionStatus::R);
+        context.set_person_property(person_id, DiseaseStatus, DiseaseStatus::R);
     } else {
         // add plan for recovery evaluation to happen again at fastest rate
         context.add_plan(context.get_time() + context.sample_distr(ExposureRng, Exp::new(2 * parameters.gamma).unwrap()),

--- a/examples/time-varying-infection/README.md
+++ b/examples/time-varying-infection/README.md
@@ -120,5 +120,57 @@ any function numerically.
 
 ## Time-varying recovery rate
 
+Imagine that the recovery rate scales inversely with the number of infected
+people (so that the recovery time increases with the number of infected people).
+A potential biological explanation of this would be that infected people
+require some medicine, but their time to getting that medicine depends on how
+many other people are infected.
+
+This scenario has a key difference from the preceeding example: at the
+point of someone's infection, we cannot schedule their recovery because we do
+not know exactly what the number of infected people over time will be
+out into the future. (OK, just kidding. We kinda actually do because this example
+is a deterministic model, but calculating the number of infecteds while accounting
+for recovery sounds like  a pain, so please continue playing pretend with me that
+we do not know.) In other words, we can't analytically write out a priori $\textrm{for}(q)$
+(force of recovery over time time since infection, $q$). So, we have to use an
+alternative sampling technique to obtain draws from the time-varying recovery rate
+distribution.
+
+### What is rejection sampling?
+
+Rejection sampling is similarly grounded in understanding the CDF. The CDF tells
+us the probability that recovery has happened at some time since infection.
+Imagine obtaining a probability that recovery has happened at some time, $t_2$
+from the CDF, $p_2$, and using a Bernoulli distribution to assess whether
+the recovery event has happened. If you obtain a Bernoulli sample of 1, you
+know that recovery has happened by that time. Now, imagine that you had just
+sampled some value of time $q_1 < q_2$. If you had obtained a Bernoulli sample of 0
+at $q_1$, you would know that this person's recovery must have happened between the
+two times. For sufficiently small $q_2 - q_1$, it is fair to say that the recovery
+event happens at $q_2$.
+
+In other words, by assessing whether recovery has happened by making sequential
+samples from a Bernoulli distribution with probability parameter obtained
+from the CDF, one can obtain samples of the underlying distribution for which
+we have written the CDF.
+
+However, there's a big catch -- finding the value of $q_2 - q_1$ or the time
+between sequential checks from the CDF to assess whether recovery has happened.
+Imagine a trivial case where we pick a value of $q_2 - q_1 = \tau(t)$ that is infinitely
+small. We would be having events in our model at every $\tau(t)$. That would be
+painfully inefficient. So, what is the biggest $\tau(t)$ that we can have
+that would still enable our simulation to be accurate? First, note how I have written
+$\tau$ to be a function of time. This rate can change over time. In fact, it really just
+must be the maximal possible rate of change in the recovery rate for a given time.
+
+Let's develop some intuition for this:
+
+There's also another matter I've brushed over: writing down the CDF. In this case,
+that is actually quite simple. If we say that recovery rate scales inversely
+with the number of infected people, we can write the following:
+
+$\textrm{CDF}(q, t) = 1 - \exp(-q*n(t))$ where $n(t)$ is the effective
+number of infected people (effective because it may be scaled by a recovery rate).
 
 ## Alternative ways of modeling time-varying forces

--- a/examples/time-varying-infection/README.md
+++ b/examples/time-varying-infection/README.md
@@ -43,6 +43,10 @@ and time of the simulation aka seasonality) while the technique I describe
 for dealing with a time-varying recovery rate may be more likely applied to
 force of infection in real-world models.
 
+# Running the example
+
+`cargo run --example time-varying-infection -- ./examples/time-varying-infection/input.json`
+
 ## Why are time-varying rates special?
 The classic SIR compartmental ODE model assumes a constant recovery rate,
 $\gamma$, so that the infection period is exponentially distributed. In

--- a/examples/time-varying-infection/README.md
+++ b/examples/time-varying-infection/README.md
@@ -1,60 +1,130 @@
 # Infection model: time-varying force of infection and recovery
 This example is centered around demonstrating two of the classical
 ways of modeling a time-varying force in a continuous time simulation.
+The two approaches are inverse transform sampling and rejection sampling,
+and I explain what both of these approaches are and when to use each of them.
 I explore the use of inverse transform sampling to deal with a force
-of infection that is sinusoidal and rejection sampling to deal with a
-recovery rate that depends on the number of infected people.
+of infection that changes based on the season and rejection sampling to
+deal with a recovery rate that depends on the number of infected people.
 
 The goal of this example is two-fold:
-1) Explain the math and process behind properly modeling a time-varying force.
-2) Demonstrate how to implement this math in Rust and within the `ixa` framework.
+1. Explain the math and process behind properly modeling a time-varying rate.
     - Develop best practices for when model math should be done in `ixa` vs
     the pre-processing stages to best drive modularity.
-3) Bonus: Bench-test complicated example of time-varying infection to show that
-they are simple to implement with `ixa`'s functionality.
+2. Provide a template from which we can bench-test complicated examples of
+time-varying infection to explore the need for us to establish `ixa`
+standards for modeling time-varying rates.
+3. Bonus: the basic-infection example did not use `ixa`'s internal  `people`
+or `global_properties` modules, so this example also updates to using the
+built-in functionality.
 
-Conceptually, the structure/flow in this model is same as the `basic-infection`
+Some aspects worth thinking about standardizing on time-varying rates:
+- Format of time-varying input data: as a function, or random samples from
+the distribution? If a function, how should it be discretized?
+- Library of curves needed to improve rejection sampling efficiency
+- What Rust tools should be used when modeling time-varying rates?
+- When should integration be done within Rust vs externally and fed in
+as a model input? If a model input, how should the data be formatted?
+
+Conceptually, the structure in this model is same as the `basic-infection`
 example except with time-varying forces of infection/recovery. As such, this
-readme focuses on explaining why modeling time-varying infection in continuous
-time requires a bit of math and then why inverse transform sampling and rejection
-sampling are two viable approaches and their associated pros/cons.
+readme instead focuses on explaining why modeling time-varying infection in
+continuous time requires a bit of math and then why inverse transform sampling
+and rejection sampling are two viable approaches and their associated pros/cons.
+
+## Why are time-varying rates special?
+The classic SIR compartmental ODE model assumes a constant recovery rate,
+$\gamma$, so that the infection period is exponentially distributed. In
+the real-world, infection periods are often not exponentially distributed.
+However, observational studies often provide a distribution for the actual
+infection period. One might use that distribution as an input to their ABM
+and then draw from that empirical distribution when scheduling an
+individual's recovery. This is an entirely valid approach.
+
+However, it is generally easier to work in terms of rates rather than
+distributions. In other words, it is useful to have the recovery rate
+over time. For any distribution besides the exponential distribution,
+the recovery rate is time-varying. Having a rate is useful because (a)
+there is a direct analogue to a corresponding compartmental model, and (b)
+clinical studies often report rates for people based on some
+demographic factor in a proportional hazards model, and then the user
+can assemble the individual's overall rate from their
+demographic characteristics and the demography-->corresponding rate
+values provided by the clinical study.
+
+This leads us to the following question: given a rate function, $f(t)$,
+how can we accurately draw times of recovery or infection that follow the
+given rate over time? We can't just draw values from an exponential distribution
+anymore -- what would we put as the rate? You can probably see that if we
+know $f(t)$ as the hazard rate, we know the corresponding PDF, so we could
+draw recovery times from that distribution. This is the crux of the idea
+behind inverse-transform sampling. You may probably also see that if
+you drew times at some constant rate faster than the rate function, you could
+evaluate whether the recovery event had happened at a given time even
+without knowing how the recovery rate function may change in the future.
+This is the crux of the idea behind rejection sampling.
+
+Below, I go into greater detail about each of these two methods and their tradeoffs.
+The ultimate goal of this example is to demonstrate how modeling time-varying rates
+is really just a simple extension over time-constant rates within `ixa` and how
+we can use the ideas presented here to build up towards a time-varying infection
+rates when the infection is person-to-person rather than just environmental.
 
 ## Time-varying force of infection
-In a constant force of infection model, a person experiences a constant hazard
-rate of infection. Therfore, we use the exponential distribution to plan for
-the time at which a person will fall sick. With time-varying infection, the hazard
-rate is not constant over time, so we must draw times from an alternate distribution,
-one that follows the time-varying hazard rate and therefore properly apportions people's
+In a constant force of infection model (like the classic compartmental ODE SIR),
+a person experiences a constant hazard rate of infection. Therfore, we
+use the exponential distribution to plan for the time at which a person
+will fall sick. With time-varying infection, the hazard rate is not constant
+over time, so we must draw times from an alternate distribution, one that
+follows the time-varying hazard rate and therefore properly apportions people's
 sickness events at the right times.
 
 ### What is inverse-transform sampling?
-
 If foi$(t)$ describes the hazard rate for infection at a given time,
 $1 - e ^ {-\int_0^t \textrm{foi}(u)du}$ is the cumulative probability of
-infection at $t$. Note that this is a CDF, so if we draw a random number
-$u \sim \mathcal{U}(0, 1)$, set $u$ equal to the CDF, and solve for the
-corresponding value of $t$, we obtain a random sample of $t$ that follows
-the arbitrary distribution defined by the hazard rate. This is a generic
-strategy that works because the CDF is a transformation that takes any
-distribution and turns it into a uniform distribution.
+infection by $t$ elapsed. In the case where foi$(t) = k$, we recover an
+exponential distribution. This is just stating the relationship between the
+hazard rate and the CDF, but this identity provides us with what we need
+to go from the hazard rate to the distribution function. Now we must figure
+out how to draw random values of $t$ that follow the given CDF.
+
+Since the integral is a CDF, if we draw a random number $u \sim \mathcal{U}(0, 1)$,
+set $u$ equal to the CDF, and solve for the corresponding value of $t$,
+we obtain a random sample of $t$ that follows the arbitrary distribution
+defined by the hazard rate. This is a generic strategy that works because
+the CDF is a transformation that takes any distribution and turns it into a
+uniform distribution.
 
 In other words, we have a method of going from $\mathcal{U}(0, 1)$ to
 samples of $t$. We can do one additional step of math to make the work
 needed to be done by the modeler easier. In general, the CDF of an
 exponentially distributed random variable with rate 1, $s ~ \textrm{Exp}(1)$,
-is $F(s) = 1 - e^{-s}$. As such, if we instead draw an exponential
-random variable, $s$, and set that equal to $\int_0^t \textrm{foi}(u)du$,
-we have a slight shortcut for generating samples of $t$ that does not
-require a natural logarithm.
+is $F(s) = 1 - e^{-s}$. We could rewrite the integral of foi$(t)$ instead as
+$F(\int_0^t \textrm{foi}(u)du)$. As such, we see that to obtain a uniform
+distributed random variable on (0, 1), we have to pass the integral of the foi
+through an exponential CDF. We can bypass this step if we instead draw an
+exponential random variable, $s$, and set that equal to
+$\int_0^t \textrm{foi}(u)du$, we have a slight shortcut for generating
+samples of $t$ that does not require taking a natural logarithm. Overall,
+this technique of expressing an abstract distribution in terms of samples
+of another distribution is called inverse-transform sampling because
+it exploits inverting the CDF of the abstract distribution to be able to
+express it in terms of some other distribution.
 
-In our particular example of food-borne illness, based on the function $\textrm{foi}(t)$,
-we can pre-schedule everyone's infection at the beginning of the simulation and infections
-will occur at the correct nonuniformly distributed rate. Note that there is an implicit
-difference in how this ABM is set up versus the last example: rather than drawing infection
-_attempt_ events and _then_ picking a person to infect, we schedule infection _transition_
-events for all people at the beginning of the simulation (recall, we have an environmental
-disease so eventually all people will get infected). This is a bit more of the _individual_-specific
-approach.
+In our particular example of food-borne illness, based on the function
+$\textrm{foi}(t)$, we can pre-schedule everyone's infection at the beginning
+of the simulation and infections will occur at the correct nonuniformly
+distributed rate. This is because we have an environmental disease, so
+eventually all people will get infected. There is an implicit difference
+in how this ABM is set up versus the last example: rather than drawing infection
+_attempt_ events and _then_ picking a person to infect (as was done in the last
+example), we schedule infection _transition_ events for all people at the beginning
+of the simulation and then just execute their transitions at the given time.
+This is a bit more of the _individual_-specific approach. The other benefit
+of this approach in this particular example is that there is no longer a need
+for a `MAX_TIME` after which infection attempts cannot be scheduled: instead,
+the simulation will just end once everyone has been infected (pre-scheduled
+at simulation beginning) and they all recover.
 
 ### Implementation
 
@@ -66,13 +136,29 @@ use roots::find_root_brent;
 use reikna::integral::*;
 define_rng!(InfectionRng);
 
+pub enum InfectionStatus {
+    S, I, R
+}
+
+define_person_property_with_default!(InfectionStatusType,
+                                     InfectionStatus,
+                                     InfectionStatus::S);
+
+define_person_property!(InfectionTime, f64);
+
 fn init(context: &mut Context) {
-    context.subscribe_to_event(PersonCreationEvent, expose_person_to_deviled_eggs);
+    // let deviled eggs be our food borne illness
+    // as soon as a person enters the simulation, they are exposed to deviled eggs
+    // based on foi(t), they will have their infection planned at a given time
+    context.subscribe_to_event(PersonCreatedEvent, expose_person_to_deviled_eggs);
 }
 
 fn expose_person_to_deviled_eggs(context: &mut Context,
-                                 person_creation_event: PersonCreationEvent) {
-    inverse_sampling_infection(context, person_creation_event.person_id());
+                                 person_created_event: PersonCreatedEvent) {
+    // when the person is exposed to deviled eggs, make a plan for them to fall
+    // sick based on foi(t), where inverse sampling is used to draw times from
+    // the corresponding distribution
+    inverse_sampling_infection(context, person_created_event.person_id());
 }
 
 // parameterize the foi
@@ -85,38 +171,43 @@ fn inverse_sampling_infection(context: &mut Context, person_id: PersonID) {
     let s = context.sample_distr(InfectionRng, Exp1::new());
     // get the time by following the formula described above
     // first need to get the simulation's sin_shift
-    let sin_shift = parameters.get_parameter(foi_sin_shift);
+    let parameters = context.get_global_property_value(Parameters).clone();
+    let sin_shift = parameters.foi_sin_shift;
     let f = func!(move |t| foi(t, sin_shift));
     // as easy as Python to integrate and find roots in Rust!
     let f_int_shifted = func!(move |t| integrate(&f, 0, t) - s);
-    let t = find_root_brent(0f64, 100f64, // guesses for the root bracketing
+    let t = find_root_brent(0f64, 100f64, // lower and upper bounds for the root finding
                             f_int_shifted).unwrap();
-    context.add_plan(context.set_person_property(person_id, Properties::infection_time, context.get_time()),
-                        t)
+    context.add_plan(t, move |context| {
+        context.set_person_property(person_id, InfectionStatus, InfectionStatusType::I);
+        // for reasons that will become apparent with the recovery rate example,
+        // we also need to record the time at which a person becomes infected
+        context.set_person_property(person_id, InfectionTime, t);
+    });
 }
 
 ```
 
 ### Caveats
 
-However, there are some constraints of vanilla inverse-transform sampling.
-1) We needed to be able to write down the way the force of infection varies with
+There are some constraints of vanilla inverse-transform sampling.
+1. We needed to be able to write down the way the force of infection varies with
 time as a hazard function (or, more generally, any type of distribution function).
 It is possible that we know, from data, the mean waiting time of illness and standard
-deviation. In that case, some approximation will need to be made for the distribution
+deviation. In that case, some approximation will need to be made for the hazard
 function. This issue speaks to a more general problem of incorporating real-world
 data into ABMs.
-2) We needed to know the function $\textrm{foi}(t)$ a priori. Imagine a model
+2. We needed to know the function $\textrm{foi}(t)$ a priori. Imagine a model
 where the time-varying rate depends on some internal state of the model, so the
 modeler does not know how the time-varying rate will change over time as it
 can only be determined as the model is running. Then, this approach will not work.
 Instead, rejection sampling provides a strategy for taking draws from an arbitrary
 and potentially changing distribution, and more is discussed on this below.
-3) Sampling a new value of $t$ requires inverting an integral function
+3. Sampling a new value of $t$ requires inverting an integral function
 (i.e., $\int_0^t \textrm{foi}(u)du$). Not only must this process be done every time
 a new sample is required, but inverting the function may not be straightforward. This
-is potentially computationally inefficient and prone to the errors associated with inverting
-any function numerically.
+is potentially computationally inefficient and makes inverse-transform sampling prine
+to the errors associated with inverting any function numerically.
 
 ## Time-varying recovery rate
 
@@ -130,24 +221,25 @@ This scenario has a key difference from the preceeding example: at the
 point of someone's infection, we cannot schedule their recovery because we do
 not know exactly what the number of infected people over time will be
 out into the future. (OK, just kidding. We kinda actually do because this example
-is a deterministic model, but calculating the number of infecteds while accounting
-for recovery sounds like  a pain, so please continue playing pretend with me that
-we do not know.) In other words, we can't analytically write out a priori $\textrm{for}(q)$
-(force of recovery over time time since infection, $q$). So, we have to use an
-alternative sampling technique to obtain draws from the time-varying recovery rate
-distribution.
+is a deterministic model, but calculating the number of infecteds at every time
+in the future while accounting for recovery sounds like  a pain, so please continue
+playing pretend with me that we do not know.) In other words, we can't analytically
+write out a priori $\textrm{for}(q)$ (force of recovery over time time since
+infection, $q$). So, we have to use an alternative sampling technique to obtain
+draws from the time-varying recovery rate distribution.
 
 ### What is rejection sampling?
 
 Rejection sampling is similarly grounded in understanding the CDF. The CDF tells
 us the probability that recovery has happened at some time since infection.
-Imagine obtaining a probability that recovery has happened at some time, $t_2$
-from the CDF, $p_2$, and using a Bernoulli distribution to assess whether
-the recovery event has happened. If you obtain a Bernoulli sample of 1, you
-know that recovery has happened by that time. Now, imagine that you had just
-sampled some value of time $q_1 < q_2$. If you had obtained a Bernoulli sample of 0
-at $q_1$, you would know that this person's recovery must have happened between the
-two times. For sufficiently small $q_2 - q_1$, it is fair to say that the recovery
+Imagine obtaining a probability that recovery has happened at some time, $t_j$
+from the CDF, $p_j$, and using a Bernoulli distribution with parameter $p_j$
+to assess whether the recovery event has happened. If you obtain a Bernoulli
+sample of 1, you know that recovery has happened by that time. Now, imagine that
+you had just sampled some value of time $q_i < q_j$. If you had obtained a
+Bernoulli sample of 0 at $q_i$ and then obtain a 1 at $q_j$, you would know
+that this person's recovery must have happened between the two times.
+For sufficiently small $q_2 - q_1$, it is fair to say that the recovery
 event happens at $q_2$.
 
 In other words, by assessing whether recovery has happened by making sequential
@@ -155,22 +247,131 @@ samples from a Bernoulli distribution with probability parameter obtained
 from the CDF, one can obtain samples of the underlying distribution for which
 we have written the CDF.
 
-However, there's a big catch -- finding the value of $q_2 - q_1$ or the time
-between sequential checks from the CDF to assess whether recovery has happened.
-Imagine a trivial case where we pick a value of $q_2 - q_1 = \tau(t)$ that is infinitely
-small. We would be having events in our model at every $\tau(t)$. That would be
-painfully inefficient. So, what is the biggest $\tau(t)$ that we can have
-that would still enable our simulation to be accurate? First, note how I have written
-$\tau$ to be a function of time. This rate can change over time. In fact, it really just
-must be the maximal possible rate of change in the recovery rate for a given time.
+However, there's a big catch -- we need to do some work to figure out the
+subsequent times we should be checking the CDF, in other words finding the
+value of $q_j - q_i$ or the time between sequential checks from the CDF to
+assess whether recovery has happened. Imagine a trivial case where we pick a
+value of $q_j - q_i = \tau(t)$ that is infinitely small. We would be having
+events in our model at every $\tau(t)$. That would be painfully inefficient.
+On the other hand, if we pick some large $\tau(t)$, we may skip over when the
+recovery event really happens and schedule it to happen later than it should,
+biasing the sequence of events.
 
-Let's develop some intuition for this:
+So, what is the biggest $\tau(t)$ (slowest rate of events) that we can have
+that would still enable our simulation to be accurate? First, note how I have
+written $\tau$ to be a function of time. This rate can change over time. Let's
+develop some intuition for what it should be.
 
-There's also another matter I've brushed over: writing down the CDF. In this case,
-that is actually quite simple. If we say that recovery rate scales inversely
-with the number of infected people, we can write the following:
+First, let us write down the CDF of recovery, similar to how we did
+this with rejection sampling. If we say that recovery rate scales
+inversely with the number of infected people, we can write the following:
+$\textrm{CDF}_\textrm{recovery}(q, t) = 1 - \exp(-q/n(t))$ where $n(t)$ is
+the effective number of infected people (effective because it may be
+scaled by a disease recovery rate).
 
-$\textrm{CDF}(q, t) = 1 - \exp(-q*n(t))$ where $n(t)$ is the effective
-number of infected people (effective because it may be scaled by a recovery rate).
+The reason we don't know the recovery time a priori is becaues the recovery
+rate changes with the number of infected people. Therefore, each time
+the number of infected people changes, we need to recalculate the expected
+recovery time. Alternatively, instead of subscribing the simulation to
+a change in the number of infected people, we could schedule events to occur
+at the maximum rate of change in the number of infected people. This rate
+is the maximum of the absolute value of either the infection rate or the recovery
+rate. The maximum recovery rate is equal to recovery rate scaling factor (i.e.,
+the factor that makes $n(t)$ an _effective_ number of infected people) because
+this is the theoretically fastest recovery rate (1 person is infected), and the
+maximum of the infection rate is 2 ($sin(t + c)$ has maximum range of 1,
+and foi$(t) = sin(t + c) + 1$). Let us assume that the recovery rate is less than 1
+(as would be expected for a food-borne illness), so we must schedule rejection sampling
+events to happen at a time of 1/2 days.
 
-## Alternative ways of modeling time-varying forces
+### Implementation
+
+```rust
+define_rng!(RecoveryRNG);
+
+fn init(context: &mut Context) {
+    context.subscribe_to_event(move |context,
+                               event: PersonPropertyChangeEvent<InfectionStatusType>| {
+        handle_infection_status_change(context, event);
+    });
+}
+
+fn handle_infection_status_change(context: &mut Context,
+                                  event: PersonPropertyChangeEvent<InfectionStatusType>) {
+    if matches!(event.current, InfectionStatus::I) {
+        evaluate_recovery(context, event.person_id);
+    }
+}
+
+fn recovery_cdf(context: &mut Context, time_spent_infected: f64) -> f64 {
+    1 - f64::exp(-time_spent_infected / n_effective_infected(context))
+}
+
+fn n_effective_infected(context: &mut Context) -> f64 {
+    let parameters = context.get_global_property_value(Parameters).clone();
+    // get number of infected people
+    let mut n_infected = 0;
+    for usize_id in 0..context.get_current_population() {
+        if matches!(context.get_person_property(context.get_person_id(usize_id),
+                                       InfectionStatusType), InfectionStatus::I) {
+                                        n_infected = n_infected + 1;
+                                       }
+    }
+    parameters.foi_sin_shift * n_infected
+}
+
+fn evaluate_recovery(context: &mut Context, person_id: usize) {
+    // get time person has spent infected
+    let time_spent_infected = context.get_time() - context.get_person_property(person_id, InfectionTime)
+    // evaluate whether recovery has happened by this time or not
+    let recovery_probability = recovery_cdf(context, time_spent_infected);
+    if context.sample_bool(recovey_probability) {
+        // recovery has happened by now
+        context.set_person_property(person_id, InfectionStatus, InfectionStatus::R);
+    } else {
+        // add plan for recovery to happen again at fastest rate
+        context.add_plan(context.get_time() + 0.5, move |context| {
+        evaluate_recovery();
+    });
+    }
+}
+```
+
+### Caveats
+
+1. Rejection sampling is inherently inefficient. It is effectively
+a guess and check method and requires scheduling events just to evaluate
+whether the real event in question has happened or not. As such, it
+requires scheduling more events than are transitions that actually
+happen in the simulation -- there are ancillary events that have no
+impact on simulation state. There are ways around this problem --
+for instance, instead of always resampling at the maximal rate of change,
+one could resample at the local maximal rate of change. In fact,
+one could make a series of linear functions that approximate a given
+unknown distribution that is being modeled. Development of such a
+functional library is a valuable area of `ixa` advancement. This
+becomes increasingly important if the distribution from which we are
+trying to sample has a high peak -- then, the maximal value at which
+we sample must be based on that high peak, which is inefficient for the
+majority of the distribution.
+
+2. Rejection sampling is effectively a geometric sampling technique.
+In essence, we sampling in two dimensions (time values at which we sample
+and whether the sampled value is a viable draw from the distribution) to
+obtain samples from a one dimensional distribution. As such, if we were to
+expand rejection sampling from a distribution in more dimensions, it is natural
+to see that the method will always be subject to the curse of dimensionality
+and sampling will become increasingly inefficient.
+
+## Sidenotes
+
+1. Imagine that we had to take multiple draws from a time-varying
+rate's distribution -- for instance, scheduling infection
+attempts based on the generation distribution. We would have to take
+all of our samples from the generation distribution at the moment a person
+is infected and then have infection attempts happen at the ordering
+of the times. This becomes messy, and explaining how to do this
+is the subject of a future example.
+
+2. Note that MCMC can be used to obtain correlated samples from paired
+distributions.

--- a/examples/time-varying-infection/README.md
+++ b/examples/time-varying-infection/README.md
@@ -287,7 +287,7 @@ events to happen at a time of 1/2 days.
 ### Implementation
 
 ```rust
-define_rng!(RecoveryRNG);
+define_rng!(RecoveryRng);
 
 fn init(context: &mut Context) {
     context.subscribe_to_event(move |context,
@@ -325,7 +325,7 @@ fn evaluate_recovery(context: &mut Context, person_id: usize) {
     let time_spent_infected = context.get_time() - context.get_person_property(person_id, InfectionTime)
     // evaluate whether recovery has happened by this time or not
     let recovery_probability = recovery_cdf(context, time_spent_infected);
-    if context.sample_bool(recovey_probability) {
+    if context.sample_bool(RecoveryRng, recovey_probability) {
         // recovery has happened by now
         context.set_person_property(person_id, InfectionStatus, InfectionStatus::R);
     } else {

--- a/examples/time-varying-infection/README.md
+++ b/examples/time-varying-infection/README.md
@@ -1,0 +1,124 @@
+# Infection model: time-varying force of infection and recovery
+This example is centered around demonstrating two of the classical
+ways of modeling a time-varying force in a continuous time simulation.
+I explore the use of inverse transform sampling to deal with a force
+of infection that is sinusoidal and rejection sampling to deal with a
+recovery rate that depends on the number of infected people.
+
+The goal of this example is two-fold:
+1) Explain the math and process behind properly modeling a time-varying force.
+2) Demonstrate how to implement this math in Rust and within the `ixa` framework.
+    - Develop best practices for when model math should be done in `ixa` vs
+    the pre-processing stages to best drive modularity.
+3) Bonus: Bench-test complicated example of time-varying infection to show that
+they are simple to implement with `ixa`'s functionality.
+
+Conceptually, the structure/flow in this model is same as the `basic-infection`
+example except with time-varying forces of infection/recovery. As such, this
+readme focuses on explaining why modeling time-varying infection in continuous
+time requires a bit of math and then why inverse transform sampling and rejection
+sampling are two viable approaches and their associated pros/cons.
+
+## Time-varying force of infection
+In a constant force of infection model, a person experiences a constant hazard
+rate of infection. Therfore, we use the exponential distribution to plan for
+the time at which a person will fall sick. With time-varying infection, the hazard
+rate is not constant over time, so we must draw times from an alternate distribution,
+one that follows the time-varying hazard rate and therefore properly apportions people's
+sickness events at the right times.
+
+### What is inverse-transform sampling?
+
+If foi$(t)$ describes the hazard rate for infection at a given time,
+$1 - e ^ {-\int_0^t \textrm{foi}(u)du}$ is the cumulative probability of
+infection at $t$. Note that this is a CDF, so if we draw a random number
+$u \sim \mathcal{U}(0, 1)$, set $u$ equal to the CDF, and solve for the
+corresponding value of $t$, we obtain a random sample of $t$ that follows
+the arbitrary distribution defined by the hazard rate. This is a generic
+strategy that works because the CDF is a transformation that takes any
+distribution and turns it into a uniform distribution.
+
+In other words, we have a method of going from $\mathcal{U}(0, 1)$ to
+samples of $t$. We can do one additional step of math to make the work
+needed to be done by the modeler easier. In general, the CDF of an
+exponentially distributed random variable with rate 1, $s ~ \textrm{Exp}(1)$,
+is $F(s) = 1 - e^{-s}$. As such, if we instead draw an exponential
+random variable, $s$, and set that equal to $\int_0^t \textrm{foi}(u)du$,
+we have a slight shortcut for generating samples of $t$ that does not
+require a natural logarithm.
+
+In our particular example of food-borne illness, based on the function $\textrm{foi}(t)$,
+we can pre-schedule everyone's infection at the beginning of the simulation and infections
+will occur at the correct nonuniformly distributed rate. Note that there is an implicit
+difference in how this ABM is set up versus the last example: rather than drawing infection
+_attempt_ events and _then_ picking a person to infect, we schedule infection _transition_
+events for all people at the beginning of the simulation (recall, we have an environmental
+disease so eventually all people will get infected). This is a bit more of the _individual_-specific
+approach.
+
+### Implementation
+
+Let's look at some pseudo-code. In this pseudo example, we pick
+$\textrm{foi}(t) = \sin(t + c) + 1$ where $c$ is a user parameter.
+
+```rust
+use roots::find_root_brent;
+use reikna::integral::*;
+define_rng!(InfectionRng);
+
+fn init(context: &mut Context) {
+    context.subscribe_to_event(PersonCreationEvent, expose_person_to_deviled_eggs);
+}
+
+fn expose_person_to_deviled_eggs(context: &mut Context,
+                                 person_creation_event: PersonCreationEvent) {
+    inverse_sampling_infection(context, person_creation_event.person_id());
+}
+
+// parameterize the foi
+fn foi(t: f64, sin_shift: f64) -> f64 {
+    f64::sin(t + sin_shift) + 1 // foi must always be greater than 1
+}
+
+fn inverse_sampling_infection(context: &mut Context, person_id: PersonID) {
+    // random exponential value
+    let s = context.sample_distr(InfectionRng, Exp1::new());
+    // get the time by following the formula described above
+    // first need to get the simulation's sin_shift
+    let sin_shift = parameters.get_parameter(foi_sin_shift);
+    let f = func!(move |t| foi(t, sin_shift));
+    // as easy as Python to integrate and find roots in Rust!
+    let f_int_shifted = func!(move |t| integrate(&f, 0, t) - s);
+    let t = find_root_brent(0f64, 100f64, // guesses for the root bracketing
+                            f_int_shifted).unwrap();
+    context.add_plan(context.set_person_property(person_id, Properties::infection_time, context.get_time()),
+                        t)
+}
+
+```
+
+### Caveats
+
+However, there are some constraints of vanilla inverse-transform sampling.
+1) We needed to be able to write down the way the force of infection varies with
+time as a hazard function (or, more generally, any type of distribution function).
+It is possible that we know, from data, the mean waiting time of illness and standard
+deviation. In that case, some approximation will need to be made for the distribution
+function. This issue speaks to a more general problem of incorporating real-world
+data into ABMs.
+2) We needed to know the function $\textrm{foi}(t)$ a priori. Imagine a model
+where the time-varying rate depends on some internal state of the model, so the
+modeler does not know how the time-varying rate will change over time as it
+can only be determined as the model is running. Then, this approach will not work.
+Instead, rejection sampling provides a strategy for taking draws from an arbitrary
+and potentially changing distribution, and more is discussed on this below.
+3) Sampling a new value of $t$ requires inverting an integral function
+(i.e., $\int_0^t \textrm{foi}(u)du$). Not only must this process be done every time
+a new sample is required, but inverting the function may not be straightforward. This
+is potentially computationally inefficient and prone to the errors associated with inverting
+any function numerically.
+
+## Time-varying recovery rate
+
+
+## Alternative ways of modeling time-varying forces

--- a/examples/time-varying-infection/README.md
+++ b/examples/time-varying-infection/README.md
@@ -275,14 +275,14 @@ the number of infected people changes, we need to recalculate the expected
 recovery time. Alternatively, instead of subscribing the simulation to
 a change in the number of infected people, we could schedule events to occur
 at the maximum rate of change in the number of infected people. This rate
-is the maximum of the absolute value of either the infection rate or the recovery
-rate. The maximum recovery rate is equal to recovery rate scaling factor (i.e.,
-the factor that makes $n(t)$ an _effective_ number of infected people) because
-this is the theoretically fastest recovery rate (1 person is infected), and the
+is the maximum recovery rate over the maximum infection rate. The maximum
+recovery rate is equal to recovery rate scaling factor (i.e., the factor
+that makes $n(t)$ an _effective_ number of infected people) because this
+is the theoretically fastest recovery rate (1 person is infected), and the
 maximum of the infection rate is 2 ($sin(t + c)$ has maximum range of 1,
-and foi$(t) = sin(t + c) + 1$). Let us assume that the recovery rate is less than 1
-(as would be expected for a food-borne illness), so we must schedule rejection sampling
-events to happen at a time of 1/2 days.
+and foi$(t) = sin(t + c) + 1$). Let us call the recovery rate scaling factor
+$\gamma$, so we must schedule rejection sampling events to happen at a rate of
+$\gamma/(1/2) = 2\gamma$.
 
 ### Implementation
 
@@ -329,8 +329,9 @@ fn evaluate_recovery(context: &mut Context, person_id: usize) {
         // recovery has happened by now
         context.set_person_property(person_id, InfectionStatus, InfectionStatus::R);
     } else {
-        // add plan for recovery to happen again at fastest rate
-        context.add_plan(context.get_time() + 0.5, move |context| {
+        // add plan for recovery evaluation to happen again at fastest rate
+        context.add_plan(context.get_time() + context.sample_distr(ExposureRng, Exp::new(2 * parameters.gamma).unwrap()),
+        move |context| {
         evaluate_recovery();
     });
     }

--- a/examples/time-varying-infection/exposure_manager.rs
+++ b/examples/time-varying-infection/exposure_manager.rs
@@ -1,14 +1,17 @@
 use ixa::define_rng;
-use ixa::people::{ContextPeopleExt, PersonCreatedEvent, PersonId};
+use ixa::people::{ContextPeopleExt, PersonCreatedEvent};
 use ixa::random::ContextRandomExt;
 use ixa::{context::Context, global_properties::ContextGlobalPropertiesExt};
+use std::rc::Rc;
 
 use crate::parameters_loader::Parameters;
-use crate::population_loader::{DiseaseStatus, DiseaseStatusType};
+use crate::population_loader::{DiseaseStatus, DiseaseStatusType, InfectionTime};
 use rand_distr::Exp1;
 
-use reikna::integral::*;
-use roots::find_root_secant;
+use reikna::func;
+use reikna::func::Function;
+use reikna::integral::integrate;
+use roots::find_root_brent;
 
 define_rng!(ExposureRng);
 
@@ -16,76 +19,42 @@ fn expose_person_to_deviled_eggs(context: &mut Context, person_created_event: Pe
     // when the person is exposed to deviled eggs, make a plan for them to fall
     // sick based on foi(t), where inverse sampling is used to draw times from
     // the corresponding distribution
-    inverse_sampling_infection(context, person_created_event.person_id);
+    let t = inverse_sampling_infection(context);
+    let person_id = person_created_event.person_id;
+    context.add_plan(t, move |context| {
+        context.set_person_property(person_id, DiseaseStatusType, DiseaseStatus::I);
+        // for reasons that will become apparent with the recovery rate example,
+        // we also need to record the time at which a person becomes infected
+        context.set_person_property(person_id, InfectionTime, Some(t));
+    });
 }
 
 // parameterize the foi
 fn foi_t(t: f64, foi: f64, sin_shift: f64) -> f64 {
-    foi * (f64::sin(t + sin_shift) + 1.0) // foi must always be greater than 1
+    foi * (f64::sin(t + sin_shift) + 1.0) // foi must always be greater than 0
 }
 
-fn inverse_sampling_infection(context: &mut Context, person_id: PersonId) {
+fn inverse_sampling_infection(context: &mut Context) -> f64 {
     // random exponential value
-    let s = context.sample_distr(ExposureRng, Exp1);
+    let s: f64 = context.sample_distr(ExposureRng, Exp1);
     // get the time by following the formula described above
     // first need to get the simulation's sin_shift
     let parameters = context.get_global_property_value(Parameters).clone();
     let sin_shift = parameters.foi_sin_shift;
     let foi = parameters.foi;
-    let f = move |t| foi_t(t, foi, sin_shift);
+    let f = func!(move |t| foi_t(t, foi, sin_shift));
     // as easy as Python to integrate and find roots in Rust!
-    let f_int_shifted = move |t| integrate(&f, 0, t) - s;
-    let t = find_root_secant(
-        0f64,
-        100f64, // lower and upper bounds for the root finding
+    let f_int_shifted = move |t| integrate(&f, 0.0, t) - s;
+    find_root_brent(
+        0.0,
+        parameters.max_time, // lower and upper bounds for the root finding
         f_int_shifted,
-        &mut 1e-3f64,
+        &mut 1e-2f64,
     )
-    .unwrap();
-    context.add_plan(t, move |context| {
-        context.set_person_property(person_id, DiseaseStatusType, DiseaseStatus::I);
-        // for reasons that will become apparent with the recovery rate example,
-        // we also need to record the time at which a person becomes infected
-        context.set_person_property(person_id, InfectionTime, t);
-    });
+    .unwrap()
 }
 
-fn attempt_infection(context: &mut Context) {
-    let parameters = context.get_global_property_value(Parameters).clone();
-    let population_size: usize = context.get_current_population();
-    let person_to_infect: usize = context.sample_range(ExposureRng, 0..population_size);
-
-    let person_status: DiseaseStatus =
-        context.get_person_property(context.get_person_id(person_to_infect), DiseaseStatusType);
-
-    if matches!(person_status, DiseaseStatus::S) {
-        context.set_person_property(
-            context.get_person_id(person_to_infect),
-            DiseaseStatusType,
-            DiseaseStatus::I,
-        );
-    }
-
-    // With a food-borne illness (i.e., constant force of infection),
-    // each _person_ experiences an exponentially distributed
-    // time until infected. Here, we use a per-person force of infection derived
-    // from the population-level to represent a constant risk of infection for individuals
-    // in the population.
-
-    // An alternative implementation calculates each person's time to infection
-    // at the beginning of the simulation and scheudles their infection at that time.
-
-    #[allow(clippy::cast_precision_loss)]
-    let next_attempt_time = context.get_current_time()
-        + context.sample_distr(ExposureRng, Exp::new(parameters.foi).unwrap())
-            / population_size as f64;
-
-    context.add_plan(next_attempt_time, move |context| {
-        attempt_infection(context);
-    });
-}
-
-fn init(context: &mut Context) {
+pub fn init(context: &mut Context) {
     // let deviled eggs be our food borne illness
     // as soon as a person enters the simulation, they are exposed to deviled eggs
     // based on foi(t), they will have their infection planned at a given time
@@ -103,6 +72,7 @@ mod test {
     use ixa::global_properties::ContextGlobalPropertiesExt;
     use ixa::people::ContextPeopleExt;
     use ixa::random::ContextRandomExt;
+    use reikna::integral::integrate;
 
     use crate::parameters_loader::ParametersValues;
 
@@ -110,10 +80,10 @@ mod test {
     fn test_attempt_infection() {
         let p_values = ParametersValues {
             population: 1,
-            max_time: 10.0,
+            max_time: 200.0,
             seed: 42,
             foi: 0.15,
-            foi_sin_shift: 3,
+            foi_sin_shift: 3.0,
             infection_duration: 5.0,
             output_dir: ".".to_string(),
             output_file: ".".to_string(),
@@ -122,10 +92,51 @@ mod test {
         context.set_global_property_value(Parameters, p_values);
         let parameters = context.get_global_property_value(Parameters).clone();
         context.init_random(parameters.seed);
+        init(&mut context);
         context.add_person();
-        attempt_infection(&mut context);
+        context.execute();
         let person_status =
             context.get_person_property(context.get_person_id(0), DiseaseStatusType);
         assert_eq!(person_status, DiseaseStatus::I);
+        let infection_time = context.get_person_property(context.get_person_id(0), InfectionTime);
+        assert_eq!(infection_time.unwrap(), context.get_current_time());
+    }
+
+    #[test]
+    fn test_mean_inverse_sampling() {
+        // calculate empirical mean and compare to theoretical mean
+        // challenging to test the distribution of times
+        // we get out from inverse sampling is correct,
+        // but we can at least test that whether the mean is correct
+        // because the theoretical mean is easily calculatable form
+        // the hazard rate using survival analysis
+        let p_values = ParametersValues {
+            population: 1,
+            max_time: 200.0,
+            seed: 42,
+            foi: 0.15,
+            foi_sin_shift: 3.0,
+            infection_duration: 5.0,
+            output_dir: ".".to_string(),
+            output_file: ".".to_string(),
+        };
+        let mut context = Context::new();
+        context.set_global_property_value(Parameters, p_values);
+        let parameters = context.get_global_property_value(Parameters).clone();
+        context.init_random(parameters.seed);
+        // empirical mean
+        let mut sum = 0.0;
+        let n = 1000;
+        for _ in 0..n {
+            sum += inverse_sampling_infection(&mut context);
+        }
+        let mean = sum / n as f64;
+
+        // now calculate theoretical mean
+        // use the fact that integral from 0 to infinity of survival fcn is mean
+        let hazard_fcn = func!(move |t| foi_t(t, parameters.foi, parameters.foi_sin_shift));
+        let survival_fcn = func!(move |t| f64::exp(-integrate(&hazard_fcn, 0.0, t)));
+        let theoretical_mean = integrate(&survival_fcn, 0.0, 10000.0); // large enough upper bound
+        assert!((mean - theoretical_mean).abs() < 0.1);
     }
 }

--- a/examples/time-varying-infection/exposure_manager.rs
+++ b/examples/time-varying-infection/exposure_manager.rs
@@ -85,7 +85,7 @@ mod test {
             foi: 0.15,
             foi_sin_shift: 3.0,
             infection_duration: 5.0,
-            plan_period: 1.0,
+            report_period: 1.0,
             output_dir: ".".to_string(),
             output_file: ".".to_string(),
         };
@@ -118,7 +118,7 @@ mod test {
             foi: 0.15,
             foi_sin_shift: 3.0,
             infection_duration: 5.0,
-            plan_period: 1.0,
+            report_period: 1.0,
             output_dir: ".".to_string(),
             output_file: ".".to_string(),
         };

--- a/examples/time-varying-infection/exposure_manager.rs
+++ b/examples/time-varying-infection/exposure_manager.rs
@@ -1,0 +1,76 @@
+use ixa::context::Context;
+use ixa::define_rng;
+use ixa::people::ContextPeopleExt;
+use ixa::random::ContextRandomExt;
+
+use crate::population_loader::{DiseaseStatus, DiseaseStatusType};
+use rand_distr::Exp;
+
+use crate::FOI;
+use crate::MAX_TIME;
+
+define_rng!(ExposureRng);
+
+fn attempt_infection(context: &mut Context) {
+    let population_size: usize = context.get_current_population();
+    let person_to_infect: usize = context.sample_range(ExposureRng, 0..population_size);
+
+    let person_status: DiseaseStatus =
+        context.get_person_property(context.get_person_id(person_to_infect), DiseaseStatusType);
+
+    if matches!(person_status, DiseaseStatus::S) {
+        context.set_person_property(
+            context.get_person_id(person_to_infect),
+            DiseaseStatusType,
+            DiseaseStatus::I,
+        );
+    }
+
+    // With a food-borne illness (i.e., constant force of infection),
+    // each _person_ experiences an exponentially distributed
+    // time until infected. Here, we use a per-person force of infection derived
+    // from the population-level to represent a constant risk of infection for individuals
+    // in the population.
+
+    // An alternative implementation calculates each person's time to infection
+    // at the beginning of the simulation and scheudles their infection at that time.
+
+    #[allow(clippy::cast_precision_loss)]
+    let next_attempt_time = context.get_current_time()
+        + context.sample_distr(ExposureRng, Exp::new(FOI).unwrap()) / population_size as f64;
+
+    if next_attempt_time <= MAX_TIME {
+        context.add_plan(next_attempt_time, move |context| {
+            attempt_infection(context);
+        });
+    }
+}
+
+pub fn init(context: &mut Context) {
+    context.add_plan(0.0, |context| {
+        attempt_infection(context);
+    });
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    use crate::population_loader::{DiseaseStatus, DiseaseStatusType};
+    use crate::SEED;
+    use ixa::context::Context;
+    use ixa::people::ContextPeopleExt;
+    use ixa::random::ContextRandomExt;
+
+    #[test]
+    fn test_attempt_infection() {
+        let mut context = Context::new();
+        context.init_random(SEED);
+        context.add_person();
+        attempt_infection(&mut context);
+        let person_status =
+            context.get_person_property(context.get_person_id(0), DiseaseStatusType);
+        assert_eq!(person_status, DiseaseStatus::I);
+        context.execute();
+    }
+}

--- a/examples/time-varying-infection/exposure_manager.rs
+++ b/examples/time-varying-infection/exposure_manager.rs
@@ -25,7 +25,7 @@ fn expose_person_to_deviled_eggs(context: &mut Context, person_created_event: Pe
         context.set_person_property(person_id, DiseaseStatusType, DiseaseStatus::I);
         // for reasons that will become apparent with the recovery rate example,
         // we also need to record the time at which a person becomes infected
-        context.set_person_property(person_id, InfectionTime, Some(t));
+        context.initialize_person_property(person_id, InfectionTime, t);
     });
 }
 
@@ -100,7 +100,7 @@ mod test {
             context.get_person_property(context.get_person_id(0), DiseaseStatusType);
         assert_eq!(person_status, DiseaseStatus::I);
         let infection_time = context.get_person_property(context.get_person_id(0), InfectionTime);
-        assert_eq!(infection_time.unwrap(), context.get_current_time());
+        assert_eq!(infection_time, context.get_current_time());
     }
 
     #[test]

--- a/examples/time-varying-infection/exposure_manager.rs
+++ b/examples/time-varying-infection/exposure_manager.rs
@@ -85,6 +85,7 @@ mod test {
             foi: 0.15,
             foi_sin_shift: 3.0,
             infection_duration: 5.0,
+            plan_period: 1.0,
             output_dir: ".".to_string(),
             output_file: ".".to_string(),
         };
@@ -117,6 +118,7 @@ mod test {
             foi: 0.15,
             foi_sin_shift: 3.0,
             infection_duration: 5.0,
+            plan_period: 1.0,
             output_dir: ".".to_string(),
             output_file: ".".to_string(),
         };

--- a/examples/time-varying-infection/exposure_manager.rs
+++ b/examples/time-varying-infection/exposure_manager.rs
@@ -1,13 +1,54 @@
 use ixa::define_rng;
-use ixa::people::ContextPeopleExt;
+use ixa::people::{ContextPeopleExt, PersonCreatedEvent, PersonId};
 use ixa::random::ContextRandomExt;
 use ixa::{context::Context, global_properties::ContextGlobalPropertiesExt};
 
 use crate::parameters_loader::Parameters;
 use crate::population_loader::{DiseaseStatus, DiseaseStatusType};
-use rand_distr::Exp;
+use rand_distr::Exp1;
+
+use reikna::integral::*;
+use roots::find_root_secant;
 
 define_rng!(ExposureRng);
+
+fn expose_person_to_deviled_eggs(context: &mut Context, person_created_event: PersonCreatedEvent) {
+    // when the person is exposed to deviled eggs, make a plan for them to fall
+    // sick based on foi(t), where inverse sampling is used to draw times from
+    // the corresponding distribution
+    inverse_sampling_infection(context, person_created_event.person_id);
+}
+
+// parameterize the foi
+fn foi_t(t: f64, foi: f64, sin_shift: f64) -> f64 {
+    foi * (f64::sin(t + sin_shift) + 1.0) // foi must always be greater than 1
+}
+
+fn inverse_sampling_infection(context: &mut Context, person_id: PersonId) {
+    // random exponential value
+    let s = context.sample_distr(ExposureRng, Exp1);
+    // get the time by following the formula described above
+    // first need to get the simulation's sin_shift
+    let parameters = context.get_global_property_value(Parameters).clone();
+    let sin_shift = parameters.foi_sin_shift;
+    let foi = parameters.foi;
+    let f = move |t| foi_t(t, foi, sin_shift);
+    // as easy as Python to integrate and find roots in Rust!
+    let f_int_shifted = move |t| integrate(&f, 0, t) - s;
+    let t = find_root_secant(
+        0f64,
+        100f64, // lower and upper bounds for the root finding
+        f_int_shifted,
+        &mut 1e-3f64,
+    )
+    .unwrap();
+    context.add_plan(t, move |context| {
+        context.set_person_property(person_id, DiseaseStatusType, DiseaseStatus::I);
+        // for reasons that will become apparent with the recovery rate example,
+        // we also need to record the time at which a person becomes infected
+        context.set_person_property(person_id, InfectionTime, t);
+    });
+}
 
 fn attempt_infection(context: &mut Context) {
     let parameters = context.get_global_property_value(Parameters).clone();
@@ -44,9 +85,12 @@ fn attempt_infection(context: &mut Context) {
     });
 }
 
-pub fn init(context: &mut Context) {
-    context.add_plan(0.0, |context| {
-        attempt_infection(context);
+fn init(context: &mut Context) {
+    // let deviled eggs be our food borne illness
+    // as soon as a person enters the simulation, they are exposed to deviled eggs
+    // based on foi(t), they will have their infection planned at a given time
+    context.subscribe_to_event(move |context, event: PersonCreatedEvent| {
+        expose_person_to_deviled_eggs(context, event);
     });
 }
 
@@ -69,6 +113,7 @@ mod test {
             max_time: 10.0,
             seed: 42,
             foi: 0.15,
+            foi_sin_shift: 3,
             infection_duration: 5.0,
             output_dir: ".".to_string(),
             output_file: ".".to_string(),

--- a/examples/time-varying-infection/incidence_report.rs
+++ b/examples/time-varying-infection/incidence_report.rs
@@ -1,0 +1,41 @@
+use ixa::context::Context;
+use ixa::people::PersonPropertyChangeEvent;
+use ixa::report::ContextReportExt;
+use ixa::{create_report_trait, report::Report};
+use std::path::PathBuf;
+
+use serde::{Deserialize, Serialize};
+
+use crate::population_loader::{DiseaseStatus, DiseaseStatusType};
+
+#[derive(Serialize, Deserialize, Clone)]
+struct IncidenceReportItem {
+    time: f64,
+    person_id: String,
+    infection_status: DiseaseStatus,
+}
+
+create_report_trait!(IncidenceReportItem);
+
+fn handle_infection_status_change(
+    context: &mut Context,
+    event: PersonPropertyChangeEvent<DiseaseStatusType>,
+) {
+    context.send_report(IncidenceReportItem {
+        time: context.get_current_time(),
+        person_id: event.person_id.to_string(),
+        infection_status: event.current,
+    });
+}
+
+pub fn init(context: &mut Context) {
+    context
+        .report_options()
+        .directory(PathBuf::from("./examples/time-varying-infection/"));
+    context.add_report::<IncidenceReportItem>("incidence");
+    context.subscribe_to_event(
+        |context, event: PersonPropertyChangeEvent<DiseaseStatusType>| {
+            handle_infection_status_change(context, event);
+        },
+    );
+}

--- a/examples/time-varying-infection/incidence_report.rs
+++ b/examples/time-varying-infection/incidence_report.rs
@@ -1,4 +1,5 @@
 use ixa::context::Context;
+use ixa::global_properties::ContextGlobalPropertiesExt;
 use ixa::people::PersonPropertyChangeEvent;
 use ixa::report::ContextReportExt;
 use ixa::{create_report_trait, report::Report};
@@ -6,6 +7,7 @@ use std::path::PathBuf;
 
 use serde::{Deserialize, Serialize};
 
+use crate::parameters_loader::Parameters;
 use crate::population_loader::{DiseaseStatus, DiseaseStatusType};
 
 #[derive(Serialize, Deserialize, Clone)]
@@ -29,10 +31,11 @@ fn handle_infection_status_change(
 }
 
 pub fn init(context: &mut Context) {
+    let parameters = context.get_global_property_value(Parameters).clone();
     context
         .report_options()
-        .directory(PathBuf::from("./examples/time-varying-infection/"));
-    context.add_report::<IncidenceReportItem>("incidence");
+        .directory(PathBuf::from(parameters.output_dir));
+    context.add_report::<IncidenceReportItem>(&parameters.output_file);
     context.subscribe_to_event(
         |context, event: PersonPropertyChangeEvent<DiseaseStatusType>| {
             handle_infection_status_change(context, event);

--- a/examples/time-varying-infection/infection_manager.rs
+++ b/examples/time-varying-infection/infection_manager.rs
@@ -1,0 +1,80 @@
+use ixa::context::Context;
+use ixa::define_rng;
+use ixa::people::{ContextPeopleExt, PersonId, PersonPropertyChangeEvent};
+use ixa::random::ContextRandomExt;
+
+use rand_distr::Exp;
+
+use crate::population_loader::{DiseaseStatus, DiseaseStatusType};
+use crate::INFECTION_DURATION;
+
+define_rng!(InfectionRng);
+
+fn schedule_recovery(context: &mut Context, person_id: PersonId) {
+    let recovery_time = context.get_current_time()
+        + context.sample_distr(InfectionRng, Exp::new(1.0 / INFECTION_DURATION).unwrap());
+    context.add_plan(recovery_time, move |context| {
+        context.set_person_property(person_id, DiseaseStatusType, DiseaseStatus::R);
+    });
+}
+
+fn handle_infection_status_change(
+    context: &mut Context,
+    event: PersonPropertyChangeEvent<DiseaseStatusType>,
+) {
+    if matches!(event.current, DiseaseStatus::I) {
+        schedule_recovery(context, event.person_id);
+    }
+}
+
+pub fn init(context: &mut Context) {
+    context.subscribe_to_event(
+        move |context, event: PersonPropertyChangeEvent<DiseaseStatusType>| {
+            handle_infection_status_change(context, event);
+        },
+    );
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use crate::SEED;
+    use ixa::context::Context;
+    use ixa::people::{ContextPeopleExt, PersonPropertyChangeEvent};
+    use ixa::random::ContextRandomExt;
+
+    use crate::population_loader::{DiseaseStatus, DiseaseStatusType};
+
+    fn handle_recovery_event(
+        _context: &mut Context,
+        event: PersonPropertyChangeEvent<DiseaseStatusType>,
+    ) {
+        assert_eq!(event.current, DiseaseStatus::R);
+        assert_eq!(event.previous, DiseaseStatus::I);
+    }
+
+    #[test]
+    fn test_handle_infection_change() {
+        let mut context = Context::new();
+        context.init_random(SEED);
+        init(&mut context);
+
+        let population_size = 1;
+        for id in 0..population_size {
+            context.add_person();
+            context.set_person_property(
+                context.get_person_id(id),
+                DiseaseStatusType,
+                DiseaseStatus::I,
+            );
+        }
+
+        context.subscribe_to_event(
+            move |context, event: PersonPropertyChangeEvent<DiseaseStatusType>| {
+                handle_recovery_event(context, event);
+            },
+        );
+
+        context.execute();
+    }
+}

--- a/examples/time-varying-infection/infection_manager.rs
+++ b/examples/time-varying-infection/infection_manager.rs
@@ -107,7 +107,7 @@ mod test {
             foi: 0.15,
             foi_sin_shift: 3.0,
             infection_duration: 5.0,
-            plan_period: 1.0,
+            report_period: 1.0,
             output_dir: ".".to_string(),
             output_file: ".".to_string(),
         };
@@ -150,7 +150,7 @@ mod test {
             foi: 0.15,
             foi_sin_shift: 3.0,
             infection_duration: 5.0,
-            plan_period: 1.0,
+            report_period: 1.0,
             output_dir: ".".to_string(),
             output_file: ".".to_string(),
         };
@@ -197,7 +197,7 @@ mod test {
             foi: 0.15,
             foi_sin_shift: 3.0,
             infection_duration: 5.0,
-            plan_period: 1.0,
+            report_period: 1.0,
             output_dir: ".".to_string(),
             output_file: ".".to_string(),
         };

--- a/examples/time-varying-infection/infection_manager.rs
+++ b/examples/time-varying-infection/infection_manager.rs
@@ -62,6 +62,7 @@ mod test {
             max_time: 10.0,
             seed: 42,
             foi: 0.15,
+            foi_sin_shift: 3,
             infection_duration: 5.0,
             output_dir: ".".to_string(),
             output_file: ".".to_string(),

--- a/examples/time-varying-infection/infection_manager.rs
+++ b/examples/time-varying-infection/infection_manager.rs
@@ -107,6 +107,7 @@ mod test {
             foi: 0.15,
             foi_sin_shift: 3.0,
             infection_duration: 5.0,
+            plan_period: 1.0,
             output_dir: ".".to_string(),
             output_file: ".".to_string(),
         };
@@ -149,6 +150,7 @@ mod test {
             foi: 0.15,
             foi_sin_shift: 3.0,
             infection_duration: 5.0,
+            plan_period: 1.0,
             output_dir: ".".to_string(),
             output_file: ".".to_string(),
         };
@@ -195,6 +197,7 @@ mod test {
             foi: 0.15,
             foi_sin_shift: 3.0,
             infection_duration: 5.0,
+            plan_period: 1.0,
             output_dir: ".".to_string(),
             output_file: ".".to_string(),
         };

--- a/examples/time-varying-infection/infection_manager.rs
+++ b/examples/time-varying-infection/infection_manager.rs
@@ -1,18 +1,23 @@
 use ixa::context::Context;
 use ixa::define_rng;
+use ixa::global_properties::ContextGlobalPropertiesExt;
 use ixa::people::{ContextPeopleExt, PersonId, PersonPropertyChangeEvent};
 use ixa::random::ContextRandomExt;
 
 use rand_distr::Exp;
 
+use crate::parameters_loader::Parameters;
 use crate::population_loader::{DiseaseStatus, DiseaseStatusType};
-use crate::INFECTION_DURATION;
 
 define_rng!(InfectionRng);
 
 fn schedule_recovery(context: &mut Context, person_id: PersonId) {
+    let parameters = context.get_global_property_value(Parameters).clone();
     let recovery_time = context.get_current_time()
-        + context.sample_distr(InfectionRng, Exp::new(1.0 / INFECTION_DURATION).unwrap());
+        + context.sample_distr(
+            InfectionRng,
+            Exp::new(1.0 / parameters.infection_duration).unwrap(),
+        );
     context.add_plan(recovery_time, move |context| {
         context.set_person_property(person_id, DiseaseStatusType, DiseaseStatus::R);
     });
@@ -38,29 +43,37 @@ pub fn init(context: &mut Context) {
 #[cfg(test)]
 mod test {
     use super::*;
-    use crate::SEED;
     use ixa::context::Context;
     use ixa::people::{ContextPeopleExt, PersonPropertyChangeEvent};
     use ixa::random::ContextRandomExt;
 
+    use crate::parameters_loader::ParametersValues;
     use crate::population_loader::{DiseaseStatus, DiseaseStatusType};
 
-    fn handle_recovery_event(
-        _context: &mut Context,
-        event: PersonPropertyChangeEvent<DiseaseStatusType>,
-    ) {
+    fn handle_recovery_event(event: PersonPropertyChangeEvent<DiseaseStatusType>) {
         assert_eq!(event.current, DiseaseStatus::R);
         assert_eq!(event.previous, DiseaseStatus::I);
     }
 
     #[test]
     fn test_handle_infection_change() {
+        let p_values = ParametersValues {
+            population: 1,
+            max_time: 10.0,
+            seed: 42,
+            foi: 0.15,
+            infection_duration: 5.0,
+            output_dir: ".".to_string(),
+            output_file: ".".to_string(),
+        };
         let mut context = Context::new();
-        context.init_random(SEED);
+
+        context.set_global_property_value(Parameters, p_values);
+        let parameters = context.get_global_property_value(Parameters).clone();
+        context.init_random(parameters.seed);
         init(&mut context);
 
-        let population_size = 1;
-        for id in 0..population_size {
+        for id in 0..parameters.population {
             context.add_person();
             context.set_person_property(
                 context.get_person_id(id),
@@ -70,8 +83,8 @@ mod test {
         }
 
         context.subscribe_to_event(
-            move |context, event: PersonPropertyChangeEvent<DiseaseStatusType>| {
-                handle_recovery_event(context, event);
+            move |_context, event: PersonPropertyChangeEvent<DiseaseStatusType>| {
+                handle_recovery_event(event);
             },
         );
 

--- a/examples/time-varying-infection/infection_manager.rs
+++ b/examples/time-varying-infection/infection_manager.rs
@@ -62,7 +62,7 @@ mod test {
             max_time: 10.0,
             seed: 42,
             foi: 0.15,
-            foi_sin_shift: 3,
+            foi_sin_shift: 3.0,
             infection_duration: 5.0,
             output_dir: ".".to_string(),
             output_file: ".".to_string(),
@@ -83,6 +83,9 @@ mod test {
             );
         }
 
+        // put this subscription after every agent has become infected
+        // so that handle_recovery_event is not triggered by an S --> I transition
+        // but only I --> R transitions, which is what it checks for
         context.subscribe_to_event(
             move |_context, event: PersonPropertyChangeEvent<DiseaseStatusType>| {
                 handle_recovery_event(event);

--- a/examples/time-varying-infection/infection_manager.rs
+++ b/examples/time-varying-infection/infection_manager.rs
@@ -219,6 +219,9 @@ mod test {
             sum += context.get_current_time() - start_time;
         }
         // permit up to 5% error
-        assert!(((sum / n_iter as f64) / parameters.infection_duration - 1.0).abs() < 0.05);
+        assert!((((sum / n_iter as f64) / parameters.infection_duration) - 1.0).abs() < 0.05);
+        // the implementation of rejection sampling here for constant n_eff_inv_infec
+        // should be downwardly biased
+        assert!((sum / n_iter as f64) < parameters.infection_duration);
     }
 }

--- a/examples/time-varying-infection/input.json
+++ b/examples/time-varying-infection/input.json
@@ -5,7 +5,7 @@
     "foi": 0.15,
     "foi_sin_shift": 3,
     "infection_duration": 5.0,
-    "plan_period": 1.0,
+    "report_period": 1.0,
     "output_dir": "examples/time-varying-infection",
     "output_file": "incidence"
 }

--- a/examples/time-varying-infection/input.json
+++ b/examples/time-varying-infection/input.json
@@ -3,6 +3,7 @@
     "max_time": 200.0,
     "seed": 123,
     "foi": 0.15,
+    "foi_sin_shift": 3,
     "infection_duration": 5.0,
     "output_dir": "examples/time-varying-infection",
     "output_file": "incidence"

--- a/examples/time-varying-infection/input.json
+++ b/examples/time-varying-infection/input.json
@@ -1,0 +1,9 @@
+{
+    "population": 1000,
+    "max_time": 200.0,
+    "seed": 123,
+    "foi": 0.15,
+    "infection_duration": 5.0,
+    "output_dir": "examples/time-varying-infection",
+    "output_file": "incidence"
+}

--- a/examples/time-varying-infection/input.json
+++ b/examples/time-varying-infection/input.json
@@ -5,6 +5,7 @@
     "foi": 0.15,
     "foi_sin_shift": 3,
     "infection_duration": 5.0,
+    "plan_period": 1.0,
     "output_dir": "examples/time-varying-infection",
     "output_file": "incidence"
 }

--- a/examples/time-varying-infection/main.rs
+++ b/examples/time-varying-infection/main.rs
@@ -1,4 +1,4 @@
-use std::path::Path;
+use std::path::PathBuf;
 
 use ixa::random::ContextRandomExt;
 use ixa::{context::Context, global_properties::ContextGlobalPropertiesExt};
@@ -14,8 +14,8 @@ use crate::parameters_loader::Parameters;
 fn main() {
     let mut context = Context::new();
 
-    let current_dir = Path::new(file!()).parent().unwrap();
-    let file_path = current_dir.join("input.json");
+    let args: Vec<String> = std::env::args().collect();
+    let file_path = PathBuf::from(&args[1]);
 
     match parameters_loader::init_parameters(&mut context, &file_path) {
         Ok(()) => {

--- a/examples/time-varying-infection/main.rs
+++ b/examples/time-varying-infection/main.rs
@@ -7,6 +7,7 @@ mod exposure_manager;
 mod incidence_report;
 mod infection_manager;
 mod parameters_loader;
+mod periodic_report;
 mod population_loader;
 
 use crate::parameters_loader::Parameters;
@@ -26,6 +27,7 @@ fn main() {
             population_loader::init(&mut context);
             infection_manager::init(&mut context);
             incidence_report::init(&mut context);
+            periodic_report::init(&mut context);
 
             context.add_plan(parameters.max_time, |context| {
                 context.shutdown();

--- a/examples/time-varying-infection/main.rs
+++ b/examples/time-varying-infection/main.rs
@@ -14,17 +14,16 @@ use crate::parameters_loader::Parameters;
 fn main() {
     let mut context = Context::new();
 
-    let file_path = Path::new("examples")
-        .join("time-varying-infection")
-        .join("input.json");
+    let current_dir = Path::new(file!()).parent().unwrap();
+    let file_path = current_dir.join("input.json");
 
     match parameters_loader::init_parameters(&mut context, &file_path) {
         Ok(()) => {
             let parameters = context.get_global_property_value(Parameters).clone();
             context.init_random(parameters.seed);
 
-            population_loader::init(&mut context);
             exposure_manager::init(&mut context);
+            population_loader::init(&mut context);
             infection_manager::init(&mut context);
             incidence_report::init(&mut context);
 

--- a/examples/time-varying-infection/main.rs
+++ b/examples/time-varying-infection/main.rs
@@ -1,0 +1,30 @@
+use ixa::context::Context;
+use ixa::random::ContextRandomExt;
+
+mod exposure_manager;
+mod incidence_report;
+mod infection_manager;
+mod population_loader;
+
+static POPULATION: u64 = 1000;
+static SEED: u64 = 123;
+static MAX_TIME: f64 = 303.0;
+static FOI: f64 = 0.1;
+static INFECTION_DURATION: f64 = 5.0;
+
+fn main() {
+    let mut context = Context::new();
+
+    context.init_random(SEED);
+
+    population_loader::init(&mut context);
+    exposure_manager::init(&mut context);
+    infection_manager::init(&mut context);
+    incidence_report::init(&mut context);
+
+    context.add_plan(MAX_TIME, |context| {
+        context.shutdown();
+    });
+
+    context.execute();
+}

--- a/examples/time-varying-infection/parameters_loader.rs
+++ b/examples/time-varying-infection/parameters_loader.rs
@@ -15,6 +15,7 @@ pub struct ParametersValues {
     pub foi: f64,
     pub foi_sin_shift: f64,
     pub infection_duration: f64,
+    pub plan_period: f64,
     pub output_dir: String,
     pub output_file: String,
 }

--- a/examples/time-varying-infection/parameters_loader.rs
+++ b/examples/time-varying-infection/parameters_loader.rs
@@ -15,7 +15,7 @@ pub struct ParametersValues {
     pub foi: f64,
     pub foi_sin_shift: f64,
     pub infection_duration: f64,
-    pub plan_period: f64,
+    pub report_period: f64,
     pub output_dir: String,
     pub output_file: String,
 }

--- a/examples/time-varying-infection/parameters_loader.rs
+++ b/examples/time-varying-infection/parameters_loader.rs
@@ -1,0 +1,26 @@
+use ixa::context::Context;
+use ixa::global_properties::ContextGlobalPropertiesExt;
+use std::fmt::Debug;
+use std::path::Path;
+
+use ixa::define_global_property;
+use ixa::error::IxaError;
+use serde::{Deserialize, Serialize};
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct ParametersValues {
+    pub population: usize,
+    pub max_time: f64,
+    pub seed: u64,
+    pub foi: f64,
+    pub infection_duration: f64,
+    pub output_dir: String,
+    pub output_file: String,
+}
+define_global_property!(Parameters, ParametersValues);
+
+pub fn init_parameters(context: &mut Context, file_path: &Path) -> Result<(), IxaError> {
+    let parameters_json = context.load_parameters_from_json::<ParametersValues>(file_path)?;
+    context.set_global_property_value(Parameters, parameters_json);
+    Ok(())
+}

--- a/examples/time-varying-infection/parameters_loader.rs
+++ b/examples/time-varying-infection/parameters_loader.rs
@@ -13,6 +13,7 @@ pub struct ParametersValues {
     pub max_time: f64,
     pub seed: u64,
     pub foi: f64,
+    pub foi_sin_shift: f64,
     pub infection_duration: f64,
     pub output_dir: String,
     pub output_file: String,

--- a/examples/time-varying-infection/periodic_report.rs
+++ b/examples/time-varying-infection/periodic_report.rs
@@ -25,7 +25,7 @@ struct PeriodicReportItem {
 
 create_report_trait!(PeriodicReportItem);
 
-fn count_people_and_send_report(context: &mut Context, plan_period: f64) {
+fn count_people_and_send_report(context: &mut Context, report_period: f64) {
     for disease_state in DiseaseStatus::iter() {
         let mut counter = 0;
         for usize_id in 0..context.get_current_population() {
@@ -44,8 +44,8 @@ fn count_people_and_send_report(context: &mut Context, plan_period: f64) {
             count: counter,
         });
     }
-    context.add_plan(context.get_current_time() + plan_period, move |context| {
-        count_people_and_send_report(context, plan_period);
+    context.add_plan(context.get_current_time() + report_period, move |context| {
+        count_people_and_send_report(context, report_period);
     });
 }
 

--- a/examples/time-varying-infection/periodic_report.rs
+++ b/examples/time-varying-infection/periodic_report.rs
@@ -53,7 +53,7 @@ pub fn init(context: &mut Context) {
     let parameters = context.get_global_property_value(Parameters).clone();
     context
         .report_options()
-        .directory(PathBuf::from("./examples/time-varying-infection/"));
-    context.add_report::<PeriodicReportItem>("person_count");
-    count_people_and_send_report(context, parameters.plan_period);
+        .directory(PathBuf::from(parameters.output_dir));
+    context.add_report::<PeriodicReportItem>("person_property_count");
+    count_people_and_send_report(context, parameters.report_period);
 }

--- a/examples/time-varying-infection/periodic_report.rs
+++ b/examples/time-varying-infection/periodic_report.rs
@@ -1,0 +1,59 @@
+use ixa::context::Context;
+use ixa::global_properties::ContextGlobalPropertiesExt;
+use ixa::people::ContextPeopleExt;
+use ixa::report::ContextReportExt;
+use ixa::{create_report_trait, report::Report};
+use std::path::PathBuf;
+use strum::IntoEnumIterator;
+
+use serde::{Deserialize, Serialize};
+
+use crate::parameters_loader::Parameters;
+use crate::population_loader::{DiseaseStatus, DiseaseStatusType};
+
+#[derive(Serialize, Deserialize, Clone)]
+struct PeriodicReportItem {
+    day: f64,
+    // use a string because eventually we want
+    // to be able to report on any property
+    // and want to be able to use this one
+    // struct for all properties, even those of
+    // different types
+    property_value: String,
+    count: usize,
+}
+
+create_report_trait!(PeriodicReportItem);
+
+fn count_people_and_send_report(context: &mut Context, plan_period: f64) {
+    for disease_state in DiseaseStatus::iter() {
+        let mut counter = 0;
+        for usize_id in 0..context.get_current_population() {
+            if context.get_person_property(context.get_person_id(usize_id), DiseaseStatusType)
+                == disease_state
+            {
+                counter += 1;
+            }
+        }
+        context.send_report(PeriodicReportItem {
+            day: context.get_current_time(),
+            // format macro returns a string which is what
+            // PeriodicReportItem struct expects
+            // for generality across properties
+            property_value: format!("{disease_state:?}"),
+            count: counter,
+        });
+    }
+    context.add_plan(context.get_current_time() + plan_period, move |context| {
+        count_people_and_send_report(context, plan_period);
+    });
+}
+
+pub fn init(context: &mut Context) {
+    let parameters = context.get_global_property_value(Parameters).clone();
+    context
+        .report_options()
+        .directory(PathBuf::from("./examples/time-varying-infection/"));
+    context.add_report::<PeriodicReportItem>("person_count");
+    count_people_and_send_report(context, parameters.plan_period);
+}

--- a/examples/time-varying-infection/plot_output.R
+++ b/examples/time-varying-infection/plot_output.R
@@ -55,3 +55,15 @@ ggplot2::ggplot() +
   xlab("Time") +
   ylab("People") +
   scale_y_log10(limits = c(1, parameters$population))
+
+person_property_report <- readr::read_csv(file.path(
+  "examples",
+  "time-varying-infection",
+  "person_count.csv"
+))
+
+ggplot2::ggplot() +
+  geom_point(aes(day, count, color = property_value), person_property_report) +
+  xlab("Time") +
+  ylab("People") +
+  scale_y_log10()

--- a/examples/time-varying-infection/plot_output.R
+++ b/examples/time-varying-infection/plot_output.R
@@ -25,13 +25,14 @@ output_df <- readr::read_csv(file.path(
     infection_status == "I" ~ parameters$population - cumsum(count),
     infection_status == "R" ~ cumsum(count)
   )) |>
-  # but now infection_status "I" really tells us the number of susceptible people
+  # but now infection_status "I" really tells us
+  # the number of susceptible people
   dplyr::mutate(infection_status = dplyr::case_when(
     infection_status == "I" ~ "S",
     TRUE ~ infection_status
   ))
 
-time_array_susc <- seq(0, ceiling(max(n_inf_output_df$time)), 0.1)
+time_array_susc <- seq(0, ceiling(max(output_df$time)), 0.1)
 
 # dS / dt = -foi(t) * S(t) # nolint: commented_code_linter.
 foi_t <- function(t) {
@@ -53,4 +54,4 @@ ggplot2::ggplot() +
   geom_line(aes(time_array_susc, expected_susc), color = "black") +
   xlab("Time") +
   ylab("People") +
-  scale_y_log10()
+  scale_y_log10(limits = c(1, parameters$population))

--- a/examples/time-varying-infection/plot_output.R
+++ b/examples/time-varying-infection/plot_output.R
@@ -4,33 +4,53 @@ library(purrr)
 library(ggplot2)
 library(jsonlite)
 
-parameters <- jsonlite::read_json(file.path("examples",
-"time-varying-infection",
-"input.json"))
+parameters <- jsonlite::read_json(file.path(
+  "examples",
+  "time-varying-infection",
+  "input.json"
+))
 
-output_df <- readr::read_csv(file.path("examples",
-"time-varying-infection",
-"incidence.csv")) |>
-    dplyr::filter(infection_status == "I") |>
-    dplyr::group_by(time) |>
-    dplyr::summarise(inf = n()) |>
-    dplyr::ungroup() |>
-    dplyr::mutate(inf = cumsum(inf))
+output_df <- readr::read_csv(file.path(
+  "examples",
+  "time-varying-infection",
+  "incidence.csv"
+)) |>
+  dplyr::group_by(infection_status, time) |>
+  dplyr::summarise(count = n()) |>
+  dplyr::ungroup(time) |>
+  # want to calculate number of remaining susceptibles from
+  # population minus number of cumulative infections -- because
+  # everyone gets infected
+  dplyr::mutate(count = dplyr::case_when(
+    infection_status == "I" ~ parameters$population - cumsum(count),
+    infection_status == "R" ~ cumsum(count)
+  )) |>
+  # but now infection_status "I" really tells us the number of susceptible people
+  dplyr::mutate(infection_status = dplyr::case_when(
+    infection_status == "I" ~ "S",
+    TRUE ~ infection_status
+  ))
 
-time_array <- seq(0, ceiling(max(output_df$time)), 0.1)
+time_array_susc <- seq(0, ceiling(max(n_inf_output_df$time)), 0.1)
 
 # dS / dt = -foi(t) * S(t) # nolint: commented_code_linter.
 foi_t <- function(t) {
   return(parameters$foi * (sin(t + parameters$foi_sin_shift) + 1))
 }
 
-expected_susc <- purrr::map(time_array,
-function(x) {parameters$population * exp(-integrate(foi_t,
-lower = 0, upper = x)$value)}) |>
-    unlist()
+expected_susc <- purrr::map(
+  time_array_susc,
+  function(x) {
+    parameters$population * exp(-integrate(foi_t,
+      lower = 0, upper = x
+    )$value)
+  }
+) |>
+  unlist()
 
 ggplot2::ggplot() +
-geom_point(aes(output_df$time, parameters$population - output_df$inf)) +
-geom_line(aes(time_array, expected_susc), color = "red") +
-xlab("Time") +
-ylab("Susceptibles")
+  geom_point(aes(time, count, color = infection_status), output_df) +
+  geom_line(aes(time_array_susc, expected_susc), color = "black") +
+  xlab("Time") +
+  ylab("People") +
+  scale_y_log10()

--- a/examples/time-varying-infection/plot_output.R
+++ b/examples/time-varying-infection/plot_output.R
@@ -1,28 +1,36 @@
 library(readr)
 library(dplyr)
 library(purrr)
+library(ggplot2)
+library(jsonlite)
 
-population <- 1000
-foi <- 0.15
-foi_sin_shift <- 3
-output_df <- readr::read_csv("./examples/time-varying-infection/incidence.csv") |>
+parameters <- jsonlite::read_json(file.path("examples",
+"time-varying-infection",
+"input.json"))
+
+output_df <- readr::read_csv(file.path("examples",
+"time-varying-infection",
+"incidence.csv")) |>
     dplyr::filter(infection_status == "I") |>
     dplyr::group_by(time) |>
-    dplyr::mutate(inf = n()) |>
+    dplyr::summarise(inf = n()) |>
     dplyr::ungroup() |>
     dplyr::mutate(inf = cumsum(inf))
 
-time_array <- 0:ceiling(max(output_df$time))
+time_array <- seq(0, ceiling(max(output_df$time)), 0.1)
 
 # dS / dt = -foi(t) * S(t) # nolint: commented_code_linter.
 foi_t <- function(t) {
-  return(foi * (sin(t + foi_sin_shift) + 1))
+  return(parameters$foi * (sin(t + parameters$foi_sin_shift) + 1))
 }
 
 expected_susc <- purrr::map(time_array,
-function(x) {population * exp(-integrate(foi_t,
+function(x) {parameters$population * exp(-integrate(foi_t,
 lower = 0, upper = x)$value)}) |>
     unlist()
 
-plot(output_df$time, population - output_df$inf, ylim = c(0, population))
-lines(time_array, expected_susc, col = "red")
+ggplot2::ggplot() +
+geom_point(aes(output_df$time, parameters$population - output_df$inf)) +
+geom_line(aes(time_array, expected_susc), color = "red") +
+xlab("Time") +
+ylab("Susceptibles")

--- a/examples/time-varying-infection/plot_output.R
+++ b/examples/time-varying-infection/plot_output.R
@@ -1,7 +1,7 @@
 library(tidyverse)
 
 population = 1000
-foi = 0.1
+foi = 0.15
 output_df <- read_csv("./examples/time-varying-infection/incidence.csv") |>
     filter(infection_status == "I") |>
     group_by(time) |>

--- a/examples/time-varying-infection/plot_output.R
+++ b/examples/time-varying-infection/plot_output.R
@@ -1,17 +1,28 @@
-library(tidyverse)
+library(readr)
+library(dplyr)
+library(purrr)
 
-population = 1000
-foi = 0.15
-output_df <- read_csv("./examples/time-varying-infection/incidence.csv") |>
-    filter(infection_status == "I") |>
-    group_by(time) |>
-    mutate(inf = n()) |>
-    ungroup() |>
-    mutate(inf = cumsum(inf))
+population <- 1000
+foi <- 0.15
+foi_sin_shift <- 3
+output_df <- readr::read_csv("./examples/time-varying-infection/incidence.csv") |>
+    dplyr::filter(infection_status == "I") |>
+    dplyr::group_by(time) |>
+    dplyr::mutate(inf = n()) |>
+    dplyr::ungroup() |>
+    dplyr::mutate(inf = cumsum(inf))
 
-time_array = 0:ceiling(max(output_df$time))
+time_array <- 0:ceiling(max(output_df$time))
 
-expected_susc = population * exp(-foi * time_array)
+# dS / dt = -foi(t) * S(t) # nolint: commented_code_linter.
+foi_t <- function(t) {
+  return(foi * (sin(t + foi_sin_shift) + 1))
+}
 
-plot(output_df$time, population - output_df$inf, ylim = c(0,population))
+expected_susc <- purrr::map(time_array,
+function(x) {population * exp(-integrate(foi_t,
+lower = 0, upper = x)$value)}) |>
+    unlist()
+
+plot(output_df$time, population - output_df$inf, ylim = c(0, population))
 lines(time_array, expected_susc, col = "red")

--- a/examples/time-varying-infection/plot_output.R
+++ b/examples/time-varying-infection/plot_output.R
@@ -1,0 +1,17 @@
+library(tidyverse)
+
+population = 1000
+foi = 0.1
+output_df <- read_csv("./examples/time-varying-infection/incidence.csv") |>
+    filter(infection_status == "I") |>
+    group_by(time) |>
+    mutate(inf = n()) |>
+    ungroup() |>
+    mutate(inf = cumsum(inf))
+
+time_array = 0:ceiling(max(output_df$time))
+
+expected_susc = population * exp(-foi * time_array)
+
+plot(output_df$time, population - output_df$inf, ylim = c(0,population))
+lines(time_array, expected_susc, col = "red")

--- a/examples/time-varying-infection/population_loader.rs
+++ b/examples/time-varying-infection/population_loader.rs
@@ -14,7 +14,7 @@ pub enum DiseaseStatus {
 }
 
 define_person_property_with_default!(DiseaseStatusType, DiseaseStatus, DiseaseStatus::S);
-define_person_property!(InfectionTime, f64);
+define_person_property_with_default!(InfectionTime, Option<f64>, None);
 
 pub fn init(context: &mut Context) {
     let parameters = context.get_global_property_value(Parameters).clone();
@@ -41,7 +41,7 @@ mod tests {
             max_time: 10.0,
             seed: 42,
             foi: 0.15,
-            foi_sin_shift: 3,
+            foi_sin_shift: 3.0,
             infection_duration: 5.0,
             output_dir: ".".to_string(),
             output_file: ".".to_string(),
@@ -58,6 +58,7 @@ mod tests {
             let status = context.get_person_property(context.get_person_id(i), DiseaseStatusType);
             let time = context.get_person_property(context.get_person_id(i), InfectionTime);
             assert_eq!(status, DiseaseStatus::S);
+            assert!(time.is_none());
         }
     }
 }

--- a/examples/time-varying-infection/population_loader.rs
+++ b/examples/time-varying-infection/population_loader.rs
@@ -14,6 +14,7 @@ pub enum DiseaseStatus {
 }
 
 define_person_property_with_default!(DiseaseStatusType, DiseaseStatus, DiseaseStatus::S);
+define_person_property!(InfectionTime, f64);
 
 pub fn init(context: &mut Context) {
     let parameters = context.get_global_property_value(Parameters).clone();
@@ -40,6 +41,7 @@ mod tests {
             max_time: 10.0,
             seed: 42,
             foi: 0.15,
+            foi_sin_shift: 3,
             infection_duration: 5.0,
             output_dir: ".".to_string(),
             output_file: ".".to_string(),
@@ -54,6 +56,7 @@ mod tests {
         assert_eq!(population_size, parameters.population);
         for i in 0..population_size {
             let status = context.get_person_property(context.get_person_id(i), DiseaseStatusType);
+            let time = context.get_person_property(context.get_person_id(i), InfectionTime);
             assert_eq!(status, DiseaseStatus::S);
         }
     }

--- a/examples/time-varying-infection/population_loader.rs
+++ b/examples/time-varying-infection/population_loader.rs
@@ -44,7 +44,7 @@ mod tests {
             foi: 0.15,
             foi_sin_shift: 3.0,
             infection_duration: 5.0,
-            plan_period: 1.0,
+            report_period: 1.0,
             output_dir: ".".to_string(),
             output_file: ".".to_string(),
         };

--- a/examples/time-varying-infection/population_loader.rs
+++ b/examples/time-varying-infection/population_loader.rs
@@ -1,0 +1,46 @@
+use ixa::context::Context;
+use ixa::people::ContextPeopleExt;
+use ixa::{define_person_property, define_person_property_with_default};
+use serde::{Deserialize, Serialize};
+
+use crate::POPULATION;
+
+#[derive(Deserialize, Serialize, Copy, Clone, PartialEq, Eq, Debug)]
+pub enum DiseaseStatus {
+    S,
+    I,
+    R,
+}
+
+define_person_property_with_default!(DiseaseStatusType, DiseaseStatus, DiseaseStatus::S);
+
+pub fn init(context: &mut Context) {
+    for _ in 0..POPULATION {
+        context.add_person();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use crate::POPULATION;
+    use crate::SEED;
+    use ixa::context::Context;
+    use ixa::people::ContextPeopleExt;
+    use ixa::random::ContextRandomExt;
+
+    #[test]
+    fn test_person_creation_default_properties() {
+        let mut context = Context::new();
+        context.init_random(SEED);
+        init(&mut context);
+
+        let population_size = context.get_current_population();
+        assert_eq!(population_size as u64, POPULATION);
+        for i in 0..population_size {
+            let status = context.get_person_property(context.get_person_id(i), DiseaseStatusType);
+            assert_eq!(status, DiseaseStatus::S);
+        }
+    }
+}

--- a/examples/time-varying-infection/population_loader.rs
+++ b/examples/time-varying-infection/population_loader.rs
@@ -15,7 +15,7 @@ pub enum DiseaseStatus {
 }
 
 define_person_property_with_default!(DiseaseStatusType, DiseaseStatus, DiseaseStatus::S);
-define_person_property_with_default!(InfectionTime, Option<f64>, None);
+define_person_property!(InfectionTime, f64);
 
 pub fn init(context: &mut Context) {
     let parameters = context.get_global_property_value(Parameters).clone();
@@ -36,6 +36,7 @@ mod tests {
     use crate::parameters_loader::ParametersValues;
 
     #[test]
+    #[should_panic(expected = "Property not initialized")]
     fn test_person_creation_default_properties() {
         let p_values = ParametersValues {
             population: 1,
@@ -58,9 +59,8 @@ mod tests {
         assert_eq!(population_size, parameters.population);
         for i in 0..population_size {
             let status = context.get_person_property(context.get_person_id(i), DiseaseStatusType);
-            let time = context.get_person_property(context.get_person_id(i), InfectionTime);
             assert_eq!(status, DiseaseStatus::S);
-            assert!(time.is_none());
+            context.get_person_property(context.get_person_id(i), InfectionTime);
         }
     }
 }

--- a/examples/time-varying-infection/population_loader.rs
+++ b/examples/time-varying-infection/population_loader.rs
@@ -3,10 +3,11 @@ use ixa::global_properties::ContextGlobalPropertiesExt;
 use ixa::people::ContextPeopleExt;
 use ixa::{define_person_property, define_person_property_with_default};
 use serde::{Deserialize, Serialize};
+use strum_macros::EnumIter;
 
 use crate::parameters_loader::Parameters;
 
-#[derive(Deserialize, Serialize, Copy, Clone, PartialEq, Eq, Debug)]
+#[derive(Deserialize, Serialize, Copy, Clone, PartialEq, Eq, Debug, EnumIter)]
 pub enum DiseaseStatus {
     S,
     I,
@@ -43,6 +44,7 @@ mod tests {
             foi: 0.15,
             foi_sin_shift: 3.0,
             infection_duration: 5.0,
+            plan_period: 1.0,
             output_dir: ".".to_string(),
             output_file: ".".to_string(),
         };


### PR DESCRIPTION
Introduces two ways of modeling time-varying rates in `ixa` and Rust -- in particular, a seasonal force of infection and a recovery rate that scales with the number of infected people. This PR and the readme focuses on _how_ to model time-varying rates and different methods of doing so.

The example is the same as the basic-infection example, except that it:

1. Has been updated to include the built-in `people` module. The tests can therefore be a bit more intense and are properly updated.
2. Has been updated to include the built-in `global_properties` module. The R code also reads from the json file and some small bugs in the R code have been cleaned up.
3. A periodic report has been added!

![image](https://github.com/user-attachments/assets/856eb087-4fd5-4de7-8d13-fb1a7743e665)
