### PR TITLE
Initial implementation of a network facility.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,6 +29,7 @@
 pub mod context;
 pub mod error;
 pub mod global_properties;
+pub mod network;
 pub mod people;
 pub mod plan;
 pub mod random;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,7 +5,7 @@
 //! agent-based models for disease transmission, but the approach is applicable
 //! in a wide array of circumstances.
 //!
-//! The central object of an Eosim simulation is the `Context` that is
+//! The central object of an Ixa simulation is the `Context` that is
 //! responsible for managing all the behavior of the simulation. All of the
 //! simulation-specific logic is embedded in modules that rely on the `Context`
 //! for core services such as:

--- a/src/network.rs
+++ b/src/network.rs
@@ -130,7 +130,7 @@ impl NetworkData {
         edges.clone()
     }
 
-    fn search_by_degree<T: EdgeType + 'static>(&self, degree: usize) -> Vec<PersonId> {
+    fn find_people_by_degree<T: EdgeType + 'static>(&self, degree: usize) -> Vec<PersonId> {
         let mut result = Vec::new();
         
         for id in 0..self.network.len() {
@@ -192,7 +192,9 @@ pub trait ContextNetworkExt {
         person: PersonId,
         neighbor: PersonId,
     ) -> Option<&Edge<T::Value>>;
+    fn find_people_by_degree<T: EdgeType + 'static>(&self, degree: usize) -> Vec<PersonId>;    
 }
+
 
 impl ContextNetworkExt for Context {
     fn add_edge<T: EdgeType + 'static>(
@@ -267,6 +269,15 @@ impl ContextNetworkExt for Context {
             }
         }
         result
+    }
+
+    fn find_people_by_degree<T: EdgeType + 'static>(&self, degree: usize) -> Vec<PersonId> {
+        let data_container = self.get_data_container(NetworkPlugin);
+
+        match data_container {
+            None => Vec::new(),
+            Some(data_container) => data_container.find_people_by_degree::<T>(degree),
+        }
     }
 }
 
@@ -444,7 +455,7 @@ mod test_inner {
     }
 
     #[test]
-    fn search_by_degree() {
+    fn find_people_by_degree() {
         let mut nd = NetworkData::new();
         
         nd.add_edge::<EdgeType1>(PersonId { id: 1 }, PersonId { id: 2 }, 0.0, ()).unwrap();
@@ -452,9 +463,9 @@ mod test_inner {
         nd.add_edge::<EdgeType1>(PersonId { id: 2 }, PersonId { id: 3 }, 0.0, ()).unwrap();
         nd.add_edge::<EdgeType1>(PersonId { id: 3 }, PersonId { id: 2 }, 0.0, ()).unwrap();
 
-        let matches = nd.search_by_degree::<EdgeType1>(2);
+        let matches = nd.find_people_by_degree::<EdgeType1>(2);
         assert_eq!(matches, vec![PersonId{id:1}]);
-        let matches = nd.search_by_degree::<EdgeType1>(1);
+        let matches = nd.find_people_by_degree::<EdgeType1>(1);
         assert_eq!(matches, vec![PersonId{id:2}, PersonId{id:3}]);
     }
 }

--- a/src/network.rs
+++ b/src/network.rs
@@ -113,13 +113,7 @@ impl NetworkData {
 
         let entry = self.network[person.id].neighbors.get(&TypeId::of::<T>())?;
         let edges: &Vec<Edge<T::Value>> = entry.downcast_ref().expect("Type mismatch");
-        for edge in edges {
-            if edge.neighbor == neighbor {
-                return Some(edge);
-            }
-        }
-
-        None
+        edges.iter().find(|&edge| edge.neighbor == neighbor)
     }
 
     fn get_edges<T: EdgeType + 'static>(&self, person: PersonId) -> Vec<Edge<T::Value>> {
@@ -137,6 +131,7 @@ impl NetworkData {
     }
 }
 
+#[allow(unused_macros)]
 macro_rules! define_edge_type {
     ($edge_type:ident, $value:ty) => {
         #[derive(Debug, Copy, Clone)]

--- a/src/network.rs
+++ b/src/network.rs
@@ -129,6 +129,22 @@ impl NetworkData {
         let edges: &Vec<Edge<T::Value>> = entry.unwrap().downcast_ref().expect("Type mismatch");
         edges.clone()
     }
+
+    fn search_by_degree<T: EdgeType + 'static>(&self, degree: usize) -> Vec<PersonId> {
+        let mut result = Vec::new();
+        
+        for id in 0..self.network.len() {
+            let entry = self.network[id].neighbors.get(&TypeId::of::<T>());
+            if entry.is_none() {
+                continue;
+            }
+            let edges: &Vec<Edge<T::Value>> = entry.unwrap().downcast_ref().expect("Type mismatch");
+            if edges.len() == degree {
+                result.push(PersonId{id});
+            }
+        }
+        result
+    }
 }
 
 #[allow(unused_macros)]
@@ -425,6 +441,21 @@ mod test_inner {
         let result =
             nd.add_edge::<EdgeType1>(PersonId { id: 1 }, PersonId { id: 2 }, f32::INFINITY, ());
         assert!(matches!(result, Err(IxaError::IxaError(_))));
+    }
+
+    #[test]
+    fn search_by_degree() {
+        let mut nd = NetworkData::new();
+        
+        nd.add_edge::<EdgeType1>(PersonId { id: 1 }, PersonId { id: 2 }, 0.0, ()).unwrap();
+        nd.add_edge::<EdgeType1>(PersonId { id: 1 }, PersonId { id: 3 }, 0.0, ()).unwrap();
+        nd.add_edge::<EdgeType1>(PersonId { id: 2 }, PersonId { id: 3 }, 0.0, ()).unwrap();
+        nd.add_edge::<EdgeType1>(PersonId { id: 3 }, PersonId { id: 2 }, 0.0, ()).unwrap();
+
+        let matches = nd.search_by_degree::<EdgeType1>(2);
+        assert_eq!(matches, vec![PersonId{id:1}]);
+        let matches = nd.search_by_degree::<EdgeType1>(1);
+        assert_eq!(matches, vec![PersonId{id:2}, PersonId{id:3}]);
     }
 }
 

--- a/src/network.rs
+++ b/src/network.rs
@@ -132,7 +132,7 @@ impl NetworkData {
 
     fn find_people_by_degree<T: EdgeType + 'static>(&self, degree: usize) -> Vec<PersonId> {
         let mut result = Vec::new();
-        
+
         for id in 0..self.network.len() {
             let entry = self.network[id].neighbors.get(&TypeId::of::<T>());
             if entry.is_none() {
@@ -140,7 +140,7 @@ impl NetworkData {
             }
             let edges: &Vec<Edge<T::Value>> = entry.unwrap().downcast_ref().expect("Type mismatch");
             if edges.len() == degree {
-                result.push(PersonId{id});
+                result.push(PersonId { id });
             }
         }
         result
@@ -192,9 +192,8 @@ pub trait ContextNetworkExt {
         person: PersonId,
         neighbor: PersonId,
     ) -> Option<&Edge<T::Value>>;
-    fn find_people_by_degree<T: EdgeType + 'static>(&self, degree: usize) -> Vec<PersonId>;    
+    fn find_people_by_degree<T: EdgeType + 'static>(&self, degree: usize) -> Vec<PersonId>;
 }
-
 
 impl ContextNetworkExt for Context {
     fn add_edge<T: EdgeType + 'static>(
@@ -457,16 +456,20 @@ mod test_inner {
     #[test]
     fn find_people_by_degree() {
         let mut nd = NetworkData::new();
-        
-        nd.add_edge::<EdgeType1>(PersonId { id: 1 }, PersonId { id: 2 }, 0.0, ()).unwrap();
-        nd.add_edge::<EdgeType1>(PersonId { id: 1 }, PersonId { id: 3 }, 0.0, ()).unwrap();
-        nd.add_edge::<EdgeType1>(PersonId { id: 2 }, PersonId { id: 3 }, 0.0, ()).unwrap();
-        nd.add_edge::<EdgeType1>(PersonId { id: 3 }, PersonId { id: 2 }, 0.0, ()).unwrap();
+
+        nd.add_edge::<EdgeType1>(PersonId { id: 1 }, PersonId { id: 2 }, 0.0, ())
+            .unwrap();
+        nd.add_edge::<EdgeType1>(PersonId { id: 1 }, PersonId { id: 3 }, 0.0, ())
+            .unwrap();
+        nd.add_edge::<EdgeType1>(PersonId { id: 2 }, PersonId { id: 3 }, 0.0, ())
+            .unwrap();
+        nd.add_edge::<EdgeType1>(PersonId { id: 3 }, PersonId { id: 2 }, 0.0, ())
+            .unwrap();
 
         let matches = nd.find_people_by_degree::<EdgeType1>(2);
-        assert_eq!(matches, vec![PersonId{id:1}]);
+        assert_eq!(matches, vec![PersonId { id: 1 }]);
         let matches = nd.find_people_by_degree::<EdgeType1>(1);
-        assert_eq!(matches, vec![PersonId{id:2}, PersonId{id:3}]);
+        assert_eq!(matches, vec![PersonId { id: 2 }, PersonId { id: 3 }]);
     }
 }
 

--- a/src/network.rs
+++ b/src/network.rs
@@ -371,8 +371,6 @@ mod test_inner {
             nd.add_edge::<EdgeType1>(PersonId { id: 1 }, PersonId { id: 2 }, f32::INFINITY, ());
         assert!(matches!(result, Err(IxaError::IxaError(_))));
     }
-
-    
 }
 
 
@@ -425,7 +423,7 @@ mod test_api {
     }
 
     #[test]
-    fn add_edge_different_weightsi() {
+    fn add_edge_different_weights() {
         let (mut context, person1, person2) = setup();
 
         context

--- a/src/network.rs
+++ b/src/network.rs
@@ -374,7 +374,7 @@ impl ContextNetworkExt for Context {
             )));
         }
 
-        let weights : Vec<_> = edges.iter().map(|x| x.weight).collect();
+        let weights: Vec<_> = edges.iter().map(|x| x.weight).collect();
         let index = self.sample_weighted(rng_id, &weights);
         Ok(edges[index])
     }

--- a/src/network.rs
+++ b/src/network.rs
@@ -192,7 +192,7 @@ pub trait ContextNetworkExt {
     /// Returns `IxaError` if:
     ///
     /// * `person` and `neighbor` are the same or an edge already
-    /// exists between them.
+    ///    exists between them.
     /// * `weight` is invalid
     fn add_edge<T: EdgeType + 'static>(
         &mut self,
@@ -262,6 +262,9 @@ pub trait ContextNetworkExt {
 
     /// Select a random edge out of the list of outgoing edges of type
     /// `T` from `person_id`, weighted by the edge weights.
+    ///
+    /// # Errors
+    /// Returns `IxaError` if there are no edges.
     fn select_random_edge<T: EdgeType + 'static, R: RngId + 'static>(
         &self,
         rng_id: R,
@@ -365,7 +368,7 @@ impl ContextNetworkExt for Context {
         R::RngType: Rng,
     {
         let edges = self.get_edges::<T>(person_id);
-        if edges.len() == 0 {
+        if edges.is_empty() {
             return Err(IxaError::IxaError(String::from(
                 "Can't sample from empty list",
             )));
@@ -746,7 +749,7 @@ mod test_api {
             .add_edge::<EdgeType1>(person1, person2, 0.01, 1)
             .unwrap();
         context
-            .add_edge::<EdgeType1>(person1, person3, 10000000.0, 3)
+            .add_edge::<EdgeType1>(person1, person3, 10_000_000.0, 3)
             .unwrap();
 
         let edge = context

--- a/src/network.rs
+++ b/src/network.rs
@@ -342,6 +342,12 @@ mod test_inner {
         assert_eq!(edge.weight, 0.02);
     }
 
+    #[test]
+    fn remove_nonexistent_edge() {
+        let mut nd = NetworkData::new();
+        assert!(matches!(nd.remove_edge::<EdgeType1>(PersonId { id: 1 }, PersonId { id: 2 }),
+                                                     Err(IxaError::IxaError(_))));
+    }
     
     #[test]
     fn add_edge_to_self() {

--- a/src/network.rs
+++ b/src/network.rs
@@ -355,7 +355,7 @@ impl ContextNetworkExt for Context {
         }
 
         let weights = edges.iter().map(|x| x.weight).collect();
-        let index = self.sample_weighted(rng_id, weights);
+        let index = self.sample_weighted(rng_id, &weights);
         Ok(edges[index])
     }
 }

--- a/src/network.rs
+++ b/src/network.rs
@@ -601,7 +601,7 @@ mod test_api {
     }
 
     #[test]
-    fn get_matching_edges_property() {
+    fn get_matching_edges_inner() {
         let (mut context, person1, person2) = setup();
         let person3 = context.add_person((Age, 3)).unwrap();
 
@@ -613,6 +613,24 @@ mod test_api {
             .unwrap();
         let edges =
             context.get_matching_edges::<EdgeType1>(person1, |_context, edge| edge.inner == 3);
+        assert_eq!(edges.len(), 1);
+        assert_eq!(edges[0].neighbor, person3);
+    }
+
+    #[test]
+    fn get_matching_edges_person_property() {
+        let (mut context, person1, person2) = setup();
+        let person3 = context.add_person((Age, 3)).unwrap();
+
+        context
+            .add_edge::<EdgeType1>(person1, person2, 0.01, 1)
+            .unwrap();
+        context
+            .add_edge::<EdgeType1>(person1, person3, 0.03, 3)
+            .unwrap();
+        let edges = context.get_matching_edges::<EdgeType1>(person1, |context, edge| {
+            context.match_person(edge.neighbor, (Age, 3))
+        });
         assert_eq!(edges.len(), 1);
         assert_eq!(edges[0].neighbor, person3);
     }

--- a/src/network.rs
+++ b/src/network.rs
@@ -420,7 +420,7 @@ mod test_api {
     use crate::people::{ContextPeopleExt, PersonId, define_person_property};
     use crate::error::IxaError;
     
-    define_edge_type!(EdgeType1, ());
+    define_edge_type!(EdgeType1, u32);
     define_person_property!(Age, u8);
     
     fn setup() -> (Context, PersonId, PersonId) {
@@ -436,7 +436,7 @@ mod test_api {
         let (mut context, person1, person2) = setup();
 
         context
-            .add_edge::<EdgeType1>(person1, person2, 0.01, ())
+            .add_edge::<EdgeType1>(person1, person2, 0.01, 1)
             .unwrap();
         assert_eq!(context.get_edge::<EdgeType1>(person1, person2).unwrap().weight, 0.01);
         assert_eq!(
@@ -444,7 +444,7 @@ mod test_api {
             vec![Edge {
                 neighbor: person2,
                 weight: 0.01,
-                inner: ()
+                inner: 1
             }]
         );
     }
@@ -457,7 +457,7 @@ mod test_api {
         assert!(matches!(context.remove_edge::<EdgeType1>(person1, person2),
                 Err(IxaError::IxaError(_))));
         context
-            .add_edge::<EdgeType1>(person1, person2, 0.01, ())
+            .add_edge::<EdgeType1>(person1, person2, 0.01, 1)
             .unwrap();
         context.remove_edge::<EdgeType1>(person1, person2).unwrap();
         assert!(context.get_edge::<EdgeType1>(person1, person2).is_none());
@@ -469,7 +469,7 @@ mod test_api {
         let (mut context, person1, person2) = setup();
 
         context
-            .add_edge_bidi::<EdgeType1>(person1, person2, 0.01, ())
+            .add_edge_bidi::<EdgeType1>(person1, person2, 0.01, 1)
             .unwrap();
         assert_eq!(context.get_edge::<EdgeType1>(person1, person2).unwrap().weight, 0.01);
         assert_eq!(context.get_edge::<EdgeType1>(person2, person1).unwrap().weight, 0.01);
@@ -481,10 +481,10 @@ mod test_api {
         let (mut context, person1, person2) = setup();
 
         context
-            .add_edge::<EdgeType1>(person1, person2, 0.01, ())
+            .add_edge::<EdgeType1>(person1, person2, 0.01, 1)
             .unwrap();
         context
-            .add_edge::<EdgeType1>(person2, person1, 0.02, ())
+            .add_edge::<EdgeType1>(person2, person1, 0.02, 1)
             .unwrap();
         assert_eq!(context.get_edge::<EdgeType1>(person1, person2).unwrap().weight, 0.01);
         assert_eq!(context.get_edge::<EdgeType1>(person2, person1).unwrap().weight, 0.02);
@@ -496,10 +496,10 @@ mod test_api {
         let person3 = context.add_person((Age, 3)).unwrap();
         
         context
-            .add_edge::<EdgeType1>(person1, person2, 0.01, ())
+            .add_edge::<EdgeType1>(person1, person2, 0.01, 1)
             .unwrap();
         context
-            .add_edge::<EdgeType1>(person1, person3, 0.03, ())
+            .add_edge::<EdgeType1>(person1, person3, 0.03, 1)
             .unwrap();
         let edges = context.get_matching_edges::<EdgeType1>(person1, | _context, edge| {
             edge.weight > 0.01
@@ -514,13 +514,13 @@ mod test_api {
         let person3 = context.add_person((Age, 3)).unwrap();
         
         context
-            .add_edge::<EdgeType1>(person1, person2, 0.01, ())
+            .add_edge::<EdgeType1>(person1, person2, 0.01, 1)
             .unwrap();
         context
-            .add_edge::<EdgeType1>(person1, person3, 0.03, ())
+            .add_edge::<EdgeType1>(person1, person3, 0.03, 3)
             .unwrap();
-        let edges = context.get_matching_edges::<EdgeType1>(person1, | context, edge| {
-            context.match_person(edge.neighbor, (Age, 3))
+        let edges = context.get_matching_edges::<EdgeType1>(person1, | _context, edge| {
+            edge.inner == 3
         });
         assert_eq!(edges.len(), 1);
         assert_eq!(edges[0].neighbor, person3);

--- a/src/network.rs
+++ b/src/network.rs
@@ -1,0 +1,337 @@
+use crate::{context::Context, define_data_plugin, error::IxaError, people::PersonId};
+use std::{any::TypeId, collections::HashMap};
+
+#[derive(Copy, Clone, Debug, PartialEq)]
+pub struct Edge {
+    neighbor: PersonId,
+    weight: f32,
+}
+
+#[derive(Default)]
+struct PersonNetwork {
+    // A vector of vectors of NetworkEdge, indexed by edge type.
+    neighbors: HashMap<TypeId, Vec<Edge>>,
+}
+
+struct NetworkData {
+    network: Vec<PersonNetwork>,
+}
+
+impl NetworkData {
+    fn new() -> Self {
+        NetworkData {
+            network: Vec::new(),
+        }
+    }
+
+    fn add_edge<T: 'static>(
+        &mut self,
+        person: PersonId,
+        neighbor: PersonId,
+        weight: f32,
+    ) -> Result<(), IxaError> {
+        if person == neighbor {
+            return Err(IxaError::IxaError(String::from("Cannot make edge to self")));
+        }
+
+        if weight.is_infinite() || weight.is_nan() || weight.is_sign_negative() {
+            return Err(IxaError::IxaError(String::from("Invalid weight")));
+        }
+
+        // Make sure we have data for this person.
+        if person.id >= self.network.len() {
+            self.network.resize_with(person.id + 1, Default::default)
+        }
+
+        let entry = self.network[person.id]
+            .neighbors
+            .entry(TypeId::of::<T>())
+            .or_default();
+
+        for edge in entry.iter_mut() {
+            if edge.neighbor == neighbor {
+                edge.weight = weight;
+                return Ok(());
+            }
+        }
+
+        entry.push(Edge { neighbor, weight });
+        Ok(())
+    }
+
+    fn get_edge<T: 'static>(&self, person: PersonId, neighbor: PersonId) -> Option<f32> {
+        if person.id >= self.network.len() {
+            return None;
+        }
+
+        let entry = self.network[person.id].neighbors.get(&TypeId::of::<T>())?;
+        for edge in entry {
+            if edge.neighbor == neighbor {
+                return Some(edge.weight);
+            }
+        }
+
+        None
+    }
+
+    fn get_edges<T: 'static>(&self, person: PersonId) -> Vec<Edge> {
+        if person.id >= self.network.len() {
+            return Vec::new();
+        }
+
+        let entry = self.network[person.id].neighbors.get(&TypeId::of::<T>());
+        if entry.is_none() {
+            return Vec::new();
+        }
+
+        let mut result = Vec::new();
+        for edge in entry.unwrap() {
+            result.push(*edge);
+        }
+
+        result
+    }
+}
+
+define_data_plugin!(NetworkPlugin, NetworkData, NetworkData::new());
+
+pub trait ContextNetworkExt {
+    fn add_edge<T: 'static>(
+        &mut self,
+        person: PersonId,
+        neighbor: PersonId,
+        weight: f32,
+    ) -> Result<(), IxaError>;
+    fn add_edge_bidi<T: 'static>(
+        &mut self,
+        person1: PersonId,
+        person2: PersonId,
+        weight: f32,
+    ) -> Result<(), IxaError>;
+    fn get_edges<T: 'static>(&self, person: PersonId) -> Vec<Edge>;
+    fn get_edge<T: 'static>(&self, person: PersonId, neighbor: PersonId) -> Option<f32>;
+}
+
+impl ContextNetworkExt for Context {
+    fn add_edge<T: 'static>(
+        &mut self,
+        person: PersonId,
+        neighbor: PersonId,
+        weight: f32,
+    ) -> Result<(), IxaError> {
+        let data_container = self.get_data_container_mut(NetworkPlugin);
+        data_container.add_edge::<T>(person, neighbor, weight)
+    }
+    fn add_edge_bidi<T: 'static>(
+        &mut self,
+        person1: PersonId,
+        person2: PersonId,
+        weight: f32,
+    ) -> Result<(), IxaError> {
+        let data_container = self.get_data_container_mut(NetworkPlugin);
+        data_container.add_edge::<T>(person1, person2, weight)?;
+        data_container.add_edge::<T>(person2, person1, weight)
+    }
+
+    fn get_edge<T: 'static>(&self, person: PersonId, neighbor: PersonId) -> Option<f32> {
+        let data_container = self.get_data_container(NetworkPlugin);
+
+        match data_container {
+            None => None,
+            Some(data_container) => data_container.get_edge::<T>(person, neighbor),
+        }
+    }
+
+    fn get_edges<T: 'static>(&self, person: PersonId) -> Vec<Edge> {
+        let data_container = self.get_data_container(NetworkPlugin);
+
+        match data_container {
+            None => Vec::new(),
+            Some(data_container) => data_container.get_edges::<T>(person),
+        }
+    }
+}
+
+#[cfg(test)]
+// Tests for the inner core.
+mod test_inner {
+    use super::{Edge, NetworkData};
+    use crate::error::IxaError;
+    use crate::people::PersonId;
+
+    struct EdgeType1;
+    struct EdgeType2;
+
+    #[test]
+    fn add_edge() {
+        let mut nd = NetworkData::new();
+
+        nd.add_edge::<EdgeType1>(PersonId { id: 1 }, PersonId { id: 2 }, 0.01)
+            .unwrap();
+        let weight = nd
+            .get_edge::<EdgeType1>(PersonId { id: 1 }, PersonId { id: 2 })
+            .unwrap();
+        assert_eq!(weight, 0.01);
+    }
+
+    #[test]
+    fn add_two_edges() {
+        let mut nd = NetworkData::new();
+
+        nd.add_edge::<EdgeType1>(PersonId { id: 1 }, PersonId { id: 2 }, 0.01)
+            .unwrap();
+        nd.add_edge::<EdgeType1>(PersonId { id: 1 }, PersonId { id: 3 }, 0.02)
+            .unwrap();
+        let weight = nd
+            .get_edge::<EdgeType1>(PersonId { id: 1 }, PersonId { id: 2 })
+            .unwrap();
+        assert_eq!(weight, 0.01);
+        let weight = nd
+            .get_edge::<EdgeType1>(PersonId { id: 1 }, PersonId { id: 3 })
+            .unwrap();
+        assert_eq!(weight, 0.02);
+
+        let edges = nd.get_edges::<EdgeType1>(PersonId { id: 1 });
+        assert_eq!(
+            edges,
+            vec![
+                Edge {
+                    neighbor: PersonId { id: 2 },
+                    weight: 0.01
+                },
+                Edge {
+                    neighbor: PersonId { id: 3 },
+                    weight: 0.02
+                }
+            ]
+        );
+    }
+
+    #[test]
+    fn add_two_edge_types() {
+        let mut nd = NetworkData::new();
+
+        nd.add_edge::<EdgeType1>(PersonId { id: 1 }, PersonId { id: 2 }, 0.01)
+            .unwrap();
+        nd.add_edge::<EdgeType2>(PersonId { id: 1 }, PersonId { id: 2 }, 0.02)
+            .unwrap();
+        let weight = nd
+            .get_edge::<EdgeType1>(PersonId { id: 1 }, PersonId { id: 2 })
+            .unwrap();
+        assert_eq!(weight, 0.01);
+        let weight = nd
+            .get_edge::<EdgeType2>(PersonId { id: 1 }, PersonId { id: 2 })
+            .unwrap();
+        assert_eq!(weight, 0.02);
+
+        let edges = nd.get_edges::<EdgeType1>(PersonId { id: 1 });
+        assert_eq!(
+            edges,
+            vec![Edge {
+                neighbor: PersonId { id: 2 },
+                weight: 0.01
+            }]
+        );
+    }
+
+    #[test]
+    fn replace_edge() {
+        let mut nd = NetworkData::new();
+
+        nd.add_edge::<EdgeType1>(PersonId { id: 1 }, PersonId { id: 2 }, 0.01)
+            .unwrap();
+        let weight = nd
+            .get_edge::<EdgeType1>(PersonId { id: 1 }, PersonId { id: 2 })
+            .unwrap();
+        assert_eq!(weight, 0.01);
+        nd.add_edge::<EdgeType1>(PersonId { id: 1 }, PersonId { id: 2 }, 0.02)
+            .unwrap();
+        let weight = nd
+            .get_edge::<EdgeType1>(PersonId { id: 1 }, PersonId { id: 2 })
+            .unwrap();
+        assert_eq!(weight, 0.02)
+    }
+
+    #[test]
+    fn add_edge_to_self() {
+        let mut nd = NetworkData::new();
+
+        let result = nd.add_edge::<EdgeType1>(PersonId { id: 1 }, PersonId { id: 1 }, 0.01);
+        assert!(matches!(result, Err(IxaError::IxaError(_))));
+    }
+
+    #[test]
+    fn add_edge_bogus_weight() {
+        let mut nd = NetworkData::new();
+
+        let result = nd.add_edge::<EdgeType1>(PersonId { id: 1 }, PersonId { id: 2 }, -1.0);
+        assert!(matches!(result, Err(IxaError::IxaError(_))));
+
+        let result = nd.add_edge::<EdgeType1>(PersonId { id: 1 }, PersonId { id: 2 }, f32::NAN);
+        assert!(matches!(result, Err(IxaError::IxaError(_))));
+
+        let result =
+            nd.add_edge::<EdgeType1>(PersonId { id: 1 }, PersonId { id: 2 }, f32::INFINITY);
+        assert!(matches!(result, Err(IxaError::IxaError(_))));
+    }
+}
+
+#[cfg(test)]
+// Tests for the API.
+mod test_api {
+    use crate::context::Context;
+    use crate::network::{ContextNetworkExt, Edge};
+    use crate::people::{ContextPeopleExt, PersonId};
+
+    struct EdgeType1;
+
+    fn setup() -> (Context, PersonId, PersonId) {
+        let mut context = Context::new();
+        let person1 = context.add_person(()).unwrap();
+        let person2 = context.add_person(()).unwrap();
+
+        (context, person1, person2)
+    }
+
+    #[test]
+    fn add_edge() {
+        let (mut context, person1, person2) = setup();
+
+        context
+            .add_edge::<EdgeType1>(person1, person2, 0.01)
+            .unwrap();
+        assert_eq!(context.get_edge::<EdgeType1>(person1, person2), Some(0.01));
+        assert_eq!(
+            context.get_edges::<EdgeType1>(person1),
+            vec![Edge {
+                neighbor: person2,
+                weight: 0.01
+            }]
+        );
+    }
+
+    #[test]
+    fn add_edge_bidi() {
+        let (mut context, person1, person2) = setup();
+
+        context
+            .add_edge_bidi::<EdgeType1>(person1, person2, 0.01)
+            .unwrap();
+        assert_eq!(context.get_edge::<EdgeType1>(person1, person2), Some(0.01));
+        assert_eq!(context.get_edge::<EdgeType1>(person2, person1), Some(0.01));
+    }
+
+    #[test]
+    fn add_edge_different_weightsi() {
+        let (mut context, person1, person2) = setup();
+
+        context
+            .add_edge::<EdgeType1>(person1, person2, 0.01)
+            .unwrap();
+        context
+            .add_edge::<EdgeType1>(person2, person1, 0.02)
+            .unwrap();
+        assert_eq!(context.get_edge::<EdgeType1>(person1, person2), Some(0.01));
+        assert_eq!(context.get_edge::<EdgeType1>(person2, person1), Some(0.02));
+    }
+}

--- a/src/network.rs
+++ b/src/network.rs
@@ -304,7 +304,7 @@ mod test_inner {
     }
 
     #[test]
-    fn add_edge_twice() {
+    fn add_edge_twice_fails() {
         let mut nd = NetworkData::new();
 
         nd.add_edge::<EdgeType1>(PersonId { id: 1 }, PersonId { id: 2 }, 0.01, ())
@@ -313,10 +313,36 @@ mod test_inner {
             .get_edge::<EdgeType1>(PersonId { id: 1 }, PersonId { id: 2 })
             .unwrap();
         assert_eq!(edge.weight, 0.01);
+
         assert!(matches!(nd.add_edge::<EdgeType1>(PersonId { id: 1 }, PersonId { id: 2 }, 0.02, ()),
                          Err(IxaError::IxaError(_))));
     }
 
+    #[test]
+    fn add_remove_add_edge() {
+        let mut nd = NetworkData::new();
+
+        nd.add_edge::<EdgeType1>(PersonId { id: 1 }, PersonId { id: 2 }, 0.01, ())
+            .unwrap();
+        let edge = nd
+            .get_edge::<EdgeType1>(PersonId { id: 1 }, PersonId { id: 2 })
+            .unwrap();
+        assert_eq!(edge.weight, 0.01);
+        
+        nd.remove_edge::<EdgeType1>(PersonId { id: 1 }, PersonId { id: 2 }).unwrap();
+        let edge = nd
+            .get_edge::<EdgeType1>(PersonId { id: 1 }, PersonId { id: 2 });
+        assert!(edge.is_none());
+
+        nd.add_edge::<EdgeType1>(PersonId { id: 1 }, PersonId { id: 2 }, 0.02, ())
+            .unwrap();
+        let edge = nd
+            .get_edge::<EdgeType1>(PersonId { id: 1 }, PersonId { id: 2 })
+            .unwrap();
+        assert_eq!(edge.weight, 0.02);
+    }
+
+    
     #[test]
     fn add_edge_to_self() {
         let mut nd = NetworkData::new();

--- a/src/network.rs
+++ b/src/network.rs
@@ -213,7 +213,7 @@ pub trait ContextNetworkExt {
     /// Returns `IxaError` if:
     ///
     /// * `person` and `neighbor` are the same or an edge already
-    /// exists between them.
+    ///   exists between them.
     /// * `weight` is invalid
     fn add_edge_bidi<T: EdgeType + 'static>(
         &mut self,

--- a/src/network.rs
+++ b/src/network.rs
@@ -10,7 +10,7 @@ use std::{
     any::{Any, TypeId},
     collections::HashMap,
 };
-use rand::{Rng};
+use rand::Rng;
 
 #[derive(Copy, Clone, Debug, PartialEq)]
 /// An edge in network graph. Edges are directed, so the
@@ -257,7 +257,7 @@ pub trait ContextNetworkExt {
     /// Find all people who have an edge of type `T` and degree `degree`.
     fn find_people_by_degree<T: EdgeType + 'static>(&self, degree: usize) -> Vec<PersonId>;
 
-    fn select_random_edge<T: EdgeType + 'static, R: RngId + 'static>(&self, rng_id: R, edges: &Vec<Edge<T::Value>>) -> Result<Edge<T::Value>, IxaError> where R::RngType: Rng;    
+    fn select_random_edge<T: EdgeType + 'static, R: RngId + 'static>(&self, rng_id: R, person_id: PersonId) -> Result<Edge<T::Value>, IxaError> where R::RngType: Rng;    
 }
 
 
@@ -346,9 +346,10 @@ impl ContextNetworkExt for Context {
         }
     }
 
-    fn select_random_edge<T: EdgeType + 'static, R: RngId + 'static>(&self, rng_id: R, edges: &Vec<Edge<T::Value>>) -> Result<Edge<T::Value>, IxaError>
+    fn select_random_edge<T: EdgeType + 'static, R: RngId + 'static>(&self, rng_id: R, person_id: PersonId) -> Result<Edge<T::Value>, IxaError>
         where R::RngType: Rng,
     {
+        let edges = self.get_edges::<T>(person_id);
         if edges.len() == 0 {
             return Err(IxaError::IxaError(String::from("Can't sample from empty list")));
         }
@@ -560,7 +561,9 @@ mod test_api {
     use crate::error::IxaError;
     use crate::network::{ContextNetworkExt, Edge};
     use crate::people::{define_person_property, ContextPeopleExt, PersonId};
-
+    use crate::define_rng;
+    use crate::random::ContextRandomExt;
+    
     define_edge_type!(EdgeType1, u32);
     define_person_property!(Age, u8);
 
@@ -713,4 +716,24 @@ mod test_api {
         assert_eq!(edges.len(), 1);
         assert_eq!(edges[0].neighbor, person3);
     }
+
+    #[test]
+    fn select_random_edge() {
+        define_rng!(NetworkTestRng);
+        
+        let (mut context, person1, person2) = setup();
+        let person3 = context.add_person((Age, 3)).unwrap();
+        context.init_random(42);
+        
+        context
+            .add_edge::<EdgeType1>(person1, person2, 0.01, 1)
+            .unwrap();
+        context
+            .add_edge::<EdgeType1>(person1, person3, 10000000.0, 3)
+            .unwrap();
+
+        let edge = context.select_random_edge::<EdgeType1, _>(NetworkTestRng, person1).unwrap();
+        assert_eq!(edge.neighbor, person3);
+    }
+        
 }

--- a/src/network.rs
+++ b/src/network.rs
@@ -374,7 +374,7 @@ impl ContextNetworkExt for Context {
             )));
         }
 
-        let weights = edges.iter().map(|x| x.weight).collect();
+        let weights : Vec<_> = edges.iter().map(|x| x.weight).collect();
         let index = self.sample_weighted(rng_id, &weights);
         Ok(edges[index])
     }

--- a/src/network.rs
+++ b/src/network.rs
@@ -40,7 +40,7 @@ impl NetworkData {
 
         // Make sure we have data for this person.
         if person.id >= self.network.len() {
-            self.network.resize_with(person.id + 1, Default::default)
+            self.network.resize_with(person.id + 1, Default::default);
         }
 
         let entry = self.network[person.id]
@@ -153,6 +153,7 @@ impl ContextNetworkExt for Context {
 }
 
 #[cfg(test)]
+#[allow(clippy::float_cmp)]
 // Tests for the inner core.
 mod test_inner {
     use super::{Edge, NetworkData};
@@ -249,7 +250,7 @@ mod test_inner {
         let weight = nd
             .get_edge::<EdgeType1>(PersonId { id: 1 }, PersonId { id: 2 })
             .unwrap();
-        assert_eq!(weight, 0.02)
+        assert_eq!(weight, 0.02);
     }
 
     #[test]
@@ -277,6 +278,7 @@ mod test_inner {
 }
 
 #[cfg(test)]
+#[allow(clippy::float_cmp)]
 // Tests for the API.
 mod test_api {
     use crate::context::Context;

--- a/src/people.rs
+++ b/src/people.rs
@@ -688,6 +688,7 @@ pub trait ContextPeopleExt {
     fn get_person_id(&self, person_id: usize) -> PersonId;
     fn index_property<T: PersonProperty + 'static>(&mut self, property: T);
     fn query_people<T: Query>(&self, q: T) -> Vec<PersonId>;
+    fn match_person<T: Query>(&self, person_id: PersonId, q: T) -> bool;    
 }
 
 impl ContextPeopleExt for Context {
@@ -860,6 +861,22 @@ impl ContextPeopleExt for Context {
         self.query_people_internal(q.get_query())
     }
 
+    fn match_person<T: Query>(&self, person_id: PersonId, q: T) -> bool {
+        T::setup(&self);
+        // This cannot fail because someone must have been made by now.
+        let data_container = self.get_data_container(PeoplePlugin).unwrap();
+    
+        let query = q.get_query();
+
+        for (t, hash) in &query {
+            let index = data_container.get_index_ref(*t).unwrap();
+            if *hash != (*index.indexer)(self, person_id) {
+                return false;
+            }
+        }
+        true
+    }
+    
     fn register_property<T: PersonProperty + 'static>(&self) {
         let data_container = self.get_data_container(PeoplePlugin).unwrap();
         if !data_container
@@ -1658,6 +1675,18 @@ mod test {
         assert_eq!(not_seniors.len(), 0, "No non-seniors");
     }
 
+
+    #[test]
+    fn text_match_person() {
+        let mut context = Context::new();
+        let person = context
+            .add_person(((Age, 42), (RiskCategoryType, RiskCategory::High)))
+            .unwrap();
+        assert!(context.match_person(person, ((Age, 42), (RiskCategoryType, RiskCategory::High))));
+        assert!(!context.match_person(person, ((Age, 43), (RiskCategoryType, RiskCategory::High))));
+        assert!(!context.match_person(person, ((Age, 42), (RiskCategoryType, RiskCategory::Low))));
+    }
+    
     #[test]
     fn test_index_value_hasher_finish2_short() {
         let value = 42;

--- a/src/people.rs
+++ b/src/people.rs
@@ -688,7 +688,7 @@ pub trait ContextPeopleExt {
     fn get_person_id(&self, person_id: usize) -> PersonId;
     fn index_property<T: PersonProperty + 'static>(&mut self, property: T);
     fn query_people<T: Query>(&self, q: T) -> Vec<PersonId>;
-    fn match_person<T: Query>(&self, person_id: PersonId, q: T) -> bool;    
+    fn match_person<T: Query>(&self, person_id: PersonId, q: T) -> bool;
 }
 
 impl ContextPeopleExt for Context {
@@ -865,7 +865,7 @@ impl ContextPeopleExt for Context {
         T::setup(&self);
         // This cannot fail because someone must have been made by now.
         let data_container = self.get_data_container(PeoplePlugin).unwrap();
-    
+
         let query = q.get_query();
 
         for (t, hash) in &query {
@@ -876,7 +876,7 @@ impl ContextPeopleExt for Context {
         }
         true
     }
-    
+
     fn register_property<T: PersonProperty + 'static>(&self) {
         let data_container = self.get_data_container(PeoplePlugin).unwrap();
         if !data_container
@@ -1675,7 +1675,6 @@ mod test {
         assert_eq!(not_seniors.len(), 0, "No non-seniors");
     }
 
-
     #[test]
     fn text_match_person() {
         let mut context = Context::new();
@@ -1686,7 +1685,7 @@ mod test {
         assert!(!context.match_person(person, ((Age, 43), (RiskCategoryType, RiskCategory::High))));
         assert!(!context.match_person(person, ((Age, 42), (RiskCategoryType, RiskCategory::Low))));
     }
-    
+
     #[test]
     fn test_index_value_hasher_finish2_short() {
         let value = 42;

--- a/src/people.rs
+++ b/src/people.rs
@@ -862,7 +862,7 @@ impl ContextPeopleExt for Context {
     }
 
     fn match_person<T: Query>(&self, person_id: PersonId, q: T) -> bool {
-        T::setup(&self);
+        T::setup(self);
         // This cannot fail because someone must have been made by now.
         let data_container = self.get_data_container(PeoplePlugin).unwrap();
 

--- a/src/people.rs
+++ b/src/people.rs
@@ -226,7 +226,7 @@ define_data_plugin!(
 // 0 to population - 1 in the PeopleData container.
 #[derive(Clone, Copy, Hash, PartialEq, Eq, Serialize, Deserialize)]
 pub struct PersonId {
-    id: usize,
+    pub(crate) id: usize,
 }
 
 impl fmt::Display for PersonId {

--- a/src/random.rs
+++ b/src/random.rs
@@ -315,7 +315,7 @@ mod test {
     fn sample_weighted() {
         let mut context = Context::new();
         context.init_random(42);
-        let r: usize = context.sample_weighted(FooRng, &vec![0.1, 0.3, 0.4]);
+        let r: usize = context.sample_weighted(FooRng, &[0.1, 0.3, 0.4]);
         assert!(r < 3);
     }
 }

--- a/src/random.rs
+++ b/src/random.rs
@@ -127,7 +127,7 @@ pub trait ContextRandomExt {
     where
         R::RngType: Rng;
 
-    fn sample_weighted<R: RngId + 'static, T>(&self, rng_id: R, weights: Vec<T>) -> usize
+    fn sample_weighted<R: RngId + 'static, T>(&self, rng_id: R, weights: &Vec<T>) -> usize
     where R::RngType: Rng,
     T: Clone + Default + SampleUniform + for<'a> std::ops::AddAssign<&'a T> + PartialOrd;
 }
@@ -181,7 +181,7 @@ impl ContextRandomExt for Context {
         self.sample(rng_id, |rng| rng.gen_bool(p))
     }
 
-    fn sample_weighted<R: RngId + 'static, T>(&self, _rng_id: R, weights: Vec<T>) -> usize
+    fn sample_weighted<R: RngId + 'static, T>(&self, _rng_id: R, weights: &Vec<T>) -> usize
     where
         R::RngType: Rng,
             T: Clone + Default + SampleUniform + for<'a> std::ops::AddAssign<&'a T> + PartialOrd
@@ -315,7 +315,7 @@ mod test {
     fn sample_weighted() {
         let mut context = Context::new();
         context.init_random(42);
-        let r: usize = context.sample_weighted(FooRng, vec![0.1, 0.3, 0.4]);
+        let r: usize = context.sample_weighted(FooRng, &vec![0.1, 0.3, 0.4]);
         assert!(r < 3);
     }
     

--- a/src/random.rs
+++ b/src/random.rs
@@ -126,7 +126,7 @@ pub trait ContextRandomExt {
     where
         R::RngType: Rng;
 
-    fn sample_weighted<R: RngId + 'static, T>(&self, rng_id: R, weights: &Vec<T>) -> usize
+    fn sample_weighted<R: RngId + 'static, T>(&self, rng_id: R, weights: &[T]) -> usize
     where
         R::RngType: Rng,
         T: Clone + Default + SampleUniform + for<'a> std::ops::AddAssign<&'a T> + PartialOrd;
@@ -181,7 +181,7 @@ impl ContextRandomExt for Context {
         self.sample(rng_id, |rng| rng.gen_bool(p))
     }
 
-    fn sample_weighted<R: RngId + 'static, T>(&self, _rng_id: R, weights: &Vec<T>) -> usize
+    fn sample_weighted<R: RngId + 'static, T>(&self, _rng_id: R, weights: &[T]) -> usize
     where
         R::RngType: Rng,
         T: Clone + Default + SampleUniform + for<'a> std::ops::AddAssign<&'a T> + PartialOrd,

--- a/src/random.rs
+++ b/src/random.rs
@@ -6,7 +6,6 @@ use rand::{Rng, SeedableRng};
 use std::any::{Any, TypeId};
 use std::cell::{RefCell, RefMut};
 use std::collections::HashMap;
-use std::ops::DerefMut;
 
 /// Use this to define a unique type which will be used as a key to retrieve
 /// an independent rng instance when calling `.get_rng`.
@@ -189,7 +188,7 @@ impl ContextRandomExt for Context {
     {
         let index = WeightedIndex::new(weights).unwrap();
         let mut rng = get_rng::<R>(self);
-        index.sample(rng.deref_mut())
+        index.sample(&mut *rng)
     }
 }
 

--- a/src/random.rs
+++ b/src/random.rs
@@ -1,5 +1,5 @@
 use crate::context::Context;
-use rand::distributions::uniform::{SampleUniform, SampleRange};
+use rand::distributions::uniform::{SampleRange, SampleUniform};
 use rand::distributions::WeightedIndex;
 use rand::prelude::Distribution;
 use rand::{Rng, SeedableRng};
@@ -128,8 +128,9 @@ pub trait ContextRandomExt {
         R::RngType: Rng;
 
     fn sample_weighted<R: RngId + 'static, T>(&self, rng_id: R, weights: &Vec<T>) -> usize
-    where R::RngType: Rng,
-    T: Clone + Default + SampleUniform + for<'a> std::ops::AddAssign<&'a T> + PartialOrd;
+    where
+        R::RngType: Rng,
+        T: Clone + Default + SampleUniform + for<'a> std::ops::AddAssign<&'a T> + PartialOrd;
 }
 
 impl ContextRandomExt for Context {
@@ -184,7 +185,7 @@ impl ContextRandomExt for Context {
     fn sample_weighted<R: RngId + 'static, T>(&self, _rng_id: R, weights: &Vec<T>) -> usize
     where
         R::RngType: Rng,
-            T: Clone + Default + SampleUniform + for<'a> std::ops::AddAssign<&'a T> + PartialOrd
+        T: Clone + Default + SampleUniform + for<'a> std::ops::AddAssign<&'a T> + PartialOrd,
     {
         let index = WeightedIndex::new(weights).unwrap();
         let mut rng = get_rng::<R>(self);
@@ -318,5 +319,4 @@ mod test {
         let r: usize = context.sample_weighted(FooRng, &vec![0.1, 0.3, 0.4]);
         assert!(r < 3);
     }
-    
 }


### PR DESCRIPTION
A network is modeled as a directed graph.  Edges are typed in the usual fashion, i.e., keyed by a Rust type, and each person can have an arbitrary number of outgoing edges of a given type, with each edge having a weight, as in:

        context
            .add_edge::<EdgeType1>(person1, person2, 0.01);
        context
            .add_edge::<EdgeType1>(person1, person3, 0.02);

Which creates a graph where `person1` has two outgoing edges of type `EdgeType`, to `person2` and `person3`.

Edges are directional but `add_edge_bidi()` will create one edge in each direction between two people with the same weight for both edges. If you want to create edges with different weights, you have to do it separately.

Creating an edge to yourself is forbidden (returns IxaError). It is not technically possible to create an edge to a person who doesn't exist because `PersonId` is minted by `add_person()`.