### PR TITLE
Person Properties Periodic Report

### DIFF
--- a/examples/basic-infection/people.rs
+++ b/examples/basic-infection/people.rs
@@ -26,7 +26,8 @@ pub trait ContextPeopleExt {
     fn get_population(&self) -> usize;
 }
 
-struct PeopleData {
+#[allow(clippy::module_name_repetitions)]
+pub struct PeopleData {
     people_map: HashMap<usize, InfectionStatus>,
 }
 // Register the data container in context

--- a/examples/load-people/main.rs
+++ b/examples/load-people/main.rs
@@ -1,4 +1,4 @@
-use ixa::{context::Context, random::ContextRandomExt};
+use ixa::{context::Context, random::ContextRandomExt, report::ContextReportExt};
 mod logger;
 mod population_loader;
 mod sir;
@@ -18,6 +18,8 @@ fn main() {
 
     // Load people from csv and set up some base properties
     population_loader::init(&mut context);
+
+    context.add_person_properties_report("person_properties_report", 1.0);
 
     context.execute();
 }

--- a/examples/load-people/main.rs
+++ b/examples/load-people/main.rs
@@ -19,7 +19,7 @@ fn main() {
     // Load people from csv and set up some base properties
     population_loader::init(&mut context);
 
-    context.add_person_properties_report("person_properties_report", 1.0);
+    context.add_person_properties_report("person_properties_report", 0.5);
 
     context.execute();
 }

--- a/examples/load-people/population_loader.rs
+++ b/examples/load-people/population_loader.rs
@@ -18,8 +18,8 @@ struct PeopleRecord {
     risk_category: RiskCategory,
 }
 
-define_person_property!(Age, u8);
-define_person_property!(RiskCategoryType, RiskCategory);
+define_person_property!(Age, u8, true);
+define_person_property!(RiskCategoryType, RiskCategory, true);
 
 fn create_person_from_record(context: &mut Context, record: &PeopleRecord) -> PersonId {
     let person = context.add_person();

--- a/examples/load-people/sir.rs
+++ b/examples/load-people/sir.rs
@@ -11,7 +11,7 @@ pub enum DiseaseStatus {
     R,
 }
 
-define_person_property_with_default!(DiseaseStatusType, DiseaseStatus, DiseaseStatus::S);
+define_person_property_with_default!(DiseaseStatusType, DiseaseStatus, true, DiseaseStatus::S);
 
 pub fn init(context: &mut Context) {
     context.subscribe_to_event(move |context, event: PersonCreatedEvent| {

--- a/examples/load-people/vaccine.rs
+++ b/examples/load-people/vaccine.rs
@@ -12,9 +12,9 @@ pub enum VaccineTypeValue {
     A,
     B,
 }
-define_person_property!(VaccineType, VaccineTypeValue);
-define_person_property!(VaccineEfficacy, f64);
-define_person_property!(VaccineDoses, u8, |context: &Context, person_id| {
+define_person_property!(VaccineType, VaccineTypeValue, true);
+define_person_property!(VaccineEfficacy, f64, true);
+define_person_property!(VaccineDoses, u8, true, |context: &Context, person_id| {
     let age = context.get_person_property(person_id, Age);
     if age > 10 {
         context.sample_range(VaccineRng, 0..5)

--- a/examples/load-people/vaccine.rs
+++ b/examples/load-people/vaccine.rs
@@ -14,14 +14,19 @@ pub enum VaccineTypeValue {
 }
 define_person_property!(VaccineType, VaccineTypeValue, true);
 define_person_property!(VaccineEfficacy, f64, true);
-define_person_property!(VaccineDoses, u8, true, |context: &Context, person_id| {
-    let age = context.get_person_property(person_id, Age);
-    if age > 10 {
-        context.sample_range(VaccineRng, 0..5)
-    } else {
-        0
+define_person_property!(
+    VaccineDoses,
+    u8,
+    true,
+    |context: &mut Context, person_id| {
+        let age = context.get_person_property(person_id, Age);
+        if age > 10 {
+            context.sample_range(VaccineRng, 0..5)
+        } else {
+            0
+        }
     }
-});
+);
 
 pub trait ContextVaccineExt {
     fn get_vaccine_props(&self, risk: RiskCategory) -> (VaccineTypeValue, f64);

--- a/examples/load-people/vaccine.rs
+++ b/examples/load-people/vaccine.rs
@@ -21,9 +21,9 @@ define_person_property!(
     |context: &mut Context, person_id| {
         let age = context.get_person_property(person_id, Age);
         if age > 10 {
-            context.sample_range(VaccineRng, 0..5)
+            Some(context.sample_range(VaccineRng, 0..5))
         } else {
-            0
+            Some(0)
         }
     }
 );

--- a/examples/parameter-loading/main.rs
+++ b/examples/parameter-loading/main.rs
@@ -21,7 +21,12 @@ pub enum InfectionStatus {
     I,
     R,
 }
-define_person_property_with_default!(InfectionStatusType, InfectionStatus, InfectionStatus::S);
+define_person_property_with_default!(
+    InfectionStatusType,
+    InfectionStatus,
+    true,
+    InfectionStatus::S
+);
 
 fn main() {
     let mut context = Context::new();

--- a/src/context.rs
+++ b/src/context.rs
@@ -231,7 +231,7 @@ pub trait DataPlugin: Any {
 #[macro_export]
 macro_rules! define_data_plugin {
     ($plugin:ident, $data_container:ty, $default: expr) => {
-        struct $plugin;
+        pub struct $plugin;
 
         impl $crate::context::DataPlugin for $plugin {
             type DataContainer = $data_container;

--- a/src/global_properties.rs
+++ b/src/global_properties.rs
@@ -31,7 +31,8 @@ pub trait GlobalProperty: Any {
 
 pub use define_global_property;
 
-struct GlobalPropertiesDataContainer {
+#[allow(clippy::module_name_repetitions)]
+pub struct GlobalPropertiesDataContainer {
     global_property_container: HashMap<TypeId, Box<dyn Any>>,
 }
 

--- a/src/people.rs
+++ b/src/people.rs
@@ -10,7 +10,8 @@ use std::{
 // PeopleData represents each unique person in the simulation with an id ranging
 // from 0 to population - 1. Person properties are associated with a person
 // via their id.
-struct PeopleData {
+#[allow(clippy::module_name_repetitions)]
+pub struct PeopleData {
     current_population: usize,
     properties_map: RefCell<HashMap<TypeId, Box<dyn Any>>>,
 }

--- a/src/plan.rs
+++ b/src/plan.rs
@@ -66,6 +66,11 @@ impl<T> Queue<T> {
         self.data_map.remove(&id.id).expect("Plan does not exist");
     }
 
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.queue.is_empty()
+    }
+
     /// Retrieve the earliest plan in the queue
     ///
     /// Returns the next plan if it exists or else `None` if the queue is empty
@@ -153,19 +158,23 @@ mod tests {
         plan_queue.add_plan(1.0, 1);
         plan_queue.add_plan(3.0, 3);
         plan_queue.add_plan(2.0, 2);
+        assert!(!plan_queue.is_empty());
 
         let next_plan = plan_queue.get_next_plan().unwrap();
         assert_eq!(next_plan.time, 1.0);
         assert_eq!(next_plan.data, 1);
 
+        assert!(!plan_queue.is_empty());
         let next_plan = plan_queue.get_next_plan().unwrap();
         assert_eq!(next_plan.time, 2.0);
         assert_eq!(next_plan.data, 2);
 
+        assert!(!plan_queue.is_empty());
         let next_plan = plan_queue.get_next_plan().unwrap();
         assert_eq!(next_plan.time, 3.0);
         assert_eq!(next_plan.data, 3);
 
+        assert!(plan_queue.is_empty());
         assert!(plan_queue.get_next_plan().is_none());
     }
 
@@ -174,15 +183,18 @@ mod tests {
         let mut plan_queue = Queue::new();
         plan_queue.add_plan(1.0, 1);
         plan_queue.add_plan(1.0, 2);
+        assert!(!plan_queue.is_empty());
 
         let next_plan = plan_queue.get_next_plan().unwrap();
         assert_eq!(next_plan.time, 1.0);
         assert_eq!(next_plan.data, 1);
 
+        assert!(!plan_queue.is_empty());
         let next_plan = plan_queue.get_next_plan().unwrap();
         assert_eq!(next_plan.time, 1.0);
         assert_eq!(next_plan.data, 2);
 
+        assert!(plan_queue.is_empty());
         assert!(plan_queue.get_next_plan().is_none());
     }
 
@@ -193,15 +205,18 @@ mod tests {
         let plan_to_cancel = plan_queue.add_plan(2.0, 2);
         plan_queue.add_plan(3.0, 3);
         plan_queue.cancel_plan(&plan_to_cancel);
+        assert!(!plan_queue.is_empty());
 
         let next_plan = plan_queue.get_next_plan().unwrap();
         assert_eq!(next_plan.time, 1.0);
         assert_eq!(next_plan.data, 1);
 
+        assert!(!plan_queue.is_empty());
         let next_plan = plan_queue.get_next_plan().unwrap();
         assert_eq!(next_plan.time, 3.0);
         assert_eq!(next_plan.data, 3);
 
+        assert!(plan_queue.is_empty());
         assert!(plan_queue.get_next_plan().is_none());
     }
 
@@ -210,6 +225,7 @@ mod tests {
         let mut plan_queue = Queue::new();
         plan_queue.add_plan(1.0, 1);
         plan_queue.add_plan(2.0, 2);
+        assert!(!plan_queue.is_empty());
 
         let next_plan = plan_queue.get_next_plan().unwrap();
         assert_eq!(next_plan.time, 1.0);
@@ -217,14 +233,17 @@ mod tests {
 
         plan_queue.add_plan(1.5, 3);
 
+        assert!(!plan_queue.is_empty());
         let next_plan = plan_queue.get_next_plan().unwrap();
         assert_eq!(next_plan.time, 1.5);
         assert_eq!(next_plan.data, 3);
 
+        assert!(!plan_queue.is_empty());
         let next_plan = plan_queue.get_next_plan().unwrap();
         assert_eq!(next_plan.time, 2.0);
         assert_eq!(next_plan.data, 2);
 
+        assert!(plan_queue.is_empty());
         assert!(plan_queue.get_next_plan().is_none());
     }
 
@@ -233,7 +252,10 @@ mod tests {
     fn cancel_invalid_plan() {
         let mut plan_queue = Queue::<()>::new();
         let plan_to_cancel = plan_queue.add_plan(1.0, ());
+        // is_empty just checks for a plan existing, not whether it is valid/has data
+        assert!(!plan_queue.is_empty());
         plan_queue.get_next_plan();
+        assert!(plan_queue.is_empty());
         plan_queue.cancel_plan(&plan_to_cancel);
     }
 }

--- a/src/random.rs
+++ b/src/random.rs
@@ -45,7 +45,8 @@ struct RngHolder {
     rng: Box<dyn Any>,
 }
 
-struct RngData {
+#[allow(clippy::module_name_repetitions)]
+pub struct RngData {
     base_seed: u64,
     rng_holders: RefCell<HashMap<TypeId, RngHolder>>,
 }

--- a/src/report.rs
+++ b/src/report.rs
@@ -72,7 +72,8 @@ macro_rules! create_report_trait {
     };
 }
 
-struct ReportData {
+#[allow(clippy::module_name_repetitions)]
+pub struct ReportData {
     file_writers: RefCell<HashMap<TypeId, Writer<File>>>,
     config: ConfigReportOptions,
 }

--- a/src/report.rs
+++ b/src/report.rs
@@ -132,26 +132,26 @@ impl Context {
             self.add_plan(self.get_current_time() + report_period, move |context| {
                 context.count_person_properties_and_report(report_period);
             });
-            let people_data = self.get_data_container(PeoplePlugin).unwrap();
-            let include_in_report = &people_data.include_in_periodic_report;
-            // iterate through the various properties that are in the report
-            // and call their tabulate method to get the counts of each property value
-            for property in include_in_report.values() {
-                // use a trait function to get the tabulation of values for the property
-                // in essence, this function grabs the property vector for this particular property
-                // and turns that into a vector of property values of the right type and then tabulates
-                let property_values_tabulated =
-                    property.get_tabulation(people_data.properties_map.borrow());
-                // iterate through the tabulated values and send a report item for each
-                for property_value in property_values_tabulated.keys() {
-                    // send a generic report item for each property value
-                    self.send_report(PeriodicReportItem {
-                        time: self.get_current_time(),
-                        property_type: property.to_string(),
-                        property_value: property_value.to_string(),
-                        count: *property_values_tabulated.get(property_value).unwrap(),
-                    });
-                }
+        }
+        let people_data = self.get_data_container(PeoplePlugin).unwrap();
+        let include_in_report = &people_data.include_in_periodic_report;
+        // iterate through the various properties that are in the report
+        // and call their tabulate method to get the counts of each property value
+        for property in include_in_report.values() {
+            // use a trait function to get the tabulation of values for the property
+            // in essence, this function grabs the property vector for this particular property
+            // and turns that into a vector of property values of the right type and then tabulates
+            let property_values_tabulated =
+                property.get_tabulation(people_data.properties_map.borrow());
+            // iterate through the tabulated values and send a report item for each
+            for property_value in property_values_tabulated.keys() {
+                // send a generic report item for each property value
+                self.send_report(PeriodicReportItem {
+                    time: self.get_current_time(),
+                    property_type: property.to_string(),
+                    property_value: property_value.to_string(),
+                    count: *property_values_tabulated.get(property_value).unwrap(),
+                });
             }
         }
     }

--- a/src/report.rs
+++ b/src/report.rs
@@ -136,7 +136,7 @@ impl Context {
             let include_in_report = &people_data.include_in_periodic_report;
             // iterate through the various properties that are in the report
             // and call their tabulate method to get the counts of each property value
-            for property in include_in_report {
+            for property in include_in_report.values() {
                 // use a trait function to get the tabulation of values for the property
                 // in essence, this function grabs the property vector for this particular property
                 // and turns that into a vector of property values of the right type and then tabulates

--- a/src/report.rs
+++ b/src/report.rs
@@ -148,8 +148,6 @@ impl Context {
                     .unwrap()
                     .downcast_ref()
                     .unwrap();
-                //let vec_of_values: RefCell<&mut Vec<Box<dyn Any>>> = RefCell::new(person_properties_map.get(property).unwrap()
-                //.downcast_mut().unwrap());
                 for value in vec_of_values {
                     *property_values_tabulated
                         .entry(format!("{value:?}"))

--- a/src/report.rs
+++ b/src/report.rs
@@ -4,6 +4,7 @@ use std::any::TypeId;
 use std::cell::RefCell;
 use std::collections::HashMap;
 use std::env;
+use std::fs;
 use std::fs::File;
 use std::path::PathBuf;
 
@@ -32,7 +33,11 @@ impl ConfigReportOptions {
         self
     }
     /// Sets the directory where reports will be output
+    /// # Panics
+    /// if the directory in which the report is to be stored does not exist and cannot be created
     pub fn directory(&mut self, directory: PathBuf) -> &mut ConfigReportOptions {
+        // if the directory does not exist, create it
+        fs::create_dir_all(directory.clone()).expect("Failed to create directory");
         self.directory = directory;
         self
     }


### PR DESCRIPTION
I started hacking around and got pretty close to building in easy user functionality for a periodic person properties report like GCM had. In this PR, I'm trying to put on more of my developer hat, so any feedback on how to improve the Rust code and structure is welcome. One of the features that I always wanted in GCM was a periodic report that listed people by cross combination of two person properties (number of people who are sick and under five, sick and over 65, etc.), so I implemented this as a necessary first step to adding that functionality.

However, this process raised a bunch of key questions for me about our `ixa` design so far, mainly on lazy property initialization.

### Design Sketch

1. When defining a person property, the user specifies whether they would like the property included in the report or not.
```rust
define_person_property!(IsRunner, bool, true); // true means to include in report
define_person_property_with_default!(RunningShoes, u8, false, 0); // third arg is whether in report
```
2. All person properties implement a trait `PersonPropertiesPeriodicReport` that provides a method that tabulates the number of occurrences of each of the observed property values.
3. The reports module has a method that allows people to add a person properties periodic report that reports out the properties tabulation every `report_period` amount of time. Properties that are included in the report are passed onto the reports module automatically, and the reports module iterates over them, calling their tabulation method and sending a report for each property value to the `person_properties_report.csv`.

### Implementation challenges
Challenges I describe here are also listed in the comments in the code, if it's easier to read inline.
1. At the current time, we have no `context.remove_person(person_id)` functionality, and it does not seem like we will add this functionality. This means that people we have set to be dead are still reported out on in the report. We could create add a new person property value to every property specific to dead people, or make every property an Option of what it already is and set dead people to be None, but neither of these feel like (a) good solutions (the first case sounds dangerous for f64 types and in the second case what if the type is already an Option?) or (b) user-friendly solutions. **Some sort of `context.person_teardown(person_id)` functionality would be really helpful.**
2. Each row in the report is associated with a time, but the interpretation of that time is not consistent. The report plan is added to the plan queue like any other plan, and there could be plans added after it at the same time as it. It is logical to make the row mean "the state of the world at _the end_ of the listed time", but to implement that **we need to have plans with priority.**
3. Lazy initialization for person properties means that the initialize method for a property isn't called until that property is first accessed. The initialize method also adds the property to the list of properties, so a person property isn't included in the report until it is first accessed. One way around this is by producing an "initialization" report as well, and then our accompanying Python analysis package for `ixa` can stitch together the two to make a true person properties periodic report.
    - Moreover, lazy initialization also includes automatic set expansion. So, if the property is only accessed for the first two of five people (i.e., people with Ids 0 and 1), only property values for the first two people will be listed, not even listing "None" for the remaining three. if the property is accessed for people 0 and 3, two values will be listed and two "None"s will be listed. I have a test that shows this counterintuitive behavior in `people.rs`.

I think I caught a bug on the data plugins macro. I believe the data plugins struct must be public so that data plugins are accessible beyond just the mod in which they are created. This is necessary for being able to share the person properties data plugin with the reports module and generally for user-defined data plugins. I can pull out those commits into a separate PR if this is a bug fix. However, to not give the user the entirety of the data container plugin in a way that they could mess with it, I've made the `properties_map` public only to the crate. I couldn't do the same for the `include_in_periodic_report` attribute, but I do not understand why.

### Next steps
1. GCM printed out person properties tabulations by region. With the argument that we just want to support a broad "partition" plugin for users, of which regions is one subclass, it is not clear to me where listing out number of people with each person property by some group fits in here -- perhaps the user can pick one of their one-to-one groups as a stratifier?
2. The code for counting number of people with each person property may be refactored as new `ixa` functionality comes online.
3. I realized that the implementation for the cross combination properties report I described is probably very different, instead with the user just providing the two particular properties they want cross tabulated as function inputs and does not require the `PersonPropertiesPeriodicReport` trait.

### Example of what the report looks like
![image](https://github.com/user-attachments/assets/fde2db81-e517-4aa1-9840-e92d8f880aa8)
