### PR TITLE
Derived properties

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ csv = "1.3"
 serde = { version = "1.0", features = ["derive"] }
 serde_derive = "1.0"
 serde_json = "1.0.128"
+ixa-derive = { path = "ixa-derive" }
 
 [dev-dependencies]
 rand_distr = "0.4.3"

--- a/examples/basic-infection/people.rs
+++ b/examples/basic-infection/people.rs
@@ -1,4 +1,4 @@
-use ixa::context::Context;
+use ixa::context::{Context, Event};
 use ixa::define_data_plugin;
 use std::collections::HashMap;
 
@@ -18,6 +18,7 @@ pub struct InfectionStatusEvent {
     pub updated_status: InfectionStatus,
     pub person_id: usize,
 }
+impl Event for InfectionStatusEvent {}
 
 pub trait ContextPeopleExt {
     fn create_person(&mut self);

--- a/examples/basic-infection/people.rs
+++ b/examples/basic-infection/people.rs
@@ -1,5 +1,6 @@
-use ixa::context::{Context, Event};
+use ixa::context::{Context, IxaEvent};
 use ixa::define_data_plugin;
+use ixa_derive::IxaEvent;
 use std::collections::HashMap;
 
 use serde::{Deserialize, Serialize};
@@ -11,14 +12,13 @@ pub enum InfectionStatus {
     R,
 }
 
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, IxaEvent)]
 pub struct InfectionStatusEvent {
     #[allow(dead_code)]
     pub prev_status: InfectionStatus,
     pub updated_status: InfectionStatus,
     pub person_id: usize,
 }
-impl Event for InfectionStatusEvent {}
 
 pub trait ContextPeopleExt {
     fn create_person(&mut self);

--- a/ixa-derive/Cargo.toml
+++ b/ixa-derive/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "ixa-derive"
+version = "0.0.0"
+edition = "2021"
+
+[dependencies]
+proc-macro2 = "1.0"
+quote = "1.0"
+syn = "2.0.85"
+
+[lib]
+proc-macro = true

--- a/ixa-derive/src/lib.rs
+++ b/ixa-derive/src/lib.rs
@@ -1,0 +1,16 @@
+extern crate proc_macro;
+use proc_macro::TokenStream;
+use quote::quote;
+use syn::{parse_macro_input, DeriveInput};
+
+#[proc_macro_derive(IxaEvent)]
+pub fn derive_ixa_event(input: TokenStream) -> TokenStream {
+    let input = parse_macro_input!(input as DeriveInput);
+    let name = &input.ident;
+
+    let expanded = quote! {
+        impl IxaEvent for #name {}
+    };
+
+    TokenStream::from(expanded)
+}

--- a/src/context.rs
+++ b/src/context.rs
@@ -16,7 +16,7 @@ type Callback = dyn FnOnce(&mut Context);
 /// A handler for an event type `E`
 type EventHandler<E> = dyn Fn(&mut Context, E);
 
-pub trait Event {
+pub trait IxaEvent {
     /// Called every time `context.subscribe_to_event` is called with this event
     fn on_subscribe(_context: &mut Context) {}
 }
@@ -76,7 +76,7 @@ impl Context {
     /// Handlers will be called upon event emission in order of subscription as
     /// queued `Callback`s with the appropriate event.
     #[allow(clippy::missing_panics_doc)]
-    pub fn subscribe_to_event<E: Event + Copy + 'static>(
+    pub fn subscribe_to_event<E: IxaEvent + Copy + 'static>(
         &mut self,
         handler: impl Fn(&mut Context, E) + 'static,
     ) {
@@ -94,7 +94,7 @@ impl Context {
     /// Receivers will handle events in the order that they have subscribed and
     /// are queued as callbacks
     #[allow(clippy::missing_panics_doc)]
-    pub fn emit_event<E: Event + Copy + 'static>(&mut self, event: E) {
+    pub fn emit_event<E: IxaEvent + Copy + 'static>(&mut self, event: E) {
         // Destructure to obtain event handlers and plan queue
         let Context {
             event_handlers,
@@ -251,6 +251,7 @@ mod tests {
     use std::cell::RefCell;
 
     use super::*;
+    use ixa_derive::IxaEvent;
 
     define_data_plugin!(ComponentA, Vec<u32>, vec![]);
 
@@ -419,17 +420,15 @@ mod tests {
         assert_eq!(*context.get_data_container_mut(ComponentA), vec![1, 2]);
     }
 
-    #[derive(Copy, Clone)]
+    #[derive(Copy, Clone, IxaEvent)]
     struct Event1 {
         pub data: usize,
     }
-    impl Event for Event1 {}
 
-    #[derive(Copy, Clone)]
+    #[derive(Copy, Clone, IxaEvent)]
     struct Event2 {
         pub data: usize,
     }
-    impl Event for Event2 {}
 
     #[test]
     fn simple_event() {

--- a/src/people.rs
+++ b/src/people.rs
@@ -112,7 +112,7 @@ where
     ) {
         let previous = context.get_person_property(person, T::get_instance());
 
-        // Stores the current value of the person property and defer the actual event
+        // Captures the current value of the person property and defers the actual event
         // emission to when we have access to the new value.
         callback_vec.push(Box::new(move |ctx| {
             let current = ctx.get_person_property(person, T::get_instance());

--- a/src/people.rs
+++ b/src/people.rs
@@ -78,6 +78,8 @@ type ContextCallback = dyn FnOnce(&mut Context);
 // primarily because it stores a different Value type for each kind of property,
 // `PersonPropertyHolder` is, meaning we can treat different types of properties
 // uniformly at runtime.
+// Note: this has to be pub because `PersonProperty` (which is pub) implements
+// a dependency method that returns `PersonPropertyHolder` instances.
 pub trait PersonPropertyHolder {
     // Registers a callback in the provided `callback_vec` that is invoked when
     // a dependency of a derived property is updated for the given person

--- a/src/people.rs
+++ b/src/people.rs
@@ -1,9 +1,12 @@
-use crate::{context::Context, define_data_plugin};
 use serde::{Deserialize, Serialize};
+use crate::{
+    context::{Context, Event},
+    define_data_plugin,
+};
 use std::{
     any::{Any, TypeId},
     cell::{RefCell, RefMut},
-    collections::HashMap,
+    collections::{HashMap, HashSet},
     fmt,
 };
 
@@ -13,6 +16,8 @@ use std::{
 struct PeopleData {
     current_population: usize,
     properties_map: RefCell<HashMap<TypeId, Box<dyn Any>>>,
+    registered_derived_properties: RefCell<HashSet<TypeId>>,
+    dependency_map: RefCell<HashMap<TypeId, Vec<Box<dyn PersonPropertyHolder>>>>,
 }
 
 define_data_plugin!(
@@ -20,7 +25,9 @@ define_data_plugin!(
     PeopleData,
     PeopleData {
         current_population: 0,
-        properties_map: RefCell::new(HashMap::new())
+        properties_map: RefCell::new(HashMap::new()),
+        registered_derived_properties: RefCell::new(HashSet::new()),
+        dependency_map: RefCell::new(HashMap::new())
     }
 );
 
@@ -51,7 +58,54 @@ impl fmt::Debug for PersonId {
 // They may be defined with the define_person_property! macro.
 pub trait PersonProperty: Copy {
     type Value: Copy;
-    fn initialize(context: &Context, person_id: PersonId) -> Self::Value;
+    #[must_use]
+    fn is_derived() -> bool {
+        false
+    }
+    #[must_use]
+    fn dependencies() -> Vec<TypeId> {
+        panic!("Dependencies not implemented");
+    }
+    fn compute(context: &Context, person_id: PersonId) -> Self::Value;
+    fn get_instance() -> Self;
+}
+
+type ContextCallback = dyn FnOnce(&mut Context);
+
+// The purpose of this trait is to allow us to store a vector of different PersonProperties
+// in an object safe way, and use them to emit change events.
+pub trait PersonPropertyHolder {
+    // Adds a callback to callback_vec which can later be called with a new context
+    // to emit a change event
+    fn add_event_callback(
+        &self,
+        context: &mut Context,
+        person: PersonId,
+        callback_vec: &mut Vec<Box<ContextCallback>>,
+    );
+}
+
+impl<T> PersonPropertyHolder for T
+where
+    T: PersonProperty + 'static,
+{
+    fn add_event_callback(
+        &self,
+        context: &mut Context,
+        person: PersonId,
+        callback_vec: &mut Vec<Box<ContextCallback>>,
+    ) {
+        let previous = context.get_person_property(person, T::get_instance());
+        callback_vec.push(Box::new(move |ctx| {
+            let current = ctx.get_person_property(person, T::get_instance());
+            let change_event: PersonPropertyChangeEvent<T> = PersonPropertyChangeEvent {
+                person_id: person,
+                current,
+                previous,
+            };
+            ctx.emit_event(change_event);
+        }));
+    }
 }
 
 /// Defines a person property with the following parameters:
@@ -67,11 +121,14 @@ macro_rules! define_person_property {
         pub struct $person_property;
         impl $crate::people::PersonProperty for $person_property {
             type Value = $value;
-            fn initialize(
+            fn compute(
                 _context: &$crate::context::Context,
                 _person: $crate::people::PersonId,
             ) -> Self::Value {
                 $initialize(_context, _person)
+            }
+            fn get_instance() -> Self {
+                $person_property
             }
         }
     };
@@ -92,6 +149,38 @@ macro_rules! define_person_property_with_default {
         define_person_property!($person_property, $value, |_context, _person_id| {
             $default
         });
+    };
+}
+
+/// Defines a derived person property with the following parameters:
+/// * `$person_property`: A name for the identifier type of the property
+/// * `$value`: The type of the property's value
+/// * `[$($dependency),+]`: A list of person properties the derived property depends on
+/// * $calculate: A closure that takes the values of each dependency and returns the derived value
+#[macro_export]
+macro_rules! define_derived_property {
+    ($derived_property:ident, $value:ty, [$($dependency:ident),+], |$($param:ident),+| $derive_fn:expr) => {
+        #[derive(Copy, Clone)]
+        pub struct $derived_property;
+
+        impl $crate::people::PersonProperty for $derived_property {
+            type Value = $value;
+
+            fn compute(context: &$crate::context::Context, person_id: $crate::people::PersonId) -> Self::Value {
+                #[allow(unused_parens)]
+                let ($($param),+) = (
+                    $(context.get_person_property(person_id, $dependency)),+
+                );
+                (|$($param),+| $derive_fn)($($param),+)
+            }
+            fn is_derived() -> bool { true }
+            fn dependencies() -> Vec<std::any::TypeId> {
+                vec![$(std::any::TypeId::of::<$dependency>()),+]
+             }
+             fn get_instance() -> Self {
+                 $derived_property
+             }
+        }
     };
 }
 
@@ -152,6 +241,7 @@ impl PeopleData {
 pub struct PersonCreatedEvent {
     pub person_id: PersonId,
 }
+impl Event for PersonCreatedEvent {}
 
 // Emitted when a person property is updated
 // These should not be emitted outside this module
@@ -161,6 +251,13 @@ pub struct PersonPropertyChangeEvent<T: PersonProperty> {
     pub person_id: PersonId,
     pub current: T::Value,
     pub previous: T::Value,
+}
+impl<T: PersonProperty + 'static> Event for PersonPropertyChangeEvent<T> {
+    fn on_subscribe(context: &mut Context) {
+        if T::is_derived() {
+            context.register_property::<T>();
+        }
+    }
 }
 
 pub trait ContextPeopleExt {
@@ -178,6 +275,8 @@ pub trait ContextPeopleExt {
         person_id: PersonId,
         _property: T,
     ) -> T::Value;
+
+    fn register_property<T: PersonProperty + 'static>(&mut self);
 
     /// Given a `PersonId`, initialize the value of a defined person property.
     /// Once the the value is set using this API, any initializer will
@@ -216,6 +315,27 @@ impl ContextPeopleExt for Context {
         person_id
     }
 
+    fn register_property<T: PersonProperty + 'static>(&mut self) {
+        let data_container = self.get_data_container(PeoplePlugin)
+            .expect("PeoplePlugin is not initialized; make sure you add a person before accessing properties");
+        if !data_container
+            .registered_derived_properties
+            .borrow()
+            .contains(&TypeId::of::<T>())
+        {
+            let dependencies = T::dependencies();
+            for dependency in dependencies {
+                let mut property_dependencies = data_container.dependency_map.borrow_mut();
+                let deps = property_dependencies.entry(dependency).or_default();
+                deps.push(Box::new(T::get_instance()));
+            }
+            data_container
+                .registered_derived_properties
+                .borrow_mut()
+                .insert(TypeId::of::<T>());
+        }
+    }
+
     fn get_person_property<T: PersonProperty + 'static>(
         &self,
         person_id: PersonId,
@@ -224,13 +344,17 @@ impl ContextPeopleExt for Context {
         let data_container = self.get_data_container(PeoplePlugin)
             .expect("PeoplePlugin is not initialized; make sure you add a person before accessing properties");
 
+        if T::is_derived() {
+            return T::compute(self, person_id);
+        }
+
         // Attempt to retrieve the existing value
         if let Some(value) = *data_container.get_person_property_ref(person_id, property) {
             return value;
         }
 
         // Initialize the property. This does not fire a change event
-        let initialized_value = T::initialize(self, person_id);
+        let initialized_value = T::compute(self, person_id);
         data_container.set_person_property(person_id, property, initialized_value);
 
         initialized_value
@@ -242,6 +366,7 @@ impl ContextPeopleExt for Context {
         property: T,
         value: T::Value,
     ) {
+        assert!(!T::is_derived(), "Cannot initialize a derived property");
         let data_container = self.get_data_container(PeoplePlugin)
             .expect("PeoplePlugin is not initialized; make sure you add a person before accessing properties");
 
@@ -257,26 +382,56 @@ impl ContextPeopleExt for Context {
         property: T,
         value: T::Value,
     ) {
+        assert!(!T::is_derived(), "Cannot set a derived property");
         let data_container = self.get_data_container(PeoplePlugin)
             .expect("PeoplePlugin is not initialized; make sure you add a person before accessing properties");
 
-        let current_value = *data_container.get_person_property_ref(person_id, property);
-        let previous_value = match current_value {
-            Some(current_value) => current_value,
+        let current_cached_value = *data_container.get_person_property_ref(person_id, property);
+        let previous_value = match current_cached_value {
+            Some(value) => value,
             None => {
-                let initialize_value = T::initialize(self, person_id);
+                let initialize_value = T::compute(self, person_id);
                 data_container.set_person_property(person_id, property, initialize_value);
                 initialize_value
             }
         };
 
+        // Temporarily remove dependency properties since we need mutable references
+        // to self during callback execution
+        let deps_temp = {
+            let data_container = self.get_data_container(PeoplePlugin).unwrap();
+            let mut dependencies = data_container.dependency_map.borrow_mut();
+            dependencies.get_mut(&TypeId::of::<T>()).map(std::mem::take)
+        };
+
+        let mut dependency_event_callbacks = Vec::new();
+        if let Some(mut deps) = deps_temp {
+            // If there are dependencies, set up a bunch of callbacks with the
+            // current value
+            for dep in &mut deps {
+                dep.add_event_callback(self, person_id, &mut dependency_event_callbacks);
+            }
+
+            // Put the dependency list back in
+            let data_container = self.get_data_container(PeoplePlugin).unwrap();
+            let mut dependencies = data_container.dependency_map.borrow_mut();
+            dependencies.insert(TypeId::of::<T>(), deps);
+        }
+
+        // Update the main property and send a change event
+        let data_container = self.get_data_container(PeoplePlugin).unwrap();
+        data_container.set_person_property(person_id, property, value);
         let change_event: PersonPropertyChangeEvent<T> = PersonPropertyChangeEvent {
             person_id,
             current: value,
             previous: previous_value,
         };
-        data_container.set_person_property(person_id, property, value);
         self.emit_event(change_event);
+
+        // If there are dependency callbacks, call them with the updated value
+        for callback in dependency_event_callbacks {
+            callback(self);
+        }
     }
 
     fn get_person_id(&self, person_id: usize) -> PersonId {
@@ -295,6 +450,19 @@ mod test {
     use std::{cell::RefCell, rc::Rc};
 
     define_person_property!(Age, u8);
+    #[derive(Copy, Clone, Debug, PartialEq, Eq)]
+    pub enum AgeGroupType {
+        Child,
+        Adult,
+    }
+    define_derived_property!(AgeGroup, AgeGroupType, [Age], |age| {
+        if age < 18 {
+            AgeGroupType::Child
+        } else {
+            AgeGroupType::Adult
+        }
+    });
+
     #[derive(Copy, Clone, PartialEq, Eq, Debug)]
     pub enum RiskCategory {
         High,
@@ -310,6 +478,15 @@ mod test {
             0
         }
     });
+    define_derived_property!(TrailRunner, bool, [IsRunner, Age], |is_runner, age| {
+        is_runner && age > 29
+    });
+    define_derived_property!(
+        UltraRunner,
+        bool,
+        [TrailRunner, Age],
+        |trail_runner, age| { trail_runner && age > 39 }
+    );
 
     #[test]
     fn observe_person_addition() {
@@ -552,5 +729,124 @@ mod test {
         let mut context = Context::new();
         context.add_person();
         context.get_person_id(1);
+    }
+
+    #[test]
+    fn get_person_property_returns_correct_value() {
+        let mut context = Context::new();
+        let person = context.add_person();
+        context.initialize_person_property(person, Age, 10);
+        assert_eq!(
+            context.get_person_property(person, AgeGroup),
+            AgeGroupType::Child
+        );
+    }
+
+    #[test]
+    fn get_person_property_changes_correctly() {
+        let mut context = Context::new();
+        let person = context.add_person();
+        context.initialize_person_property(person, Age, 17);
+        assert_eq!(
+            context.get_person_property(person, AgeGroup),
+            AgeGroupType::Child
+        );
+        context.set_person_property(person, Age, 18);
+        assert_eq!(
+            context.get_person_property(person, AgeGroup),
+            AgeGroupType::Adult
+        );
+    }
+    #[test]
+    fn get_person_property_change_event() {
+        let mut context = Context::new();
+        let person = context.add_person();
+        context.initialize_person_property(person, Age, 17);
+
+        let flag = Rc::new(RefCell::new(false));
+        let flag_clone = flag.clone();
+        context.subscribe_to_event(
+            move |_context, event: PersonPropertyChangeEvent<AgeGroup>| {
+                assert_eq!(event.person_id.id, 0);
+                assert_eq!(event.previous, AgeGroupType::Child);
+                assert_eq!(event.current, AgeGroupType::Adult);
+                *flag_clone.borrow_mut() = true;
+            },
+        );
+        context.set_person_property(person, Age, 18);
+        context.execute();
+        assert!(*flag.borrow());
+    }
+
+    #[test]
+    fn get_derived_property_multiple_deps() {
+        let mut context = Context::new();
+        let person = context.add_person();
+        context.initialize_person_property(person, Age, 29);
+        context.initialize_person_property(person, IsRunner, true);
+
+        let flag = Rc::new(RefCell::new(false));
+        let flag_clone = flag.clone();
+        context.subscribe_to_event(
+            move |_context, event: PersonPropertyChangeEvent<TrailRunner>| {
+                assert_eq!(event.person_id.id, 0);
+                assert!(!event.previous);
+                assert!(event.current);
+                *flag_clone.borrow_mut() = true;
+            },
+        );
+        context.set_person_property(person, Age, 30);
+        context.execute();
+        assert!(*flag.borrow());
+    }
+
+    #[test]
+    fn register_derived_only_once() {
+        let mut context = Context::new();
+        let person = context.add_person();
+        context.initialize_person_property(person, Age, 29);
+        context.initialize_person_property(person, IsRunner, true);
+
+        let flag = Rc::new(RefCell::new(0));
+        let flag_clone = flag.clone();
+        context.subscribe_to_event(
+            move |_context, _event: PersonPropertyChangeEvent<TrailRunner>| {
+                *flag_clone.borrow_mut() += 1;
+            },
+        );
+        context.subscribe_to_event(
+            move |_context, _event: PersonPropertyChangeEvent<TrailRunner>| {
+                // Make sure that we don't register multiple times
+            },
+        );
+        context.set_person_property(person, Age, 30);
+        context.execute();
+        assert_eq!(*flag.borrow(), 1);
+    }
+
+    // TODO(ryl8@cdc.gov): Nested derived properties don't currently work; we should
+    // probably either fix this or disallow it.
+    #[ignore]
+    #[test]
+    fn get_derived_property_dependent_on_another_derived() {
+        let mut context = Context::new();
+        let person = context.add_person();
+        context.initialize_person_property(person, Age, 40);
+        context.initialize_person_property(person, IsRunner, false);
+
+        let flag = Rc::new(RefCell::new(false));
+        let flag_clone = flag.clone();
+        assert!(!context.get_person_property(person, UltraRunner));
+        context.subscribe_to_event(
+            move |_context, event: PersonPropertyChangeEvent<UltraRunner>| {
+                assert_eq!(event.person_id.id, 0);
+                assert!(!event.previous);
+                assert!(event.current);
+                *flag_clone.borrow_mut() = true;
+            },
+        );
+        context.set_person_property(person, IsRunner, true);
+        context.execute();
+        assert!(*flag.borrow());
     }
 }

--- a/src/people.rs
+++ b/src/people.rs
@@ -1,8 +1,8 @@
-use serde::{Deserialize, Serialize};
 use crate::{
     context::{Context, Event},
     define_data_plugin,
 };
+use serde::{Deserialize, Serialize};
 use std::{
     any::{Any, TypeId},
     cell::{RefCell, RefMut},

--- a/src/people.rs
+++ b/src/people.rs
@@ -438,9 +438,12 @@ impl ContextPeopleExt for Context {
         // Temporarily remove dependency properties since we need mutable references
         // to self during callback execution
         let deps_temp = {
-            let data_container = self.get_data_container(PeoplePlugin).unwrap();
-            let mut dependencies = data_container.dependency_map.borrow_mut();
-            dependencies.get_mut(&TypeId::of::<T>()).map(std::mem::take)
+            self.get_data_container(PeoplePlugin)
+                .unwrap()
+                .dependency_map
+                .borrow_mut()
+                .get_mut(&TypeId::of::<T>())
+                .map(std::mem::take)
         };
 
         let mut dependency_event_callbacks = Vec::new();


### PR DESCRIPTION
This implementation supports multiple property dependencies and computes values lazily for derived properties (avoiding some of the mechanics around updating the cache and therefore the need to register early). Registration happens during subscription only; we will also need to do this during index creation). 

I avoid wrapping the events with a special function by implementing a `on_subscribe` hook on an `Event` trait.