### PR TITLE
Changed `sample_person()` to take a query

### DIFF
--- a/examples/parameter-loading/transmission_manager.rs
+++ b/examples/parameter-loading/transmission_manager.rs
@@ -13,7 +13,7 @@ define_rng!(TransmissionRng);
 
 fn attempt_infection(context: &mut Context) {
     let population_size: usize = context.get_current_population();
-    let person_to_infect = context.sample_person(TransmissionRng).unwrap();
+    let person_to_infect = context.sample_person(TransmissionRng, ()).unwrap();
     let person_status: InfectionStatusValue =
         context.get_person_property(person_to_infect, InfectionStatus);
     let parameters = context

--- a/src/people.rs
+++ b/src/people.rs
@@ -2189,7 +2189,7 @@ mod test {
        
         let mut count_p1: usize = 0;
         let mut count_p2: usize = 0;
-        for _ in 0..100 {
+        for _ in 0..10000 {
             let p = context.sample_person(SampleRng2, (Age, 10)).unwrap();
             if p == person1 {
                 count_p1 += 1;
@@ -2199,7 +2199,9 @@ mod test {
                 panic!("Unexpected person");
             }
         }
-        assert!(count_p1 >= 30);
-        assert!(count_p2 >= 30);
+
+        // The chance of being more unbalanced than this is ~10^{-4}
+        assert!(count_p1 >= 4800);
+        assert!(count_p2 >= 4800);
     } 
 }

--- a/src/people.rs
+++ b/src/people.rs
@@ -894,18 +894,13 @@ pub trait ContextPeopleExt {
     where
         F: Fn(&Context, &[String], usize);
 
-    /// Randomly sample a person from the population.
+    /// Randomly sample a person from the population of people who match the query.
     ///
-    /// This is currently implemented by sampling in `0..current_population`
-    /// but in the future we might have holes where people were removed.
-    ///
+    /// The syntax here is the same as with [`Context::query_people()`].
+    /// 
     /// # Errors
     /// Returns `IxaError` if population is 0.
-    fn sample_person<R: RngId + 'static>(&self, rng_id: R) -> Result<PersonId, IxaError>
-    where
-        R::RngType: Rng;
-
-    fn sample_matching_person<R: RngId + 'static, T: Query>(&self, rng_id: R, q: T) -> Result<PersonId, IxaError>  where R::RngType: Rng;
+    fn sample_person<R: RngId + 'static, T: Query>(&self, rng_id: R, q: T) -> Result<PersonId, IxaError>  where R::RngType: Rng;
 }
 
 fn process_indices(
@@ -1206,25 +1201,23 @@ impl ContextPeopleExt for Context {
         );
     }
 
-    fn sample_person<R: RngId + 'static>(&self, rng_id: R) -> Result<PersonId, IxaError>
-    where
-        R::RngType: Rng,
-    {
-        if self.get_current_population() == 0 {
-            return Err(IxaError::IxaError(String::from("Empty population")));
-        }
-        let result = self.sample_range(rng_id, 0..self.get_current_population());
-        Ok(PersonId { id: result })
-    }
-
-      fn sample_matching_person<R: RngId + 'static, T: Query>(&self, rng_id: R, q: T) -> Result<PersonId, IxaError>
+      fn sample_person<R: RngId + 'static, T: Query>(&self, rng_id: R, q: T) -> Result<PersonId, IxaError>
       where R::RngType: Rng {
         if self.get_current_population() == 0 {
             return Err(IxaError::IxaError(String::from("Empty population")));
         }
 
+        // Special case the empty query because we can do it in O(1).
+        if q.get_query().is_empty() {
+            let result = self.sample_range(rng_id, 0..self.get_current_population());
+            return Ok(PersonId { id: result });
+        }
+
         T::setup(self);
 
+        // This function implements "Algorithm R" from KIM-HUNG LI
+        // Reservoir-Sampling Algorithms of Time Complexity O(n(l + 10g(/V/n)))
+        // https://dl.acm.org/doi/pdf/10.1145/198429.198435
         // Temporary variables.
         let mut selected : Option<PersonId> = None;
         let mut w: f64 = 0.0;
@@ -2163,16 +2156,16 @@ mod test {
     use crate::random::{define_rng, ContextRandomExt};
 
     #[test]
-    fn test_sample_person() {
+    fn test_sample_person_simple() {
         define_rng!(SampleRng1);
         let mut context = Context::new();
         context.init_random(42);
         assert!(matches!(
-            context.sample_person(SampleRng1),
+            context.sample_person(SampleRng1, ()),
             Err(IxaError::IxaError(_))
         ));
         let person = context.add_person(()).unwrap();
-        assert_eq!(context.sample_person(SampleRng1).unwrap(), person);
+        assert_eq!(context.sample_person(SampleRng1, ()).unwrap(), person);
     }
 
     #[test]
@@ -2182,7 +2175,7 @@ mod test {
         let mut context = Context::new();
         context.init_random(42);
         assert!(matches!(
-            context.sample_person(SampleRng2),
+            context.sample_person(SampleRng2, ()),
             Err(IxaError::IxaError(_))
         ));
         let person1 = context.add_person((Age, 10)).unwrap();
@@ -2191,13 +2184,13 @@ mod test {
 
         // See that the simple query always returns person3
         for _ in 0..10 {
-          assert_eq!(context.sample_matching_person(SampleRng2, (Age, 30)).unwrap(), person3);
+          assert_eq!(context.sample_person(SampleRng2, (Age, 30)).unwrap(), person3);
         }
        
         let mut count_p1: usize = 0;
         let mut count_p2: usize = 0;
         for _ in 0..100 {
-            let p = context.sample_matching_person(SampleRng2, (Age, 10)).unwrap();
+            let p = context.sample_person(SampleRng2, (Age, 10)).unwrap();
             if p == person1 {
                 count_p1 += 1;
             } else if p == person2 {

--- a/src/people.rs
+++ b/src/people.rs
@@ -1253,7 +1253,7 @@ impl ContextPeopleExt for Context {
 
         match selected {
             Some(person) => Ok(person),
-            None => Err(IxaError::IxaError(String::from("No matching people"))) 
+            None => Err(IxaError::IxaError(String::from("No matching people"))),
         }
     }
 }
@@ -2207,7 +2207,7 @@ mod test {
             context.sample_person(SampleRng2, (Age, 50)),
             Err(IxaError::IxaError(_))
         ));
-        
+
         // See that the simple query always returns person3
         for _ in 0..10 {
             assert_eq!(

--- a/src/people.rs
+++ b/src/people.rs
@@ -1251,10 +1251,7 @@ impl ContextPeopleExt for Context {
             query.get_query(),
         );
 
-        match selected {
-            Some(person) => Ok(person),
-            None => Err(IxaError::IxaError(String::from("No matching people"))),
-        }
+        selected.ok_or(IxaError::IxaError(String::from("No matching people")))
     }
 }
 

--- a/src/random.rs
+++ b/src/random.rs
@@ -12,7 +12,7 @@ use std::collections::HashMap;
 #[macro_export]
 macro_rules! define_rng {
     ($random_id:ident) => {
-        #[derive(Copy,Clone)]
+        #[derive(Copy, Clone)]
         struct $random_id;
 
         impl $crate::random::RngId for $random_id {
@@ -35,7 +35,7 @@ macro_rules! define_rng {
 }
 pub use define_rng;
 
-pub trait RngId : Copy + Clone {
+pub trait RngId: Copy + Clone {
     type RngType: SeedableRng;
     fn get_name() -> &'static str;
 }

--- a/src/random.rs
+++ b/src/random.rs
@@ -12,6 +12,7 @@ use std::collections::HashMap;
 #[macro_export]
 macro_rules! define_rng {
     ($random_id:ident) => {
+        #[derive(Copy,Clone)]
         struct $random_id;
 
         impl $crate::random::RngId for $random_id {
@@ -34,7 +35,7 @@ macro_rules! define_rng {
 }
 pub use define_rng;
 
-pub trait RngId {
+pub trait RngId : Copy + Clone {
     type RngType: SeedableRng;
     fn get_name() -> &'static str;
 }


### PR DESCRIPTION
The original `sample_person()` would query over the entire population. With this change you can provide a `query_people()` style query and it will sample over the matching subset.

For whole-population queries, we just draw a random value from the population size.

For subset queries, to avoid allocating a vector with all the matching people, this uses the efficient Reservoir Sampling algorithm published by Kim-Hung Li.