### PR TITLE
Initialize properties in add_person

### DIFF
--- a/examples/births-deaths/population_manager.rs
+++ b/examples/births-deaths/population_manager.rs
@@ -151,9 +151,7 @@ impl ContextPopulationExt for Context {
     }
 
     fn create_new_person(&mut self, age: u8) -> PersonId {
-        let person = self.add_person();
-        self.initialize_person_property(person, Age, age);
-        person
+        self.add_person((Age, age)).unwrap()
     }
 
     fn get_current_group_population(&mut self, age_group: AgeGroupRisk) -> usize {

--- a/examples/load-people/population_loader.rs
+++ b/examples/load-people/population_loader.rs
@@ -22,16 +22,15 @@ define_person_property!(Age, u8);
 define_person_property!(RiskCategoryType, RiskCategory);
 
 fn create_person_from_record(context: &mut Context, record: &PeopleRecord) -> PersonId {
-    let person = context.add_person();
-    context.initialize_person_property(person, Age, record.age);
-    context.initialize_person_property(person, RiskCategoryType, record.risk_category);
-
-    // Set vaccine type and efficacy based on risk category
     let (t, e) = context.get_vaccine_props(record.risk_category);
-    context.initialize_person_property(person, VaccineType, t);
-    context.initialize_person_property(person, VaccineEfficacy, e);
-
-    person
+    context
+        .add_person((
+            (Age, record.age),
+            (RiskCategoryType, record.risk_category),
+            (VaccineType, t),
+            (VaccineEfficacy, e),
+        ))
+        .unwrap()
 }
 
 pub fn init(context: &mut Context) {

--- a/examples/load-people/sir.rs
+++ b/examples/load-people/sir.rs
@@ -35,7 +35,7 @@ mod tests {
         let mut context = Context::new();
         init(&mut context);
 
-        let person = context.add_person();
+        let person = context.add_person(()).unwrap();
 
         // People should start in the S state
         assert_eq!(

--- a/examples/parameter-loading/infection_manager.rs
+++ b/examples/parameter-loading/infection_manager.rs
@@ -80,7 +80,7 @@ mod test {
 
         let population_size: usize = 10;
         for _ in 0..population_size {
-            let person = context.add_person();
+            let person = context.add_person(()).unwrap();
 
             context.add_plan(1.0, move |context| {
                 context.set_person_property(person, InfectionStatusType, InfectionStatus::I);

--- a/examples/parameter-loading/main.rs
+++ b/examples/parameter-loading/main.rs
@@ -38,7 +38,7 @@ fn main() {
             context.init_random(parameters.seed);
 
             for _ in 0..parameters.population {
-                context.add_person();
+                context.add_person(()).unwrap();
             }
 
             transmission_manager::init(&mut context);

--- a/examples/parameter-loading/transmission_manager.rs
+++ b/examples/parameter-loading/transmission_manager.rs
@@ -72,7 +72,7 @@ mod test {
         let mut context = Context::new();
         context.set_global_property_value(Parameters, p_values);
         context.init_random(123);
-        let pid = context.add_person();
+        let pid = context.add_person(()).unwrap();
         attempt_infection(&mut context);
         let person_status = context.get_person_property(pid, InfectionStatusType);
         assert_eq!(person_status, InfectionStatus::I);

--- a/examples/time-varying-infection/exposure_manager.rs
+++ b/examples/time-varying-infection/exposure_manager.rs
@@ -26,7 +26,7 @@ fn expose_person_to_deviled_eggs(context: &mut Context, person_created_event: Pe
         context.set_person_property(person_id, DiseaseStatusType, DiseaseStatus::I);
         // for reasons that will become apparent with the recovery rate example,
         // we also need to record the time at which a person becomes infected
-        context.initialize_person_property(person_id, InfectionTime, Some(OrderedFloat(t)));
+        context.set_person_property(person_id, InfectionTime, Some(OrderedFloat(t)));
     });
 }
 

--- a/examples/time-varying-infection/exposure_manager.rs
+++ b/examples/time-varying-infection/exposure_manager.rs
@@ -26,7 +26,7 @@ fn expose_person_to_deviled_eggs(context: &mut Context, person_created_event: Pe
         context.set_person_property(person_id, DiseaseStatusType, DiseaseStatus::I);
         // for reasons that will become apparent with the recovery rate example,
         // we also need to record the time at which a person becomes infected
-        context.initialize_person_property(person_id, InfectionTime, OrderedFloat(t));
+        context.initialize_person_property(person_id, InfectionTime, Some(OrderedFloat(t)));
     });
 }
 
@@ -101,12 +101,14 @@ mod test {
             .clone();
         context.init_random(parameters.seed);
         init(&mut context);
-        context.add_person();
+        context.add_person(()).unwrap();
         context.execute();
         let person_status =
             context.get_person_property(context.get_person_id(0), DiseaseStatusType);
         assert_eq!(person_status, DiseaseStatus::I);
-        let infection_time = context.get_person_property(context.get_person_id(0), InfectionTime);
+        let infection_time = context
+            .get_person_property(context.get_person_id(0), InfectionTime)
+            .unwrap();
         assert_eq!(infection_time, context.get_current_time());
     }
 

--- a/examples/time-varying-infection/infection_manager.rs
+++ b/examples/time-varying-infection/infection_manager.rs
@@ -39,15 +39,10 @@ fn evaluate_recovery(
     resampling_rate: f64,
 ) -> Option<f64> {
     // get time person has spent infected
-<<<<<<< HEAD
-    let time_spent_infected =
-        context.get_current_time() - *context.get_person_property(person_id, InfectionTime);
-=======
     let time_spent_infected = context.get_current_time()
-        - context
+        - *context
             .get_person_property(person_id, InfectionTime)
             .unwrap();
->>>>>>> e03806c (Checkpoint)
     // evaluate whether recovery has happened by this time or not
     let recovery_probability = recovery_cdf(context, time_spent_infected);
     if context.sample_bool(InfectionRng, recovery_probability) {
@@ -133,24 +128,9 @@ mod test {
         context.init_random(parameters.seed);
         init(&mut context);
 
-<<<<<<< HEAD
-        for id in 0..parameters.population {
-            context.add_person();
-            context.set_person_property(
-                context.get_person_id(id),
-                DiseaseStatusType,
-                DiseaseStatus::I,
-            );
-            context.initialize_person_property(
-                context.get_person_id(id),
-                InfectionTime,
-                OrderedFloat(0.0),
-            );
-=======
         for _ in 0..parameters.population {
             let person_id = context.add_person((InfectionTime, Some(0.0))).unwrap();
             context.set_person_property(person_id, DiseaseStatusType, DiseaseStatus::I);
->>>>>>> e03806c (Checkpoint)
         }
 
         // put this subscription after every agent has become infected
@@ -232,12 +212,7 @@ mod test {
             context.set_global_property_value(Parameters, parameters.clone());
             context.init_random(seed);
             init(&mut context);
-<<<<<<< HEAD
-            let person_id = context.add_person();
-            context.initialize_person_property(person_id, InfectionTime, OrderedFloat(0.0));
-=======
             let person_id = context.add_person((InfectionTime, Some(0.0))).unwrap();
->>>>>>> e03806c (Checkpoint)
             context.set_person_property(person_id, DiseaseStatusType, DiseaseStatus::I);
             // there should only be one infected person in the simulation
             assert_eq!(

--- a/examples/time-varying-infection/infection_manager.rs
+++ b/examples/time-varying-infection/infection_manager.rs
@@ -129,7 +129,7 @@ mod test {
         init(&mut context);
 
         for _ in 0..parameters.population {
-            let person_id = context.add_person((InfectionTime, Some(0.0))).unwrap();
+            let person_id = context.add_person((InfectionTime, Some(OrderedFloat(0.0)))).unwrap();
             context.set_person_property(person_id, DiseaseStatusType, DiseaseStatus::I);
         }
 
@@ -212,7 +212,7 @@ mod test {
             context.set_global_property_value(Parameters, parameters.clone());
             context.init_random(seed);
             init(&mut context);
-            let person_id = context.add_person((InfectionTime, Some(0.0))).unwrap();
+            let person_id = context.add_person((InfectionTime, Some(OrderedFloat(0.0)))).unwrap();
             context.set_person_property(person_id, DiseaseStatusType, DiseaseStatus::I);
             // there should only be one infected person in the simulation
             assert_eq!(

--- a/examples/time-varying-infection/infection_manager.rs
+++ b/examples/time-varying-infection/infection_manager.rs
@@ -39,8 +39,15 @@ fn evaluate_recovery(
     resampling_rate: f64,
 ) -> Option<f64> {
     // get time person has spent infected
+<<<<<<< HEAD
     let time_spent_infected =
         context.get_current_time() - *context.get_person_property(person_id, InfectionTime);
+=======
+    let time_spent_infected = context.get_current_time()
+        - context
+            .get_person_property(person_id, InfectionTime)
+            .unwrap();
+>>>>>>> e03806c (Checkpoint)
     // evaluate whether recovery has happened by this time or not
     let recovery_probability = recovery_cdf(context, time_spent_infected);
     if context.sample_bool(InfectionRng, recovery_probability) {
@@ -126,6 +133,7 @@ mod test {
         context.init_random(parameters.seed);
         init(&mut context);
 
+<<<<<<< HEAD
         for id in 0..parameters.population {
             context.add_person();
             context.set_person_property(
@@ -138,6 +146,11 @@ mod test {
                 InfectionTime,
                 OrderedFloat(0.0),
             );
+=======
+        for _ in 0..parameters.population {
+            let person_id = context.add_person((InfectionTime, Some(0.0))).unwrap();
+            context.set_person_property(person_id, DiseaseStatusType, DiseaseStatus::I);
+>>>>>>> e03806c (Checkpoint)
         }
 
         // put this subscription after every agent has become infected
@@ -169,7 +182,7 @@ mod test {
         context.set_global_property_value(Parameters, parameters.clone());
         context.init_random(parameters.seed);
         for _ in 0..parameters.population {
-            let person_id = context.add_person();
+            let person_id = context.add_person(()).unwrap();
             context.set_person_property(person_id, DiseaseStatusType, DiseaseStatus::I);
         }
         assert_eq!(
@@ -219,8 +232,12 @@ mod test {
             context.set_global_property_value(Parameters, parameters.clone());
             context.init_random(seed);
             init(&mut context);
+<<<<<<< HEAD
             let person_id = context.add_person();
             context.initialize_person_property(person_id, InfectionTime, OrderedFloat(0.0));
+=======
+            let person_id = context.add_person((InfectionTime, Some(0.0))).unwrap();
+>>>>>>> e03806c (Checkpoint)
             context.set_person_property(person_id, DiseaseStatusType, DiseaseStatus::I);
             // there should only be one infected person in the simulation
             assert_eq!(

--- a/examples/time-varying-infection/infection_manager.rs
+++ b/examples/time-varying-infection/infection_manager.rs
@@ -129,7 +129,9 @@ mod test {
         init(&mut context);
 
         for _ in 0..parameters.population {
-            let person_id = context.add_person((InfectionTime, Some(OrderedFloat(0.0)))).unwrap();
+            let person_id = context
+                .add_person((InfectionTime, Some(OrderedFloat(0.0))))
+                .unwrap();
             context.set_person_property(person_id, DiseaseStatusType, DiseaseStatus::I);
         }
 
@@ -212,7 +214,9 @@ mod test {
             context.set_global_property_value(Parameters, parameters.clone());
             context.init_random(seed);
             init(&mut context);
-            let person_id = context.add_person((InfectionTime, Some(OrderedFloat(0.0)))).unwrap();
+            let person_id = context
+                .add_person((InfectionTime, Some(OrderedFloat(0.0))))
+                .unwrap();
             context.set_person_property(person_id, DiseaseStatusType, DiseaseStatus::I);
             // there should only be one infected person in the simulation
             assert_eq!(

--- a/examples/time-varying-infection/population_loader.rs
+++ b/examples/time-varying-infection/population_loader.rs
@@ -16,7 +16,7 @@ pub enum DiseaseStatus {
 }
 
 define_person_property_with_default!(DiseaseStatusType, DiseaseStatus, DiseaseStatus::S);
-define_person_property!(InfectionTime, OrderedFloat<f64>);
+define_person_property_with_default!(InfectionTime, Option<OrderedFloat<f64>>, None);
 
 pub fn init(context: &mut Context) {
     let parameters = context
@@ -24,50 +24,6 @@ pub fn init(context: &mut Context) {
         .unwrap()
         .clone();
     for _ in 0..parameters.population {
-        context.add_person();
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    use ixa::context::Context;
-    use ixa::global_properties::ContextGlobalPropertiesExt;
-    use ixa::people::ContextPeopleExt;
-    use ixa::random::ContextRandomExt;
-
-    use crate::parameters_loader::ParametersValues;
-
-    #[test]
-    #[should_panic(expected = "Property not initialized")]
-    fn test_person_creation_default_properties() {
-        let p_values = ParametersValues {
-            population: 1,
-            max_time: 10.0,
-            seed: 42,
-            foi: 0.15,
-            foi_sin_shift: 3.0,
-            infection_duration: 5.0,
-            report_period: 1.0,
-            output_dir: ".".to_string(),
-            output_file: ".".to_string(),
-        };
-        let mut context = Context::new();
-        context.set_global_property_value(Parameters, p_values);
-        let parameters = context
-            .get_global_property_value(Parameters)
-            .unwrap()
-            .clone();
-        context.init_random(parameters.seed);
-        init(&mut context);
-
-        let population_size = context.get_current_population();
-        assert_eq!(population_size, parameters.population);
-        for i in 0..population_size {
-            let status = context.get_person_property(context.get_person_id(i), DiseaseStatusType);
-            assert_eq!(status, DiseaseStatus::S);
-            context.get_person_property(context.get_person_id(i), InfectionTime);
-        }
+        context.add_person(()).unwrap();
     }
 }

--- a/src/people.rs
+++ b/src/people.rs
@@ -774,19 +774,19 @@ impl ContextPeopleExt for Context {
         let (previous_value, deps_temp) = if initializing {
             (None, None)
         } else {
-
             let previous_value = self.get_person_property(person_id, property);
             if previous_value != value {
-                    self.remove_from_index_maybe(person_id, property);
+                self.remove_from_index_maybe(person_id, property);
             }
-            
-            ( Some(previous_value),
-              self.get_data_container(PeoplePlugin)
-              .unwrap()
-              .dependency_map
-              .borrow_mut()
-              .get_mut(&TypeId::of::<T>())
-              .map(std::mem::take),
+
+            (
+                Some(previous_value),
+                self.get_data_container(PeoplePlugin)
+                    .unwrap()
+                    .dependency_map
+                    .borrow_mut()
+                    .get_mut(&TypeId::of::<T>())
+                    .map(std::mem::take),
             )
         };
 
@@ -808,12 +808,11 @@ impl ContextPeopleExt for Context {
         let data_container = self.get_data_container(PeoplePlugin).unwrap();
         data_container.set_person_property(person_id, property, value);
 
-
         if !initializing {
             if previous_value.unwrap() != value {
                 self.add_to_index_maybe(person_id, property);
             }
-            
+
             let change_event: PersonPropertyChangeEvent<T> = PersonPropertyChangeEvent {
                 person_id,
                 current: value,
@@ -1021,8 +1020,8 @@ mod test {
     use super::{ContextPeopleExt, PersonCreatedEvent, PersonId, PersonPropertyChangeEvent};
     use crate::{
         context::Context,
-        people::{Index, IndexValue, PeoplePlugin, PersonPropertyHolder},
         error::IxaError,
+        people::{Index, IndexValue, PeoplePlugin, PersonPropertyHolder},
     };
     use std::{any::TypeId, cell::RefCell, rc::Rc};
 
@@ -1432,7 +1431,9 @@ mod test {
     #[test]
     fn query_people() {
         let mut context = Context::new();
-        let _ = context.add_person((RiskCategoryType, RiskCategory::High)).unwrap();
+        let _ = context
+            .add_person((RiskCategoryType, RiskCategory::High))
+            .unwrap();
 
         let people = context.query_people((RiskCategoryType, RiskCategory::High));
         assert_eq!(people.len(), 1);
@@ -1449,7 +1450,9 @@ mod test {
     #[test]
     fn query_people_macro_index_first() {
         let mut context = Context::new();
-        let _ = context.add_person((RiskCategoryType, RiskCategory::High)).unwrap();
+        let _ = context
+            .add_person((RiskCategoryType, RiskCategory::High))
+            .unwrap();
         context.index_property(RiskCategoryType);
         assert!(property_is_indexed::<RiskCategoryType>(&context));
         let people = context.query_people((RiskCategoryType, RiskCategory::High));
@@ -1482,7 +1485,9 @@ mod test {
     #[test]
     fn query_people_macro_change() {
         let mut context = Context::new();
-        let person1 = context.add_person((RiskCategoryType, RiskCategory::High)).unwrap();
+        let person1 = context
+            .add_person((RiskCategoryType, RiskCategory::High))
+            .unwrap();
 
         let people = context.query_people((RiskCategoryType, RiskCategory::High));
         assert_eq!(people.len(), 1);
@@ -1499,7 +1504,9 @@ mod test {
     #[test]
     fn query_people_index_after_add() {
         let mut context = Context::new();
-        let _ = context.add_person((RiskCategoryType, RiskCategory::High)).unwrap();
+        let _ = context
+            .add_person((RiskCategoryType, RiskCategory::High))
+            .unwrap();
         context.index_property(RiskCategoryType);
         assert!(property_is_indexed::<RiskCategoryType>(&context));
         let people = context.query_people((RiskCategoryType, RiskCategory::High));
@@ -1509,13 +1516,17 @@ mod test {
     #[test]
     fn query_people_add_after_index() {
         let mut context = Context::new();
-        let _ = context.add_person((RiskCategoryType, RiskCategory::High)).unwrap();
+        let _ = context
+            .add_person((RiskCategoryType, RiskCategory::High))
+            .unwrap();
         context.index_property(RiskCategoryType);
         assert!(property_is_indexed::<RiskCategoryType>(&context));
         let people = context.query_people((RiskCategoryType, RiskCategory::High));
         assert_eq!(people.len(), 1);
 
-        let _ = context.add_person((RiskCategoryType, RiskCategory::High)).unwrap();
+        let _ = context
+            .add_person((RiskCategoryType, RiskCategory::High))
+            .unwrap();
         let people = context.query_people((RiskCategoryType, RiskCategory::High));
         assert_eq!(people.len(), 2);
     }
@@ -1551,9 +1562,15 @@ mod test {
     #[test]
     fn query_people_intersection() {
         let mut context = Context::new();
-        let _ = context.add_person(((Age, 42), (RiskCategoryType, RiskCategory::High))).unwrap();
-        let _ = context.add_person(((Age, 42), (RiskCategoryType, RiskCategory::Low))).unwrap();
-        let _ = context.add_person(((Age, 40), (RiskCategoryType, RiskCategory::Low))).unwrap();        
+        let _ = context
+            .add_person(((Age, 42), (RiskCategoryType, RiskCategory::High)))
+            .unwrap();
+        let _ = context
+            .add_person(((Age, 42), (RiskCategoryType, RiskCategory::Low)))
+            .unwrap();
+        let _ = context
+            .add_person(((Age, 40), (RiskCategoryType, RiskCategory::Low)))
+            .unwrap();
 
         let people = context.query_people(((Age, 42), (RiskCategoryType, RiskCategory::High)));
         assert_eq!(people.len(), 1);
@@ -1562,9 +1579,15 @@ mod test {
     #[test]
     fn query_people_intersection_non_macro() {
         let mut context = Context::new();
-        let _ = context.add_person(((Age, 42), (RiskCategoryType, RiskCategory::High))).unwrap();
-        let _ = context.add_person(((Age, 42), (RiskCategoryType, RiskCategory::Low))).unwrap();
-        let _ = context.add_person(((Age, 40), (RiskCategoryType, RiskCategory::Low))).unwrap();
+        let _ = context
+            .add_person(((Age, 42), (RiskCategoryType, RiskCategory::High)))
+            .unwrap();
+        let _ = context
+            .add_person(((Age, 42), (RiskCategoryType, RiskCategory::Low)))
+            .unwrap();
+        let _ = context
+            .add_person(((Age, 40), (RiskCategoryType, RiskCategory::Low)))
+            .unwrap();
 
         let people = context.query_people(((Age, 42), (RiskCategoryType, RiskCategory::High)));
         assert_eq!(people.len(), 1);
@@ -1573,10 +1596,15 @@ mod test {
     #[test]
     fn query_people_intersection_one_indexed() {
         let mut context = Context::new();
-        let _ = context.add_person(((Age, 42), (RiskCategoryType, RiskCategory::High))).unwrap();
-        let _ = context.add_person(((Age, 42), (RiskCategoryType, RiskCategory::Low))).unwrap();
-        let _ = context.add_person(((Age, 40), (RiskCategoryType, RiskCategory::Low))).unwrap();
-
+        let _ = context
+            .add_person(((Age, 42), (RiskCategoryType, RiskCategory::High)))
+            .unwrap();
+        let _ = context
+            .add_person(((Age, 42), (RiskCategoryType, RiskCategory::Low)))
+            .unwrap();
+        let _ = context
+            .add_person(((Age, 40), (RiskCategoryType, RiskCategory::Low)))
+            .unwrap();
 
         context.index_property(Age);
         let people = context.query_people(((Age, 42), (RiskCategoryType, RiskCategory::High)));

--- a/src/people.rs
+++ b/src/people.rs
@@ -1432,9 +1432,7 @@ mod test {
     #[test]
     fn query_people() {
         let mut context = Context::new();
-        let person1 = context.add_person();
-
-        context.initialize_person_property(person1, RiskCategoryType, RiskCategory::High);
+        let _ = context.add_person((RiskCategoryType, RiskCategory::High)).unwrap();
 
         let people = context.query_people((RiskCategoryType, RiskCategory::High));
         assert_eq!(people.len(), 1);
@@ -1451,9 +1449,7 @@ mod test {
     #[test]
     fn query_people_macro_index_first() {
         let mut context = Context::new();
-        let person1 = context.add_person();
-
-        context.initialize_person_property(person1, RiskCategoryType, RiskCategory::High);
+        let _ = context.add_person((RiskCategoryType, RiskCategory::High)).unwrap();
         context.index_property(RiskCategoryType);
         assert!(property_is_indexed::<RiskCategoryType>(&context));
         let people = context.query_people((RiskCategoryType, RiskCategory::High));
@@ -1473,9 +1469,7 @@ mod test {
     #[test]
     fn query_people_macro_index_second() {
         let mut context = Context::new();
-        let person1 = context.add_person();
-
-        context.initialize_person_property(person1, RiskCategoryType, RiskCategory::High);
+        let _ = context.add_person((RiskCategoryType, RiskCategory::High));
         let people = context.query_people((RiskCategoryType, RiskCategory::High));
         assert!(!property_is_indexed::<RiskCategoryType>(&context));
         assert_eq!(people.len(), 1);
@@ -1488,9 +1482,7 @@ mod test {
     #[test]
     fn query_people_macro_change() {
         let mut context = Context::new();
-        let person1 = context.add_person();
-
-        context.initialize_person_property(person1, RiskCategoryType, RiskCategory::High);
+        let person1 = context.add_person((RiskCategoryType, RiskCategory::High)).unwrap();
 
         let people = context.query_people((RiskCategoryType, RiskCategory::High));
         assert_eq!(people.len(), 1);
@@ -1507,8 +1499,7 @@ mod test {
     #[test]
     fn query_people_index_after_add() {
         let mut context = Context::new();
-        let person1 = context.add_person();
-        context.initialize_person_property(person1, RiskCategoryType, RiskCategory::High);
+        let _ = context.add_person((RiskCategoryType, RiskCategory::High)).unwrap();
         context.index_property(RiskCategoryType);
         assert!(property_is_indexed::<RiskCategoryType>(&context));
         let people = context.query_people((RiskCategoryType, RiskCategory::High));
@@ -1518,15 +1509,13 @@ mod test {
     #[test]
     fn query_people_add_after_index() {
         let mut context = Context::new();
-        let person = context.add_person();
-        context.initialize_person_property(person, RiskCategoryType, RiskCategory::High);
+        let _ = context.add_person((RiskCategoryType, RiskCategory::High)).unwrap();
         context.index_property(RiskCategoryType);
         assert!(property_is_indexed::<RiskCategoryType>(&context));
         let people = context.query_people((RiskCategoryType, RiskCategory::High));
         assert_eq!(people.len(), 1);
 
-        let person = context.add_person();
-        context.initialize_person_property(person, RiskCategoryType, RiskCategory::High);
+        let _ = context.add_person((RiskCategoryType, RiskCategory::High)).unwrap();
         let people = context.query_people((RiskCategoryType, RiskCategory::High));
         assert_eq!(people.len(), 2);
     }
@@ -1535,7 +1524,7 @@ mod test {
     // This is safe because we reindex only when someone queries.
     fn query_people_add_after_index_without_query() {
         let mut context = Context::new();
-        context.add_person();
+        let _ = context.add_person(()).unwrap();
         context.index_property(RiskCategoryType);
     }
 
@@ -1544,7 +1533,7 @@ mod test {
     // This will panic when we query.
     fn query_people_add_after_index_panic() {
         let mut context = Context::new();
-        context.add_person();
+        context.add_person(()).unwrap();
         context.index_property(RiskCategoryType);
         context.query_people((RiskCategoryType, RiskCategory::High));
     }
@@ -1552,9 +1541,7 @@ mod test {
     #[test]
     fn query_people_cast_value() {
         let mut context = Context::new();
-        let person = context.add_person();
-
-        context.initialize_person_property(person, Age, 42);
+        let _ = context.add_person((Age, 42)).unwrap();
 
         // Age is a u8, by default integer literals are i32; the macro should cast it.
         let people = context.query_people((Age, 42));
@@ -1564,18 +1551,9 @@ mod test {
     #[test]
     fn query_people_intersection() {
         let mut context = Context::new();
-        let person1 = context.add_person();
-        let person2 = context.add_person();
-        let person3 = context.add_person();
-
-        // Note: because of the way indexes are initialized, all properties without initializers need to be
-        // set for all people.
-        context.initialize_person_property(person1, Age, 42);
-        context.initialize_person_property(person1, RiskCategoryType, RiskCategory::High);
-        context.initialize_person_property(person2, Age, 42);
-        context.initialize_person_property(person2, RiskCategoryType, RiskCategory::Low);
-        context.initialize_person_property(person3, Age, 40);
-        context.initialize_person_property(person3, RiskCategoryType, RiskCategory::Low);
+        let _ = context.add_person(((Age, 42), (RiskCategoryType, RiskCategory::High))).unwrap();
+        let _ = context.add_person(((Age, 42), (RiskCategoryType, RiskCategory::Low))).unwrap();
+        let _ = context.add_person(((Age, 40), (RiskCategoryType, RiskCategory::Low))).unwrap();        
 
         let people = context.query_people(((Age, 42), (RiskCategoryType, RiskCategory::High)));
         assert_eq!(people.len(), 1);
@@ -1584,18 +1562,9 @@ mod test {
     #[test]
     fn query_people_intersection_non_macro() {
         let mut context = Context::new();
-        let person1 = context.add_person();
-        let person2 = context.add_person();
-        let person3 = context.add_person();
-
-        // Note: because of the way indexes are initialized, all properties without initializers need to be
-        // set for all people.
-        context.initialize_person_property(person1, Age, 42);
-        context.initialize_person_property(person1, RiskCategoryType, RiskCategory::High);
-        context.initialize_person_property(person2, Age, 42);
-        context.initialize_person_property(person2, RiskCategoryType, RiskCategory::Low);
-        context.initialize_person_property(person3, Age, 40);
-        context.initialize_person_property(person3, RiskCategoryType, RiskCategory::Low);
+        let _ = context.add_person(((Age, 42), (RiskCategoryType, RiskCategory::High))).unwrap();
+        let _ = context.add_person(((Age, 42), (RiskCategoryType, RiskCategory::Low))).unwrap();
+        let _ = context.add_person(((Age, 40), (RiskCategoryType, RiskCategory::Low))).unwrap();
 
         let people = context.query_people(((Age, 42), (RiskCategoryType, RiskCategory::High)));
         assert_eq!(people.len(), 1);
@@ -1604,18 +1573,10 @@ mod test {
     #[test]
     fn query_people_intersection_one_indexed() {
         let mut context = Context::new();
-        let person1 = context.add_person();
-        let person2 = context.add_person();
-        let person3 = context.add_person();
+        let _ = context.add_person(((Age, 42), (RiskCategoryType, RiskCategory::High))).unwrap();
+        let _ = context.add_person(((Age, 42), (RiskCategoryType, RiskCategory::Low))).unwrap();
+        let _ = context.add_person(((Age, 40), (RiskCategoryType, RiskCategory::Low))).unwrap();
 
-        // Note: because of the way indexes are initialized, all properties without initializers need to be
-        // set for all people.
-        context.initialize_person_property(person1, Age, 42);
-        context.initialize_person_property(person1, RiskCategoryType, RiskCategory::High);
-        context.initialize_person_property(person2, Age, 42);
-        context.initialize_person_property(person2, RiskCategoryType, RiskCategory::Low);
-        context.initialize_person_property(person3, Age, 40);
-        context.initialize_person_property(person3, RiskCategoryType, RiskCategory::Low);
 
         context.index_property(Age);
         let people = context.query_people(((Age, 42), (RiskCategoryType, RiskCategory::High)));
@@ -1627,11 +1588,8 @@ mod test {
         let mut context = Context::new();
         define_derived_property!(Senior, bool, [Age], |age| age >= 65);
 
-        let person = context.add_person();
-        let person2 = context.add_person();
-
-        context.initialize_person_property(person, Age, 64);
-        context.initialize_person_property(person2, Age, 88);
+        let person = context.add_person((Age, 64)).unwrap();
+        let _ = context.add_person((Age, 88)).unwrap();
 
         // Age is a u8, by default integer literals are i32; the macro should cast it.
         let not_seniors = context.query_people((Senior, false));
@@ -1654,11 +1612,8 @@ mod test {
         define_derived_property!(Senior, bool, [Age], |age| age >= 65);
 
         context.index_property(Senior);
-        let person = context.add_person();
-        let person2 = context.add_person();
-
-        context.initialize_person_property(person, Age, 64);
-        context.initialize_person_property(person2, Age, 88);
+        let person = context.add_person((Age, 64)).unwrap();
+        let _ = context.add_person((Age, 88)).unwrap();
 
         // Age is a u8, by default integer literals are i32; the macro should cast it.
         let not_seniors = context.query_people((Senior, false));

--- a/src/people.rs
+++ b/src/people.rs
@@ -187,14 +187,14 @@ impl Index {
 // from 0 to population - 1. Person properties are associated with a person
 // via their id.
 struct StoredPeopleProperties {
-    must_be_initialized: bool,
+    is_required: bool,
     values: Box<dyn Any>,
 }
 
 impl StoredPeopleProperties {
     fn new<T: PersonProperty + 'static>() -> Self {
         StoredPeopleProperties {
-            must_be_initialized: T::must_be_initialized(),
+            is_required: T::is_required(),
             values: Box::new(Vec::<Option<T::Value>>::new()),
         }
     }
@@ -254,7 +254,7 @@ pub trait PersonProperty: Copy {
         false
     }
     #[must_use]
-    fn must_be_initialized() -> bool {
+    fn is_required() -> bool {
         false
     }
     #[must_use]
@@ -451,7 +451,7 @@ macro_rules! define_person_property {
             ) -> Self::Value {
                 panic!("Property not initialized when person created.");
             }
-            fn must_be_initialized() -> bool {
+            fn is_required() -> bool {
                 true
             }
             fn get_instance() -> Self {
@@ -597,7 +597,7 @@ impl PeopleData {
     ) -> Result<(), IxaError> {
         let properties_map = self.properties_map.borrow();
         for (t, property) in properties_map.iter() {
-            if property.must_be_initialized && !initialization.has_property(*t) {
+            if property.is_required && !initialization.has_property(*t) {
                 return Err(IxaError::IxaError(String::from("Missing initial value")));
             }
         }


### PR DESCRIPTION
This PR adds the ability to initialize properties in `add_person()`, as in:


```
       let person = context.add_person(((Age, 17), (IsSwimmer, true))).unwrap()
```

Any non-derived property that doesn't have automatic initialization must be initialized in this fashion during creation, which means we have removed `initiialize_person_property()`. This is technically enforced by checking that any known such property is present in the initialization list. This enforcement is imperfect because `Context` doesn't know about any property which has never been used. This means that if you do `add_person()` followed by `get_person_property()` for such a property, it will panic. However, as long as there is any use of a property this invariant will instead be enforced in `add_person()`