### PR TITLE
Report test: remove written files to working dir automatically

### DIFF
--- a/src/report.rs
+++ b/src/report.rs
@@ -242,11 +242,11 @@ mod test {
         }
     }
 
-    struct PathBuffWithDrop {
+    struct PathBufWithDrop {
         file: PathBuf,
     }
 
-    impl Drop for PathBuffWithDrop {
+    impl Drop for PathBufWithDrop {
         fn drop(&mut self) {
             std::fs::remove_file(&self.file).unwrap();
         }
@@ -266,7 +266,7 @@ mod test {
         context.send_report(report);
 
         let path = env::current_dir().unwrap();
-        let file_path = PathBuffWithDrop {
+        let file_path = PathBufWithDrop {
             file: path.join("test_prefix_sample_report.csv"),
         };
         assert!(file_path.file.exists(), "CSV file should exist");


### PR DESCRIPTION
Kate rightly pointed out that the updated test for writing a file with no directory specified could error out before the "remove file" step. Based on her suggestion, I reimplemented that step in a `Drop` trait so that it automatically happens even if the test errors out earlier.

Doing this made me catch a few places where I believe `clone` was used extraneously. However, please correct me if I am wrong.