### PR TITLE
Load global properties from a configuration file

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,8 @@ strum_macros = "0.26.4"
 ixa-derive = { path = "ixa-derive" }
 seq-macro = "0.3.5"
 paste = "1.0.15"
+ctor = "0.2.8"
+once_cell = "1.20.2"
 
 [dev-dependencies]
 rand_distr = "0.4.3"

--- a/src/global_properties.rs
+++ b/src/global_properties.rs
@@ -23,6 +23,7 @@ pub fn add_global_property<T: GlobalProperty>(name: &String)
 where
     for<'de> <T as GlobalProperty>::Value: serde::Deserialize<'de>,
 {
+    println!("Adding property {}", name);
     let properties = GLOBAL_PROPERTIES.lock().unwrap();
     properties.borrow_mut().insert(
         name.clone(),
@@ -62,7 +63,10 @@ macro_rules! define_global_property {
         paste::paste! {
             #[ctor::ctor]
             fn [<$global_property:snake _register>]() {
-                $crate::global_properties::add_global_property::<$global_property>(&String::from(stringify!($global_property)));
+                let mut name = String::from(module_path!());
+                name += "::";
+                name += stringify!($global_property);
+                $crate::global_properties::add_global_property::<$global_property>(&name);
             }
         }
     };
@@ -294,7 +298,7 @@ mod test {
             .join("tests/data/global_properties_missing.json");
         match context.load_global_properties(&path) {
             Err(IxaError::IxaError(msg)) => {
-                assert_eq!(msg, "No global property: Property3");
+                assert_eq!(msg, "No global property: ixa::global_properties::test::Property3");
             }
             _ => panic!("Unexpected error type"),
         }

--- a/src/global_properties.rs
+++ b/src/global_properties.rs
@@ -29,6 +29,9 @@ where
         name.clone(),
         Arc::new(|context: &mut Context, value| -> Result<(), IxaError> {
             let val: T::Value = serde_json::from_value(value)?;
+            if context.get_global_property_value(T::new()).is_some() {
+                return Err(IxaError::IxaError(format!("Duplicate property")));
+            }
             context.set_global_property_value(T::new(), val);
             Ok(())
         }),
@@ -316,4 +319,18 @@ mod test {
             _ => panic!("Unexpected error type"),
         }
     }
+
+    #[test]
+    fn read_duplicate_property() {
+        let mut context = Context::new();
+        let path = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+            .join("tests/data/global_properties_test1.json");
+        context.load_global_properties(&path).unwrap();
+        let error = context.load_global_properties(&path);
+        match error {
+            Err(IxaError::IxaError(_)) => {}
+            _ => panic!("Unexpected error type"),
+        }
+    }
+    
 }

--- a/src/global_properties.rs
+++ b/src/global_properties.rs
@@ -122,6 +122,23 @@ pub trait ContextGlobalPropertiesExt {
         file_path: &Path,
     ) -> Result<T, IxaError>;
 
+    /// Load global properties from a JSON file.
+    ///
+    /// The expected structure is a dictionary with each name being
+    /// the fully qualified name of a struct, e.g. `ixa::diseases::FluStrains`
+    /// and the value being an object which can serde deserialize into the
+    /// relevant struct.
+    ///
+    /// # Errors
+    /// Will return an `IxaError` if:
+    /// * The `file_path` doesn't exist
+    /// * The file isn't valid JSON
+    /// * A specified object doesn't correspond to an existing global property.
+    /// * There are two values for the same object.
+    ///
+    /// Ixa automatically knows about any property defined with
+    /// `define_global_property!()` so you don't need to register them
+    /// explicitly.
     fn load_global_properties(&mut self, file_name: &Path) -> Result<(), IxaError>;
 }
 

--- a/src/global_properties.rs
+++ b/src/global_properties.rs
@@ -15,30 +15,33 @@ use std::sync::Mutex;
 type PropertySetterFn =
     dyn Fn(&mut Context, &str, serde_json::Value) -> Result<(), IxaError> + Send + Sync;
 
+#[allow(clippy::type_complexity)]
 pub static GLOBAL_PROPERTIES: LazyLock<Mutex<RefCell<HashMap<String, Arc<PropertySetterFn>>>>> =
     LazyLock::new(|| Mutex::new(RefCell::new(HashMap::new())));
 
 #[allow(clippy::missing_panics_doc)]
-pub fn add_global_property<T: GlobalProperty>(name: &String)
+pub fn add_global_property<T: GlobalProperty>(name: &str)
 where
     for<'de> <T as GlobalProperty>::Value: serde::Deserialize<'de>,
 {
     let properties = GLOBAL_PROPERTIES.lock().unwrap();
     properties.borrow_mut().insert(
-        name.clone(),
-        Arc::new(|context: &mut Context, name, value| -> Result<(), IxaError> {
-            let val: T::Value = serde_json::from_value(value)?;
-            if context.get_global_property_value(T::new()).is_some() {
-                return Err(IxaError::IxaError(format!("Duplicate property {name}")));
-            }
-            context.set_global_property_value(T::new(), val);
-            Ok(())
-        }),
+        name.to_string(),
+        Arc::new(
+            |context: &mut Context, name, value| -> Result<(), IxaError> {
+                let val: T::Value = serde_json::from_value(value)?;
+                if context.get_global_property_value(T::new()).is_some() {
+                    return Err(IxaError::IxaError(format!("Duplicate property {name}")));
+                }
+                context.set_global_property_value(T::new(), val);
+                Ok(())
+            },
+        ),
     );
 }
 
 #[allow(clippy::missing_panics_doc)]
-fn get_global_property(name: &String) -> Option<Arc<PropertySetterFn>> {        
+fn get_global_property(name: &String) -> Option<Arc<PropertySetterFn>> {
     let properties = GLOBAL_PROPERTIES.lock().unwrap();
     let tmp = properties.borrow();
     match tmp.get(name) {
@@ -59,7 +62,9 @@ macro_rules! define_global_property {
         impl $crate::global_properties::GlobalProperty for $global_property {
             type Value = $value;
 
-            fn new() -> Self { $global_property }
+            fn new() -> Self {
+                $global_property
+            }
         }
 
         paste::paste! {
@@ -205,7 +210,7 @@ impl ContextGlobalPropertiesExt for Context {
             if let Some(handler) = get_global_property(&k) {
                 handler(self, &k, v)?;
             } else {
-                return Err(IxaError::from(format!("No global property: {}", k)));
+                return Err(IxaError::from(format!("No global property: {k}")));
             }
         }
 
@@ -317,7 +322,10 @@ mod test {
             .join("tests/data/global_properties_missing.json");
         match context.load_global_properties(&path) {
             Err(IxaError::IxaError(msg)) => {
-                assert_eq!(msg, "No global property: ixa::global_properties::test::Property3");
+                assert_eq!(
+                    msg,
+                    "No global property: ixa::global_properties::test::Property3"
+                );
             }
             _ => panic!("Unexpected error type"),
         }
@@ -329,7 +337,7 @@ mod test {
         let path = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
             .join("tests/data/global_properties_malformed.json");
         let error = context.load_global_properties(&path);
-        println!("Error {:?}", error);
+        println!("Error {error:?}");
         match error {
             Err(IxaError::JsonError(_)) => {}
             _ => panic!("Unexpected error type"),
@@ -348,5 +356,4 @@ mod test {
             _ => panic!("Unexpected error type"),
         }
     }
-    
 }

--- a/tests/data/global_properties_malformed.json
+++ b/tests/data/global_properties_malformed.json
@@ -1,0 +1,5 @@
+{
+  "Property1": {
+    "field_str": "test"
+  }
+}

--- a/tests/data/global_properties_malformed.json
+++ b/tests/data/global_properties_malformed.json
@@ -1,5 +1,5 @@
 {
-  "Property1": {
+  "ixa::global_properties::test::Property1": {
     "field_str": "test"
   }
 }

--- a/tests/data/global_properties_missing.json
+++ b/tests/data/global_properties_missing.json
@@ -1,0 +1,6 @@
+{
+  "Property3": {
+    "field_int": 1,
+    "field_str": "test"
+  }
+}

--- a/tests/data/global_properties_missing.json
+++ b/tests/data/global_properties_missing.json
@@ -1,5 +1,5 @@
 {
-  "Property3": {
+  "ixa::global_properties::test::Property3": {
     "field_int": 1,
     "field_str": "test"
   }

--- a/tests/data/global_properties_test1.json
+++ b/tests/data/global_properties_test1.json
@@ -1,10 +1,10 @@
 {
-  "Property1": {
+  "ixa::global_properties::test::Property1": {
     "field_int": 1,
     "field_str": "test"
   },
 
-  "Property2": {
+  "ixa::global_properties::test::Property2": {
     "field_int": 2
   }
 }

--- a/tests/data/global_properties_test1.json
+++ b/tests/data/global_properties_test1.json
@@ -1,0 +1,10 @@
+{
+  "Property1": {
+    "field_int": 1,
+    "field_str": "test"
+  },
+
+  "Property2": {
+    "field_int": 2
+  }
+}


### PR DESCRIPTION
This PR adds a facility to load arbitrary global properties from a configuration file.

The way this works is that Ixa automatically knows about all global properties defined with `define_global_property!()`, no matter which crate they are defined in. The config file is formatted as a JSON dictionary with the top-level keys being the fully qualified names of global properties, like so:

```
{
  "ixa::global_properties::test::Property1": {
    "field_int": 1,
    "field_str": "test"
  },

  "ixa::global_properties::test::Property2": {
    "field_int": 2
  }
}
```
`context.load_global_properties()` reads the file and then uses the name to find the associated global property and deserialize the associated object into the global property using serde, where it can then be accessed in the usual fashion with `get_global_property()`.

You can call `load_global_properties()` an arbitrary number of times with different files, but you can't load the same property twice, so the files can't overlap.