### PR TITLE
Debugger should use an internal debugger API for setting breakpoints

### DIFF
--- a/examples/cli-debugger/main.rs
+++ b/examples/cli-debugger/main.rs
@@ -1,0 +1,46 @@
+use ixa::runner::run_with_args;
+use ixa::{
+    define_person_property, define_person_property_with_default, ContextPeopleExt,
+    PersonPropertyChangeEvent,
+};
+
+define_person_property_with_default!(IsRunner, bool, false);
+
+// Using run_with_args / run_with_custom_args will parse command line options, including
+// the --debugger interface.
+// Try:
+// cargo run --example cli-debugger -- --debugger      Starts the debugger before
+//                                                     the simulation starts executing.
+// cargo run --example cli-debugger -- --debugger 2.0  Pauses the simulation after all plans
+//                                                     have executed for t=2.0
+//
+// When the debugger is open, type 'help' to see some options.
+// Try typing `next` to step through each callback in this simulation
+// (two plans, and an event listener when the status of a person changes)
+fn main() {
+    run_with_args(|context, _, _| {
+        context.subscribe_to_event(|context, event: PersonPropertyChangeEvent<IsRunner>| {
+            if !event.previous && event.current {
+                println!(
+                    "{} became a runner at t={}",
+                    event.person_id,
+                    context.get_current_time()
+                );
+            }
+        });
+
+        context.add_plan(2.0, |context| {
+            println!("Adding person at t=2");
+            let p1 = context.add_person(()).unwrap();
+
+            context.add_plan(2.0, move |context| {
+                println!("Change runner status, add another person at t=2");
+                context.set_person_property(p1, IsRunner, true);
+                context.add_person(()).unwrap();
+            });
+        });
+
+        Ok(())
+    })
+    .unwrap();
+}

--- a/src/context.rs
+++ b/src/context.rs
@@ -9,7 +9,7 @@ use std::{
 };
 
 use crate::{
-    debugger::ContextDebugExt,
+    debugger::{start_debugger, ContextDebugExt},
     plan::{Id, Queue},
 };
 
@@ -275,6 +275,8 @@ impl Context {
     }
 
     /// Execute the simulation until the plan and callback queues are empty
+    /// # Panics
+    /// Panics as the result of a callback or if a problem happens during debugging
     pub fn execute(&mut self) {
         // Start plan loop
         loop {
@@ -285,7 +287,7 @@ impl Context {
             // If there's a breakpoint, pause before continuing execution
             if self.breakpoint_requested() {
                 self.clear_breakpoint();
-                self.start_debugger();
+                start_debugger(self).unwrap();
             }
 
             // If there is a callback, run it.

--- a/src/context.rs
+++ b/src/context.rs
@@ -8,7 +8,10 @@ use std::{
     rc::Rc,
 };
 
-use crate::plan::{Id, Queue};
+use crate::{
+    debugger::ContextDebugExt,
+    plan::{Id, Queue},
+};
 
 /// The common callback used by multiple `Context` methods for future events
 type Callback = dyn FnOnce(&mut Context);
@@ -277,6 +280,12 @@ impl Context {
         loop {
             if self.shutdown_requested {
                 break;
+            }
+
+            // If there's a breakpoint, pause before continuing execution
+            if self.breakpoint_requested() {
+                self.clear_breakpoint();
+                self.start_debugger();
             }
 
             // If there is a callback, run it.

--- a/src/debugger.rs
+++ b/src/debugger.rs
@@ -189,8 +189,8 @@ fn readline(t: f64) -> Result<String, String> {
     Ok(buffer)
 }
 
-/// Starts the debugger and pauses execution
-fn start_debugger(context: &mut Context) -> Result<(), IxaError> {
+// Used internally to start the debugger and pause execution
+pub(crate) fn start_debugger(context: &mut Context) -> Result<(), IxaError> {
     let t = context.get_current_time();
     let repl = build_repl(std::io::stdout());
     println!("DEBUGGER: Simulation Paused");
@@ -217,7 +217,8 @@ fn start_debugger(context: &mut Context) -> Result<(), IxaError> {
 }
 
 pub trait ContextDebugExt {
-    /// Schedule the simulation to pause at time t and start the debugger.
+    /// Schedule the simulation to pause at the end of time t
+    /// (`ExecutionPhase::Last`) and start the debugger.
     /// This will give you a REPL which allows you to inspect the state of
     /// the simulation (type help to see a list of commands)
     ///
@@ -226,19 +227,17 @@ pub trait ContextDebugExt {
     /// errors in Ixa are printed to stdout
     fn schedule_debugger(&mut self, t: f64);
 
+    /// Is a breakpoint currently requested?
     fn breakpoint_requested(&self) -> bool;
 
+    /// Sets the breakpoint flag to true
     fn set_breakpoint(&mut self);
 
+    /// Sets the breakpoint flag to false
     fn clear_breakpoint(&mut self);
-
-    fn start_debugger(&mut self);
 }
 
 impl ContextDebugExt for Context {
-    fn start_debugger(&mut self) {
-        start_debugger(self).expect("Error in debugger");
-    }
     fn breakpoint_requested(&self) -> bool {
         let d = self.get_data_container(DebuggerDataPlugin);
         if d.is_none() {

--- a/src/debugger.rs
+++ b/src/debugger.rs
@@ -193,7 +193,7 @@ fn readline(t: f64) -> Result<String, String> {
 fn start_debugger(context: &mut Context) -> Result<(), IxaError> {
     let t = context.get_current_time();
     let repl = build_repl(std::io::stdout());
-    println!("Debugging simulation at t={t}");
+    println!("DEBUGGER: Simulation Paused");
     loop {
         let line = readline(t).expect("Error reading input");
         let line = line.trim();


### PR DESCRIPTION
Rather than just adding a plan, I updated the debugger to be triggered separately from other plans; this makes it possible to actually step through each callback with`next`.

To support setting a breakpoint at `t`, I use `ExecutionPhase:Last`, which triggers on the next loop. I could alternatively create a new phase (for debugging) or a separate time queue altogether... curious if others have thoughts