### PR TITLE
Change |get_global_property()| to return Option<&T::Value>. Fixes #72

### DIFF
--- a/examples/parameter-loading/incidence_report.rs
+++ b/examples/parameter-loading/incidence_report.rs
@@ -32,7 +32,10 @@ fn handle_infection_status_change(
 }
 
 pub fn init(context: &mut Context) {
-    let parameters = context.get_global_property_value(Parameters).clone();
+    let parameters = context
+        .get_global_property_value(Parameters)
+        .unwrap()
+        .clone();
     context
         .report_options()
         .directory(PathBuf::from(parameters.output_dir));

--- a/examples/parameter-loading/infection_manager.rs
+++ b/examples/parameter-loading/infection_manager.rs
@@ -12,7 +12,10 @@ use crate::Parameters;
 define_rng!(InfectionRng);
 
 fn schedule_recovery(context: &mut Context, person_id: PersonId) {
-    let parameters = context.get_global_property_value(Parameters).clone();
+    let parameters = context
+        .get_global_property_value(Parameters)
+        .unwrap()
+        .clone();
     let infection_duration = parameters.infection_duration;
     let recovery_time = context.get_current_time()
         + context.sample_distr(InfectionRng, Exp::new(1.0 / infection_duration).unwrap());

--- a/examples/parameter-loading/main.rs
+++ b/examples/parameter-loading/main.rs
@@ -31,7 +31,10 @@ fn main() {
 
     match parameters_loader::init_parameters(&mut context, &file_path) {
         Ok(()) => {
-            let parameters = context.get_global_property_value(Parameters).clone();
+            let parameters = context
+                .get_global_property_value(Parameters)
+                .unwrap()
+                .clone();
             context.init_random(parameters.seed);
 
             for _ in 0..parameters.population {

--- a/examples/parameter-loading/transmission_manager.rs
+++ b/examples/parameter-loading/transmission_manager.rs
@@ -17,7 +17,10 @@ fn attempt_infection(context: &mut Context) {
         context.get_person_id(context.sample_range(TransmissionRng, 0..population_size));
     let person_status: InfectionStatus =
         context.get_person_property(person_to_infect, InfectionStatusType);
-    let parameters = context.get_global_property_value(Parameters).clone();
+    let parameters = context
+        .get_global_property_value(Parameters)
+        .unwrap()
+        .clone();
 
     if matches!(person_status, InfectionStatus::S) {
         context.set_person_property(person_to_infect, InfectionStatusType, InfectionStatus::I);

--- a/examples/time-varying-infection/exposure_manager.rs
+++ b/examples/time-varying-infection/exposure_manager.rs
@@ -39,7 +39,7 @@ fn inverse_sampling_infection(context: &mut Context) -> f64 {
     let s: f64 = context.sample_distr(ExposureRng, Exp1);
     // get the time by following the formula described above
     // first need to get the simulation's sin_shift
-    let parameters = context.get_global_property_value(Parameters).clone();
+    let parameters = context.get_global_property_value(Parameters).unwrap().clone();
     let sin_shift = parameters.foi_sin_shift;
     let foi = parameters.foi;
     let f = func!(move |t| foi_t(t, foi, sin_shift));
@@ -91,7 +91,7 @@ mod test {
         };
         let mut context = Context::new();
         context.set_global_property_value(Parameters, p_values);
-        let parameters = context.get_global_property_value(Parameters).clone();
+        let parameters = context.get_global_property_value(Parameters).unwrap().clone();
         context.init_random(parameters.seed);
         init(&mut context);
         context.add_person();
@@ -124,7 +124,7 @@ mod test {
         };
         let mut context = Context::new();
         context.set_global_property_value(Parameters, p_values);
-        let parameters = context.get_global_property_value(Parameters).clone();
+        let parameters = context.get_global_property_value(Parameters).unwrap().clone();
         context.init_random(parameters.seed);
         // empirical mean
         let mut sum = 0.0;

--- a/examples/time-varying-infection/exposure_manager.rs
+++ b/examples/time-varying-infection/exposure_manager.rs
@@ -39,7 +39,10 @@ fn inverse_sampling_infection(context: &mut Context) -> f64 {
     let s: f64 = context.sample_distr(ExposureRng, Exp1);
     // get the time by following the formula described above
     // first need to get the simulation's sin_shift
-    let parameters = context.get_global_property_value(Parameters).unwrap().clone();
+    let parameters = context
+        .get_global_property_value(Parameters)
+        .unwrap()
+        .clone();
     let sin_shift = parameters.foi_sin_shift;
     let foi = parameters.foi;
     let f = func!(move |t| foi_t(t, foi, sin_shift));
@@ -91,7 +94,10 @@ mod test {
         };
         let mut context = Context::new();
         context.set_global_property_value(Parameters, p_values);
-        let parameters = context.get_global_property_value(Parameters).unwrap().clone();
+        let parameters = context
+            .get_global_property_value(Parameters)
+            .unwrap()
+            .clone();
         context.init_random(parameters.seed);
         init(&mut context);
         context.add_person();
@@ -124,7 +130,10 @@ mod test {
         };
         let mut context = Context::new();
         context.set_global_property_value(Parameters, p_values);
-        let parameters = context.get_global_property_value(Parameters).unwrap().clone();
+        let parameters = context
+            .get_global_property_value(Parameters)
+            .unwrap()
+            .clone();
         context.init_random(parameters.seed);
         // empirical mean
         let mut sum = 0.0;

--- a/examples/time-varying-infection/incidence_report.rs
+++ b/examples/time-varying-infection/incidence_report.rs
@@ -31,7 +31,7 @@ fn handle_infection_status_change(
 }
 
 pub fn init(context: &mut Context) {
-    let parameters = context.get_global_property_value(Parameters).clone();
+    let parameters = context.get_global_property_value(Parameters).unwrap().clone();
     context
         .report_options()
         .directory(PathBuf::from(parameters.output_dir));

--- a/examples/time-varying-infection/incidence_report.rs
+++ b/examples/time-varying-infection/incidence_report.rs
@@ -31,7 +31,10 @@ fn handle_infection_status_change(
 }
 
 pub fn init(context: &mut Context) {
-    let parameters = context.get_global_property_value(Parameters).unwrap().clone();
+    let parameters = context
+        .get_global_property_value(Parameters)
+        .unwrap()
+        .clone();
     context
         .report_options()
         .directory(PathBuf::from(parameters.output_dir));

--- a/examples/time-varying-infection/infection_manager.rs
+++ b/examples/time-varying-infection/infection_manager.rs
@@ -16,7 +16,7 @@ fn recovery_cdf(context: &mut Context, time_spent_infected: f64) -> f64 {
 }
 
 fn n_eff_inv_infec(context: &mut Context) -> f64 {
-    let parameters = context.get_global_property_value(Parameters).clone();
+    let parameters = context.get_global_property_value(Parameters).unwrap().clone();
     // get number of infected people
     let mut n_infected = 0;
     for usize_id in 0..context.get_current_population() {
@@ -61,7 +61,7 @@ fn handle_infection_status_change(
     context: &mut Context,
     event: PersonPropertyChangeEvent<DiseaseStatusType>,
 ) {
-    let parameters = context.get_global_property_value(Parameters).clone();
+    let parameters = context.get_global_property_value(Parameters).unwrap().clone();
     if matches!(event.current, DiseaseStatus::I) {
         // recall resampling rate is sum of maximum foi rate and gamma
         // maximum foi rate is foi * 2 -- the 2 because foi is sin(t + c) + 1
@@ -112,7 +112,7 @@ mod test {
         let mut context = Context::new();
 
         context.set_global_property_value(Parameters, p_values);
-        let parameters = context.get_global_property_value(Parameters).clone();
+        let parameters = context.get_global_property_value(Parameters).unwrap().clone();
         context.init_random(parameters.seed);
         init(&mut context);
 

--- a/examples/time-varying-infection/infection_manager.rs
+++ b/examples/time-varying-infection/infection_manager.rs
@@ -16,7 +16,10 @@ fn recovery_cdf(context: &mut Context, time_spent_infected: f64) -> f64 {
 }
 
 fn n_eff_inv_infec(context: &mut Context) -> f64 {
-    let parameters = context.get_global_property_value(Parameters).unwrap().clone();
+    let parameters = context
+        .get_global_property_value(Parameters)
+        .unwrap()
+        .clone();
     // get number of infected people
     let mut n_infected = 0;
     for usize_id in 0..context.get_current_population() {
@@ -61,7 +64,10 @@ fn handle_infection_status_change(
     context: &mut Context,
     event: PersonPropertyChangeEvent<DiseaseStatusType>,
 ) {
-    let parameters = context.get_global_property_value(Parameters).unwrap().clone();
+    let parameters = context
+        .get_global_property_value(Parameters)
+        .unwrap()
+        .clone();
     if matches!(event.current, DiseaseStatus::I) {
         // recall resampling rate is sum of maximum foi rate and gamma
         // maximum foi rate is foi * 2 -- the 2 because foi is sin(t + c) + 1
@@ -112,7 +118,10 @@ mod test {
         let mut context = Context::new();
 
         context.set_global_property_value(Parameters, p_values);
-        let parameters = context.get_global_property_value(Parameters).unwrap().clone();
+        let parameters = context
+            .get_global_property_value(Parameters)
+            .unwrap()
+            .clone();
         context.init_random(parameters.seed);
         init(&mut context);
 

--- a/examples/time-varying-infection/main.rs
+++ b/examples/time-varying-infection/main.rs
@@ -20,7 +20,7 @@ fn main() {
 
     match parameters_loader::init_parameters(&mut context, &file_path) {
         Ok(()) => {
-            let parameters = context.get_global_property_value(Parameters).clone();
+            let parameters = context.get_global_property_value(Parameters).unwrap().clone();
             context.init_random(parameters.seed);
 
             exposure_manager::init(&mut context);

--- a/examples/time-varying-infection/main.rs
+++ b/examples/time-varying-infection/main.rs
@@ -20,7 +20,10 @@ fn main() {
 
     match parameters_loader::init_parameters(&mut context, &file_path) {
         Ok(()) => {
-            let parameters = context.get_global_property_value(Parameters).unwrap().clone();
+            let parameters = context
+                .get_global_property_value(Parameters)
+                .unwrap()
+                .clone();
             context.init_random(parameters.seed);
 
             exposure_manager::init(&mut context);

--- a/examples/time-varying-infection/periodic_report.rs
+++ b/examples/time-varying-infection/periodic_report.rs
@@ -50,7 +50,7 @@ fn count_people_and_send_report(context: &mut Context, report_period: f64) {
 }
 
 pub fn init(context: &mut Context) {
-    let parameters = context.get_global_property_value(Parameters).clone();
+    let parameters = context.get_global_property_value(Parameters).unwrap().clone();
     context
         .report_options()
         .directory(PathBuf::from(parameters.output_dir));

--- a/examples/time-varying-infection/periodic_report.rs
+++ b/examples/time-varying-infection/periodic_report.rs
@@ -50,7 +50,10 @@ fn count_people_and_send_report(context: &mut Context, report_period: f64) {
 }
 
 pub fn init(context: &mut Context) {
-    let parameters = context.get_global_property_value(Parameters).unwrap().clone();
+    let parameters = context
+        .get_global_property_value(Parameters)
+        .unwrap()
+        .clone();
     context
         .report_options()
         .directory(PathBuf::from(parameters.output_dir));

--- a/examples/time-varying-infection/population_loader.rs
+++ b/examples/time-varying-infection/population_loader.rs
@@ -18,7 +18,10 @@ define_person_property_with_default!(DiseaseStatusType, DiseaseStatus, DiseaseSt
 define_person_property!(InfectionTime, f64);
 
 pub fn init(context: &mut Context) {
-    let parameters = context.get_global_property_value(Parameters).unwrap().clone();
+    let parameters = context
+        .get_global_property_value(Parameters)
+        .unwrap()
+        .clone();
     for _ in 0..parameters.population {
         context.add_person();
     }
@@ -51,7 +54,10 @@ mod tests {
         };
         let mut context = Context::new();
         context.set_global_property_value(Parameters, p_values);
-        let parameters = context.get_global_property_value(Parameters).unwrap().clone();
+        let parameters = context
+            .get_global_property_value(Parameters)
+            .unwrap()
+            .clone();
         context.init_random(parameters.seed);
         init(&mut context);
 

--- a/examples/time-varying-infection/population_loader.rs
+++ b/examples/time-varying-infection/population_loader.rs
@@ -18,7 +18,7 @@ define_person_property_with_default!(DiseaseStatusType, DiseaseStatus, DiseaseSt
 define_person_property!(InfectionTime, f64);
 
 pub fn init(context: &mut Context) {
-    let parameters = context.get_global_property_value(Parameters).clone();
+    let parameters = context.get_global_property_value(Parameters).unwrap().clone();
     for _ in 0..parameters.population {
         context.add_person();
     }
@@ -51,7 +51,7 @@ mod tests {
         };
         let mut context = Context::new();
         context.set_global_property_value(Parameters, p_values);
-        let parameters = context.get_global_property_value(Parameters).clone();
+        let parameters = context.get_global_property_value(Parameters).unwrap().clone();
         context.init_random(parameters.seed);
         init(&mut context);
 


### PR DESCRIPTION
Returns None when either:

- No global properties have been set
- Global properties exist but the requested property has not been set.