### PR TITLE
Initial rustyline integration. Fixes #126

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ ctor = "0.2.8"
 once_cell = "1.20.2"
 clap = { version = "4.5.21", features = ["derive"] }
 shlex = "1.3.0"
+rustyline = "15.0.0"
 
 [dev-dependencies]
 rand_distr = "0.4.3"

--- a/src/debugger.rs
+++ b/src/debugger.rs
@@ -170,8 +170,8 @@ fn start_debugger(context: &mut Context) -> Result<(), IxaError> {
     loop {
         let line = match rl.readline(&format!("t={t} $ ")) {
             Ok(line) => line,
-            Err(rustyline::error::ReadlineError::WindowResized)
-            | Err(rustyline::error::ReadlineError::Interrupted) => continue,
+            Err(rustyline::error::ReadlineError::WindowResized
+                | rustyline::error::ReadlineError::Interrupted) => continue,
             Err(rustyline::error::ReadlineError::Eof) => return Ok(()),
             Err(err) => return Err(IxaError::IxaError(format!("Read error: {err}"))),
         };

--- a/src/debugger.rs
+++ b/src/debugger.rs
@@ -171,7 +171,7 @@ fn start_debugger(context: &mut Context) -> Result<(), IxaError> {
         let line = match rl.readline(&format!("t={t} $ ")) {
             Ok(line) => line,
             Err(rustyline::error::ReadlineError::WindowResized) => continue,
-            Err(err) => return Err(IxaError::IxaError(format!("Read error: {}", err))),
+            Err(err) => return Err(IxaError::IxaError(format!("Read error: {err}"))),
         };
         rl.add_history_entry(line.clone())
             .expect("Should be able to add to input");

--- a/src/debugger.rs
+++ b/src/debugger.rs
@@ -170,8 +170,8 @@ fn start_debugger(context: &mut Context) -> Result<(), IxaError> {
     loop {
         let line = match rl.readline(&format!("t={t} $ ")) {
             Ok(line) => line,
-            Err(rustyline::error::ReadlineError::WindowResized) => continue,
-            Err(rustyline::error::ReadlineError::Interrupted) => continue,
+            Err(rustyline::error::ReadlineError::WindowResized)
+            | Err(rustyline::error::ReadlineError::Interrupted) => continue,
             Err(rustyline::error::ReadlineError::Eof) => return Ok(()),
             Err(err) => return Err(IxaError::IxaError(format!("Read error: {err}"))),
         };

--- a/src/debugger.rs
+++ b/src/debugger.rs
@@ -170,8 +170,10 @@ fn start_debugger(context: &mut Context) -> Result<(), IxaError> {
     loop {
         let line = match rl.readline(&format!("t={t} $ ")) {
             Ok(line) => line,
-            Err(rustyline::error::ReadlineError::WindowResized
-                | rustyline::error::ReadlineError::Interrupted) => continue,
+            Err(
+                rustyline::error::ReadlineError::WindowResized
+                | rustyline::error::ReadlineError::Interrupted,
+            ) => continue,
             Err(rustyline::error::ReadlineError::Eof) => return Ok(()),
             Err(err) => return Err(IxaError::IxaError(format!("Read error: {err}"))),
         };

--- a/src/debugger.rs
+++ b/src/debugger.rs
@@ -3,10 +3,10 @@ use crate::ContextPeopleExt;
 use crate::IxaError;
 use clap::value_parser;
 use clap::{Arg, ArgMatches, Command};
+use rustyline;
 use std::cell::RefCell;
 use std::collections::HashMap;
 use std::io::Write;
-use rustyline;
 
 trait DebuggerCommand {
     /// Handle the command and any inputs; returning true will exit the debugger
@@ -168,13 +168,13 @@ fn start_debugger(context: &mut Context) -> Result<(), IxaError> {
     println!("Debugging simulation at t={t}");
     let mut rl = rustyline::DefaultEditor::new().unwrap();
     loop {
-        let line = 
-        match rl.readline(&format!("t={t} $ ")) {
+        let line = match rl.readline(&format!("t={t} $ ")) {
             Ok(line) => line,
             Err(rustyline::error::ReadlineError::WindowResized) => continue,
             Err(err) => return Err(IxaError::IxaError(format!("Read error: {}", err))),
         };
-        rl.add_history_entry(line.clone()).expect("Should be able to add to input");
+        rl.add_history_entry(line.clone())
+            .expect("Should be able to add to input");
         let line = line.trim();
         if line.is_empty() {
             continue;

--- a/src/debugger.rs
+++ b/src/debugger.rs
@@ -171,6 +171,8 @@ fn start_debugger(context: &mut Context) -> Result<(), IxaError> {
         let line = match rl.readline(&format!("t={t} $ ")) {
             Ok(line) => line,
             Err(rustyline::error::ReadlineError::WindowResized) => continue,
+            Err(rustyline::error::ReadlineError::Interrupted) => continue,
+            Err(rustyline::error::ReadlineError::Eof) => return Ok(()),
             Err(err) => return Err(IxaError::IxaError(format!("Read error: {err}"))),
         };
         rl.add_history_entry(line.clone())


### PR DESCRIPTION
This adds support for history editing via rustyline.

Before we land this, we should address the behavior under the following conditions:

* Ctrl-D -- usually end of data
* Ctrl-C -- usually interrupt

In the current code prior to this PR, C-c causes termination and C-d causes the prompt to reprint. By contrast, here is LLDB

```
20:52:35|~/dev/cfa/ixa (ekr_issue126_rustylines)$ lldb
(lldb) ^D
20:52:41|~/dev/cfa/ixa (ekr_issue126_rustylines)$ lldb
(lldb) ^C
(lldb) ^C
(lldb)
```

In 