### PR TITLE
Some changes to make the debugger more flexible

### DIFF
--- a/src/debugger.rs
+++ b/src/debugger.rs
@@ -43,7 +43,7 @@ impl Debugger {
         let args = shlex::split(l).ok_or("Error splitting lines")?;
         let matches = self
             .cli
-            .clone()
+            .clone() // cli can only be used once.
             .try_get_matches_from(args)
             .map_err(|e| e.to_string())?;
 

--- a/src/debugger.rs
+++ b/src/debugger.rs
@@ -1,10 +1,11 @@
+use crate::define_data_plugin;
 use crate::Context;
 use crate::ContextPeopleExt;
 use crate::IxaError;
 use clap::value_parser;
 use clap::{Arg, ArgMatches, Command};
 use rustyline;
-use std::cell::RefCell;
+
 use std::collections::HashMap;
 use std::io::Write;
 
@@ -21,33 +22,15 @@ trait DebuggerCommand {
     }
 }
 
-struct DebuggerRepl {
+struct Debugger {
+    cli: Command,
     commands: HashMap<&'static str, Box<dyn DebuggerCommand>>,
-    output: RefCell<Box<dyn Write>>,
 }
+define_data_plugin!(DebuggerPlugin, Option<Debugger>, None);
 
-impl DebuggerRepl {
-    fn new(output: Box<dyn Write>) -> Self {
-        DebuggerRepl {
-            commands: HashMap::new(),
-            output: RefCell::new(output),
-        }
-    }
-
-    fn register_command(&mut self, name: &'static str, handler: Box<dyn DebuggerCommand>) {
-        self.commands.insert(name, handler);
-    }
-
+impl Debugger {
     fn get_command(&self, name: &str) -> Option<&dyn DebuggerCommand> {
         self.commands.get(name).map(|command| &**command)
-    }
-
-    fn writeln(&self, formatted_string: &str) {
-        let mut output = self.output.borrow_mut();
-        writeln!(output, "{formatted_string}")
-            .map_err(|e| e.to_string())
-            .unwrap();
-        output.flush().unwrap();
     }
 
     fn build_cli(&self) -> Command {
@@ -70,21 +53,23 @@ impl DebuggerRepl {
         cli
     }
 
-    fn process_line(&self, l: &str, context: &mut Context) -> Result<bool, String> {
+    fn process_line(
+        &self,
+        l: &str,
+        context: &mut Context,
+    ) -> Result<(bool, Option<String>), String> {
         let args = shlex::split(l).ok_or("Error splitting lines")?;
         let matches = self
-            .build_cli()
+            .cli
+            .clone()
             .try_get_matches_from(args)
             .map_err(|e| e.to_string())?;
 
         if let Some((command, sub_matches)) = matches.subcommand() {
             // If the provided command is known, run its handler
+
             if let Some(handler) = self.get_command(command) {
-                let (quit, output) = handler.handle(context, sub_matches)?;
-                if let Some(output) = output {
-                    self.writeln(&output);
-                }
-                return Ok(quit);
+                return handler.handle(context, sub_matches);
             }
             // Unexpected command: print an error
             return Err(format!("Unknown command: {command}"));
@@ -151,20 +136,44 @@ impl DebuggerCommand for ContinueCommand {
 }
 
 // Assemble all the commands
-fn build_repl<W: Write + 'static>(output: W) -> DebuggerRepl {
-    let mut repl = DebuggerRepl::new(Box::new(output));
+fn init(context: &mut Context) {
+    let debugger = context.get_data_container_mut(DebuggerPlugin);
 
-    repl.register_command("population", Box::new(PopulationCommand));
-    repl.register_command("next", Box::new(NextCommand));
-    repl.register_command("continue", Box::new(ContinueCommand));
+    if debugger.is_none() {
+        let mut commands: HashMap<&'static str, Box<dyn DebuggerCommand>> = HashMap::new();
+        commands.insert("population", Box::new(PopulationCommand));
+        commands.insert("next", Box::new(NextCommand));
+        commands.insert("continue", Box::new(ContinueCommand));
 
-    repl
+        let mut cli = Command::new("repl")
+            .multicall(true)
+            .arg_required_else_help(true)
+            .subcommand_required(true)
+            .subcommand_value_name("DEBUGGER")
+            .subcommand_help_heading("IXA DEBUGGER")
+            .help_template("{all-args}");
+
+        for (name, handler) in &commands {
+            let subcommand =
+                handler.extend(Command::new(name).about(handler.about()).help_template(
+                    "{about-with-newline}\n{usage-heading}\n    {usage}\n\n{all-args}{after-help}",
+                ));
+            cli = cli.subcommand(subcommand);
+        }
+        *debugger = Some(Debugger { cli, commands });
+    }
 }
 
 /// Starts the debugger and pauses execution
 fn start_debugger(context: &mut Context) -> Result<(), IxaError> {
+    init(context);
     let t = context.get_current_time();
-    let repl = build_repl(std::io::stdout());
+
+    // Temporarily take the data container out of context so that
+    // we can operate on context.
+    let data_container = context.get_data_container_mut(DebuggerPlugin);
+    let debugger = data_container.take().unwrap();
+
     println!("Debugging simulation at t={t}");
     let mut rl = rustyline::DefaultEditor::new().unwrap();
     loop {
@@ -184,10 +193,14 @@ fn start_debugger(context: &mut Context) -> Result<(), IxaError> {
             continue;
         }
 
-        match repl.process_line(line, context) {
-            Ok(quit) => {
+        match debugger.process_line(line, context) {
+            Ok((quit, message)) => {
                 if quit {
                     break;
+                }
+                if let Some(message) = message {
+                    write!(std::io::stdout(), "{message}");
+                    std::io::stdout().flush().unwrap();
                 }
             }
             Err(err) => {
@@ -196,6 +209,10 @@ fn start_debugger(context: &mut Context) -> Result<(), IxaError> {
             }
         }
     }
+
+    // Put the debugger back into context.
+    let data_container = context.get_data_container_mut(DebuggerPlugin);
+    *data_container = Some(debugger);
     Ok(())
 }
 
@@ -220,38 +237,21 @@ impl ContextDebugExt for Context {
 
 #[cfg(test)]
 mod tests {
+    use super::{init, DebuggerPlugin};
     use crate::{Context, ContextPeopleExt};
-    use std::{cell::RefCell, io::Write, rc::Rc};
 
-    use super::build_repl;
+    fn process_line(line: &str, context: &mut Context) -> (bool, Option<String>) {
+        // Temporarily take the data container out of context so that
+        // we can operate on context.
+        init(context);
+        let data_container = context.get_data_container_mut(DebuggerPlugin);
+        let debugger = data_container.take().unwrap();
 
-    #[derive(Clone)]
-    struct StdoutMock {
-        storage: Rc<RefCell<Vec<u8>>>,
-    }
+        let res = debugger.process_line(line, context).unwrap();
 
-    impl StdoutMock {
-        fn new() -> Self {
-            StdoutMock {
-                storage: Rc::new(RefCell::new(Vec::new())),
-            }
-        }
-        fn into_inner(self) -> Vec<u8> {
-            Rc::try_unwrap(self.storage)
-                .expect("Multiple references to storage")
-                .into_inner()
-        }
-        fn into_string(self) -> String {
-            String::from_utf8(self.into_inner()).unwrap()
-        }
-    }
-    impl Write for StdoutMock {
-        fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
-            self.storage.borrow_mut().write(buf)
-        }
-        fn flush(&mut self) -> std::io::Result<()> {
-            self.storage.borrow_mut().flush()
-        }
+        let data_container = context.get_data_container_mut(DebuggerPlugin);
+        *data_container = Some(debugger);
+        res
     }
 
     #[test]
@@ -272,21 +272,16 @@ mod tests {
         context.add_person(()).unwrap();
         context.add_person(()).unwrap();
 
-        let output = StdoutMock::new();
-        let repl = build_repl(output.clone());
-        let quits = repl.process_line("population\n", context).unwrap();
-        assert!(!quits, "should not exit");
+        let (quits, output) = process_line("population\n", context);
 
-        drop(repl);
-        assert!(output.into_string().contains('2'));
+        assert!(!quits, "should not exit");
+        assert!(output.unwrap().contains('2'));
     }
 
     #[test]
     fn test_cli_continue() {
         let context = &mut Context::new();
-        let output = StdoutMock::new();
-        let repl = build_repl(output.clone());
-        let quits = repl.process_line("continue\n", context).unwrap();
+        let (quits, _) = process_line("continue\n", context);
         assert!(quits, "should exit");
     }
 
@@ -294,9 +289,7 @@ mod tests {
     fn test_cli_next() {
         let context = &mut Context::new();
         assert_eq!(context.remaining_plan_count(), 0);
-        let output = StdoutMock::new();
-        let repl = build_repl(output.clone());
-        let quits = repl.process_line("next 2\n", context).unwrap();
+        let (quits, _) = process_line("next 2\n", context);
         assert!(quits, "should exit");
         assert_eq!(
             context.remaining_plan_count(),

--- a/src/debugger.rs
+++ b/src/debugger.rs
@@ -33,26 +33,6 @@ impl Debugger {
         self.commands.get(name).map(|command| &**command)
     }
 
-    fn build_cli(&self) -> Command {
-        let mut cli = Command::new("repl")
-            .multicall(true)
-            .arg_required_else_help(true)
-            .subcommand_required(true)
-            .subcommand_value_name("DEBUGGER")
-            .subcommand_help_heading("IXA DEBUGGER")
-            .help_template("{all-args}");
-
-        for (name, handler) in &self.commands {
-            let subcommand =
-                handler.extend(Command::new(*name).about(handler.about()).help_template(
-                    "{about-with-newline}\n{usage-heading}\n    {usage}\n\n{all-args}{after-help}",
-                ));
-            cli = cli.subcommand(subcommand);
-        }
-
-        cli
-    }
-
     fn process_line(
         &self,
         l: &str,
@@ -135,7 +115,7 @@ impl DebuggerCommand for ContinueCommand {
     }
 }
 
-// Assemble all the commands
+// Build the debugger context.
 fn init(context: &mut Context) {
     let debugger = context.get_data_container_mut(DebuggerPlugin);
 
@@ -199,7 +179,7 @@ fn start_debugger(context: &mut Context) -> Result<(), IxaError> {
                     break;
                 }
                 if let Some(message) = message {
-                    write!(std::io::stdout(), "{message}");
+                    let _ = write!(std::io::stdout(), "{message}");
                     std::io::stdout().flush().unwrap();
                 }
             }


### PR DESCRIPTION
- Add persistent state (mostly for rustyline support)
- Have `process_command()` (formerly `process_line()`) return a string rather than try to write to `T: Write`.
- Remove the mocks that were needed for testing because of the previous item