### PR TITLE
Does context have more plans left to evaluate?

### DIFF
--- a/src/plan.rs
+++ b/src/plan.rs
@@ -70,6 +70,11 @@ impl<T, P: Eq + PartialEq + Ord> Queue<T, P> {
         self.data_map.remove(&id.id).expect("Plan does not exist");
     }
 
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.queue.is_empty()
+    }
+
     /// Retrieve the earliest plan in the queue
     ///
     /// Returns the next plan if it exists or else `None` if the queue is empty
@@ -170,19 +175,23 @@ mod tests {
         plan_queue.add_plan(1.0, 1, ());
         plan_queue.add_plan(3.0, 3, ());
         plan_queue.add_plan(2.0, 2, ());
+        assert!(!plan_queue.is_empty());
 
         let next_plan = plan_queue.get_next_plan().unwrap();
         assert_eq!(next_plan.time, 1.0);
         assert_eq!(next_plan.data, 1);
 
+        assert!(!plan_queue.is_empty());
         let next_plan = plan_queue.get_next_plan().unwrap();
         assert_eq!(next_plan.time, 2.0);
         assert_eq!(next_plan.data, 2);
 
+        assert!(!plan_queue.is_empty());
         let next_plan = plan_queue.get_next_plan().unwrap();
         assert_eq!(next_plan.time, 3.0);
         assert_eq!(next_plan.data, 3);
 
+        assert!(plan_queue.is_empty());
         assert!(plan_queue.get_next_plan().is_none());
     }
 
@@ -191,15 +200,37 @@ mod tests {
         let mut plan_queue = Queue::new();
         plan_queue.add_plan(1.0, 1, ());
         plan_queue.add_plan(1.0, 2, ());
+        assert!(!plan_queue.is_empty());
 
         let next_plan = plan_queue.get_next_plan().unwrap();
         assert_eq!(next_plan.time, 1.0);
         assert_eq!(next_plan.data, 1);
 
+        assert!(!plan_queue.is_empty());
         let next_plan = plan_queue.get_next_plan().unwrap();
         assert_eq!(next_plan.time, 1.0);
         assert_eq!(next_plan.data, 2);
 
+        assert!(plan_queue.is_empty());
+        assert!(plan_queue.get_next_plan().is_none());
+    }
+
+    #[test]
+    fn add_plans_at_same_time_with_different_priority() {
+        let mut plan_queue = Queue::new();
+        plan_queue.add_plan(1.0, 1, 1);
+        plan_queue.add_plan(1.0, 2, 0);
+
+        assert!(!plan_queue.is_empty());
+        let next_plan = plan_queue.get_next_plan().unwrap();
+        assert_eq!(next_plan.time, 1.0);
+        assert_eq!(next_plan.data, 2);
+
+        let next_plan = plan_queue.get_next_plan().unwrap();
+        assert_eq!(next_plan.time, 1.0);
+        assert_eq!(next_plan.data, 1);
+
+        assert!(plan_queue.is_empty());
         assert!(plan_queue.get_next_plan().is_none());
     }
 
@@ -227,15 +258,18 @@ mod tests {
         let plan_to_cancel = plan_queue.add_plan(2.0, 2, ());
         plan_queue.add_plan(3.0, 3, ());
         plan_queue.cancel_plan(&plan_to_cancel);
+        assert!(!plan_queue.is_empty());
 
         let next_plan = plan_queue.get_next_plan().unwrap();
         assert_eq!(next_plan.time, 1.0);
         assert_eq!(next_plan.data, 1);
 
+        assert!(!plan_queue.is_empty());
         let next_plan = plan_queue.get_next_plan().unwrap();
         assert_eq!(next_plan.time, 3.0);
         assert_eq!(next_plan.data, 3);
 
+        assert!(plan_queue.is_empty());
         assert!(plan_queue.get_next_plan().is_none());
     }
 
@@ -244,6 +278,7 @@ mod tests {
         let mut plan_queue = Queue::new();
         plan_queue.add_plan(1.0, 1, ());
         plan_queue.add_plan(2.0, 2, ());
+        assert!(!plan_queue.is_empty());
 
         let next_plan = plan_queue.get_next_plan().unwrap();
         assert_eq!(next_plan.time, 1.0);
@@ -251,14 +286,17 @@ mod tests {
 
         plan_queue.add_plan(1.5, 3, ());
 
+        assert!(!plan_queue.is_empty());
         let next_plan = plan_queue.get_next_plan().unwrap();
         assert_eq!(next_plan.time, 1.5);
         assert_eq!(next_plan.data, 3);
 
+        assert!(!plan_queue.is_empty());
         let next_plan = plan_queue.get_next_plan().unwrap();
         assert_eq!(next_plan.time, 2.0);
         assert_eq!(next_plan.data, 2);
 
+        assert!(plan_queue.is_empty());
         assert!(plan_queue.get_next_plan().is_none());
     }
 
@@ -267,7 +305,10 @@ mod tests {
     fn cancel_invalid_plan() {
         let mut plan_queue = Queue::new();
         let plan_to_cancel = plan_queue.add_plan(1.0, (), ());
+        // is_empty just checks for a plan existing, not whether it is valid/has data
+        assert!(!plan_queue.is_empty());
         plan_queue.get_next_plan();
+        assert!(plan_queue.is_empty());
         plan_queue.cancel_plan(&plan_to_cancel);
     }
 }

--- a/src/plan.rs
+++ b/src/plan.rs
@@ -235,23 +235,6 @@ mod tests {
     }
 
     #[test]
-    fn add_plans_at_same_time_with_different_priority() {
-        let mut plan_queue = Queue::new();
-        plan_queue.add_plan(1.0, 1, 1);
-        plan_queue.add_plan(1.0, 2, 0);
-
-        let next_plan = plan_queue.get_next_plan().unwrap();
-        assert_eq!(next_plan.time, 1.0);
-        assert_eq!(next_plan.data, 2);
-
-        let next_plan = plan_queue.get_next_plan().unwrap();
-        assert_eq!(next_plan.time, 1.0);
-        assert_eq!(next_plan.data, 1);
-
-        assert!(plan_queue.get_next_plan().is_none());
-    }
-
-    #[test]
     fn add_and_cancel_plans() {
         let mut plan_queue = Queue::new();
         plan_queue.add_plan(1.0, 1, ());


### PR DESCRIPTION
This pull request introduces a new method to check if there are more plans to be evaluated and adds corresponding tests to ensure the new method's functionality. Essentially, a method is added to the `Queue` object to evaluate whether there are more plans sitting on the `BinaryHeap` that stores the sorted plans. This helper method is then called from `Context`'s realization of the queue object and returns whether there are more plans to be executed. Having two methods is necessary because we don't want to expose the `plan_queue` directly to the user, and the internal `BinaryHeap` in `Queue` is private to `plan.rs`.

These new methods take immutable references to `context`.