### PR TITLE
Add global command to the debugger

### DIFF
--- a/examples/runner/main.rs
+++ b/examples/runner/main.rs
@@ -1,6 +1,6 @@
 use clap::Args;
 use ixa::runner::run_with_custom_args;
-use ixa::ContextPeopleExt;
+use ixa::{define_global_property, ContextGlobalPropertiesExt, ContextPeopleExt};
 
 #[derive(Args, Debug)]
 struct CustomArgs {
@@ -17,6 +17,8 @@ struct CustomArgs {
     #[arg(short = 'p', long)]
     starting_population: Option<u8>,
 }
+
+define_global_property!(Name, String);
 
 fn main() {
     // The runner reads arguments from the command line.
@@ -38,6 +40,10 @@ fn main() {
         if custom_args.say_hello {
             println!("Hello");
         }
+
+        context.set_global_property_value(Name, "Sim123".to_string())?;
+
+        println!("Name: {}", context.get_global_property_value(Name).unwrap());
 
         if let Some(population) = custom_args.starting_population {
             for _ in 0..population {

--- a/src/debugger-commands.md
+++ b/src/debugger-commands.md
@@ -1,0 +1,218 @@
+# Ixa Debugger Commands
+
+The Ixa Debugger is a command line interface for pausing execution of a
+simulation, reading information about its current state, and possibly manipulating
+it. This document proposes a high-level grammar and initial set of commands
+we should make available in the REPL, as well as a brief description of the
+implementation of commands.
+
+## General structure
+
+Commands in the Ixa Debugger follow a hierarchical format composed
+of a primary command, subcommands, and arguments:
+
+```
+<primary_command> [<subcommand>] [--<argument>[=][<value>] [<positional_argument>]]
+```
+
+Where:
+- `<primary_command>` is the top-level command category (e.g., `breakpoint`, `global`, `query`, `people`).
+- `[<subcommand>]` specifies an action to perform (e.g., `set`, `get`, `list`, `delete`).
+- `[<positional_argument>]` may be used to provide necessary inputs (e.g., the name of a property)
+- `[--<argument>[=][<value>]]` represents named options that modify behavior, or provide additional inputs
+
+Individual commands define which components are optional or required; for example, a people
+command might require an `--id` argument but optionally take a set of properties.
+
+## Command Categories
+
+In addition to some control flow commands (`next`, `continue`, `help`), we
+might consider the following commands:
+
+### 1. Breakpoints
+Commands related to setting, listing, and removing execution breakpoints.
+Note that this will require storing some internal state.
+
+- **`breakpoint set <t>]`**
+
+  Set a breakpoint a given time
+
+  Example: `breakpoint set 4.0`
+
+- **`breakpoint list`**
+
+  List all active breakpoints.
+
+- **`breakpoint delete <id> [--all]`**
+
+  Delete the breakpoint with the specified id.
+  Providing the `--all` option removes all breakpoints.
+
+  Example: `breakpoint delete 1`
+
+### 2. Globals
+Commands for managing global properties in the simulation.
+
+- **`global get <name>`**
+
+  Retrieve the value of the specified global property by full-qualified name.
+
+  Example: `global get ixa.Foo`
+
+- **`global set <name>=<value>`**
+
+  Set the specified global variable to a value.
+
+  Example: `global set ixa.Foo=42`
+
+- **`global unset <name>`**
+
+  Remove the value for a specified global property.
+
+  Example: `global unset Foo`
+
+- **`global list`**
+
+  List all global properties.
+
+- **`global list --prefix <prefix>`**
+
+  List all global variables with the specified prefix.
+
+  Example: `global list --prefix ixa.`
+
+
+### 3. People
+Commands for retrieving and modifying information about entities in the simulation.
+
+- **`people get --id <person_id> [--property <property>]`**
+
+  Retrieve all known properties of the specified person.
+  If the `--property` option is included, only the value that property will be returned.
+
+  Example: `people get --id 42`
+
+- **`people get --properties <property_list>`**
+
+  Retrieve people matching the specified property list
+
+  Example: `people get --properties Region=CA,RiskCategory=High`
+
+- **`people get --query <query_id>`**
+
+  Retrieve people based on the id of a previously saved query (see below).
+
+  Example: `people get --query 1`
+
+- **`people set --id <person_id> --property <property_name>=<value>`**
+
+  Set the specified property of a person.
+
+  Example: `people set --id 42 --property Region=CA`
+
+- **`people add <k=v>`**
+
+  Add a new person to the simulation with specified properties if required.
+
+  Example: `people add Age=12,Risk=High`
+
+- **`people query set <p>`**
+
+  Define a saved query in the debugger with the specified property/value pairs.
+
+  Example:
+  ```
+  query set Region=CA,RiskCategory=High
+  > Created people query: 1
+  ```
+
+- **`people query get <id>`**
+
+  Print the property/value pairs for a pre-saved query
+
+  Example:
+
+  ```
+  query get 1
+  > Region=CA,Risk=High
+  ```
+
+- **`people query list`**
+
+  List all saved queries.
+
+
+- **`people query delete <id>`**
+
+  Delete the query with the specified id.
+
+  Example: `query delete 1`
+
+## Implementation
+
+Commands are implemented as structs that are dynamically registered to a `clap`
+program (the `DebuggerRepl`) given some name (e.g., `"global"`).
+
+Given the following structure:
+
+```
+<primary_command> [<subcommand>] [--<argument>[=][<value>]] [<positional_argument>]
+```
+
+Each primary command defines the following (via the `DebuggerCommand` trait):
+
+- Some help text to display when the `help` command is called
+- A method to extend it with subcommands and arguments
+- A handler that receives a reference to subcommands/arguments and the current
+  `Context` for the simulation, and must return whether (1) the command exits
+  the debugger, and (2) some output to display.
+
+As an example:
+
+```rust
+struct GlobalPropertyCommand;
+impl DebuggerCommand for GlobalPropertyCommand {
+    fn about(&self) -> &'static str {
+        "Get the value for a global property"
+    }
+    fn extend(&self, subcommand: Command) -> Command {
+        subcommand
+            .subcommand_required(true)
+            .subcommand(
+              Command::new("list").about("List all global properties"))
+            .subcommand(
+                Command::new("get")
+                    .about("Get the value of a global property")
+                    .arg(
+                        Arg::new("property")
+                            .help("The name of the global property")
+                            .value_parser(value_parser!(String))
+                            .required(true),
+                    ),
+            )
+    }
+    fn handle(
+        &self,
+        context: &mut Context,
+        matches: &ArgMatches,
+    ) -> Result<(bool, Option<String>), String> {
+        match matches.subcommand() {
+            Some(("list", _)) => Ok((false, Some(available_properties_str(context)))),
+            Some(("get", m)) => {
+                let name = m.get_one::<String>("property").unwrap();
+                let output = context.get_serialized_value_by_string(name);
+                if output.is_err() {
+                    return Ok((false, output.err().map(|e| e.to_string())));
+                }
+                match output.unwrap() {
+                    Some(value) => Ok((false, Some(value))),
+                    None => Ok((false, Some(format!("Property {name} is not set")))),
+                }
+            }
+            // This is required by the compiler will never get hit because
+            // .subcommand_required(true) is set in extend
+            _ => unimplemented!("subcommand required"),
+        }
+    }
+}
+```

--- a/src/debugger.rs
+++ b/src/debugger.rs
@@ -1,6 +1,7 @@
 use crate::context::run_with_plugin;
 use crate::define_data_plugin;
 use crate::Context;
+use crate::ContextGlobalPropertiesExt;
 use crate::ContextPeopleExt;
 use crate::IxaError;
 use clap::value_parser;
@@ -77,6 +78,61 @@ impl DebuggerCommand for PopulationCommand {
     }
 }
 
+/// Helper function for displaying properties
+fn available_properties_str(context: &Context) -> String {
+    let properties = context.list_registered_global_properties();
+    format!(
+        "{} global properties registered:\n{}",
+        properties.len(),
+        properties.join("\n")
+    )
+}
+
+struct GlobalPropertyCommand;
+impl DebuggerCommand for GlobalPropertyCommand {
+    fn about(&self) -> &'static str {
+        "Get the value for a global property"
+    }
+    fn extend(&self, subcommand: Command) -> Command {
+        subcommand
+            .subcommand_required(true)
+            .subcommand(Command::new("list").about("List all global properties"))
+            .subcommand(
+                Command::new("get")
+                    .about("Get the value of a global property")
+                    .arg(
+                        Arg::new("property")
+                            .help("The name of the global property")
+                            .value_parser(value_parser!(String))
+                            .required(true),
+                    ),
+            )
+    }
+    fn handle(
+        &self,
+        context: &mut Context,
+        matches: &ArgMatches,
+    ) -> Result<(bool, Option<String>), String> {
+        match matches.subcommand() {
+            Some(("list", _)) => Ok((false, Some(available_properties_str(context)))),
+            Some(("get", m)) => {
+                let name = m.get_one::<String>("property").unwrap();
+                let output = context.get_serialized_value_by_string(name);
+                if output.is_err() {
+                    return Ok((false, output.err().map(|e| e.to_string())));
+                }
+                match output.unwrap() {
+                    Some(value) => Ok((false, Some(value))),
+                    None => Ok((false, Some(format!("Property {name} is not set")))),
+                }
+            }
+            // This is required by the compiler will never get hit because
+            // .subcommand_required(true) is set in extend
+            _ => unimplemented!("subcommand required"),
+        }
+    }
+}
+
 /// Adds a new debugger breakpoint at t
 struct NextCommand;
 impl DebuggerCommand for NextCommand {
@@ -126,6 +182,7 @@ fn init(context: &mut Context) {
         commands.insert("population", Box::new(PopulationCommand));
         commands.insert("next", Box::new(NextCommand));
         commands.insert("continue", Box::new(ContinueCommand));
+        commands.insert("global", Box::new(GlobalPropertyCommand));
 
         let mut cli = Command::new("repl")
             .multicall(true)
@@ -222,6 +279,7 @@ impl ContextDebugExt for Context {
 mod tests {
     use super::{init, DebuggerPlugin};
     use crate::{Context, ContextPeopleExt};
+    use crate::{define_global_property, ContextGlobalPropertiesExt};
 
     fn process_line(line: &str, context: &mut Context) -> (bool, Option<String>) {
         // Temporarily take the data container out of context so that
@@ -231,11 +289,13 @@ mod tests {
         let debugger = data_container.take().unwrap();
 
         let res = debugger.process_command(line, context).unwrap();
-
         let data_container = context.get_data_container_mut(DebuggerPlugin);
         *data_container = Some(debugger);
         res
     }
+
+    define_global_property!(FooGlobal, String);
+    define_global_property!(BarGlobal, u32);
 
     #[test]
     fn test_cli_debugger_integration() {
@@ -259,6 +319,65 @@ mod tests {
 
         assert!(!quits, "should not exit");
         assert!(output.unwrap().contains('2'));
+    }
+
+    #[test]
+    fn test_cli_debugger_global_list() {
+        let context = &mut Context::new();
+        let (_quits, output) = process_line("global list\n", context);
+        let expected = format!(
+            "{} global properties registered:",
+            context.list_registered_global_properties().len()
+        );
+        // Note: the global property names are also listed as part of the output
+        assert!(output.unwrap().contains(&expected));
+    }
+
+    #[test]
+    fn test_cli_debugger_global_no_args() {
+        let input = "global get\n";
+        let context = &mut Context::new();
+        init(context);
+        let data_container = context.get_data_container_mut(DebuggerPlugin);
+        let debugger = data_container.take().unwrap();
+
+        let result = debugger.process_command(input, context);
+        let data_container = context.get_data_container_mut(DebuggerPlugin);
+        *data_container = Some(debugger);
+
+        assert!(result.is_err());
+        assert!(result
+            .unwrap_err()
+            .contains("required arguments were not provided"));
+    }
+
+    #[test]
+    fn test_cli_debugger_global_get_unregistered_prop() {
+        let context = &mut Context::new();
+        let (_quits, output) = process_line("global get NotExist\n", context);
+        assert_eq!(
+            output.unwrap(),
+            "Error: IxaError(\"No global property: NotExist\")"
+        );
+    }
+
+    #[test]
+    fn test_cli_debugger_global_get_registered_prop() {
+        let context = &mut Context::new();
+        context.set_global_property_value(FooGlobal, "hello".to_string()).unwrap();
+        let (_quits, output) = process_line("global get ixa.FooGlobal\n", context);
+        assert_eq!( output.unwrap(), "\"hello\"");
+    }
+
+    #[test]
+    fn test_cli_debugger_global_get_empty_prop() {
+        define_global_property!(EmptyGlobal, String);
+        let context = &mut Context::new();
+        let (_quits, output) = process_line("global get ixa.EmptyGlobal\n", context);
+        assert_eq!(
+            output.unwrap(),
+            "Property ixa.EmptyGlobal is not set"
+        );
     }
 
     #[test]

--- a/src/debugger.rs
+++ b/src/debugger.rs
@@ -278,8 +278,8 @@ impl ContextDebugExt for Context {
 #[cfg(test)]
 mod tests {
     use super::{init, DebuggerPlugin};
-    use crate::{Context, ContextPeopleExt};
     use crate::{define_global_property, ContextGlobalPropertiesExt};
+    use crate::{Context, ContextPeopleExt};
 
     fn process_line(line: &str, context: &mut Context) -> (bool, Option<String>) {
         // Temporarily take the data container out of context so that
@@ -364,9 +364,11 @@ mod tests {
     #[test]
     fn test_cli_debugger_global_get_registered_prop() {
         let context = &mut Context::new();
-        context.set_global_property_value(FooGlobal, "hello".to_string()).unwrap();
+        context
+            .set_global_property_value(FooGlobal, "hello".to_string())
+            .unwrap();
         let (_quits, output) = process_line("global get ixa.FooGlobal\n", context);
-        assert_eq!( output.unwrap(), "\"hello\"");
+        assert_eq!(output.unwrap(), "\"hello\"");
     }
 
     #[test]
@@ -374,10 +376,7 @@ mod tests {
         define_global_property!(EmptyGlobal, String);
         let context = &mut Context::new();
         let (_quits, output) = process_line("global get ixa.EmptyGlobal\n", context);
-        assert_eq!(
-            output.unwrap(),
-            "Property ixa.EmptyGlobal is not set"
-        );
+        assert_eq!(output.unwrap(), "Property ixa.EmptyGlobal is not set");
     }
 
     #[test]

--- a/src/debugger.rs
+++ b/src/debugger.rs
@@ -277,7 +277,7 @@ impl ContextDebugExt for Context {
 
 #[cfg(test)]
 mod tests {
-    use super::{init, DebuggerPlugin};
+    use super::{init, run_with_plugin, DebuggerPlugin};
     use crate::{define_global_property, ContextGlobalPropertiesExt};
     use crate::{Context, ContextPeopleExt};
 
@@ -338,17 +338,20 @@ mod tests {
         let input = "global get\n";
         let context = &mut Context::new();
         init(context);
-        let data_container = context.get_data_container_mut(DebuggerPlugin);
-        let debugger = data_container.take().unwrap();
+        // We can't use process_line here because we an expect an error to be
+        // returned rather than string output
+        run_with_plugin::<DebuggerPlugin>(context, |context, data_container| {
+            let debugger = data_container.take().unwrap();
 
-        let result = debugger.process_command(input, context);
-        let data_container = context.get_data_container_mut(DebuggerPlugin);
-        *data_container = Some(debugger);
+            let result = debugger.process_command(input, context);
+            let data_container = context.get_data_container_mut(DebuggerPlugin);
+            *data_container = Some(debugger);
 
-        assert!(result.is_err());
-        assert!(result
-            .unwrap_err()
-            .contains("required arguments were not provided"));
+            assert!(result.is_err());
+            assert!(result
+                .unwrap_err()
+                .contains("required arguments were not provided"));
+        });
     }
 
     #[test]

--- a/src/global_properties.rs
+++ b/src/global_properties.rs
@@ -90,27 +90,6 @@ fn get_global_property_accessor(name: &str) -> Option<Arc<PropertyAccessors>> {
     tmp.get(name).map(Arc::clone)
 }
 
-// #[allow(clippy::missing_panics_doc)]
-// fn get_global_property_setter(name: &String) -> Option<Arc<PropertySetterFn>> {
-//     let properties = GLOBAL_PROPERTIES.lock().unwrap();
-//     let tmp = properties.borrow();
-//     match tmp.get(name) {
-//         Some(accessor) => Some(Arc::clone(&accessor.setter)),
-//         None => None,
-//     }
-// }
-
-// #[allow(clippy::missing_panics_doc)]
-// pub fn get_global_property_getter(name: &String) -> Option<Arc<PropertyGetterFn>> {
-//     let properties = GLOBAL_PROPERTIES.lock().unwrap();
-//     println!("Properties: {:?}", properties.borrow().keys());
-//     let tmp = properties.borrow();
-//     match tmp.get(name) {
-//         Some(accessor) => Some(Arc::clone(&accessor.getter)),
-//         None => None,
-//     }
-// }
-
 /// Defines a global property with the following parameters:
 /// * `$global_property`: Name for the identifier type of the global property
 /// * `$value`: The type of the property's value

--- a/src/global_properties.rs
+++ b/src/global_properties.rs
@@ -268,7 +268,7 @@ impl ContextGlobalPropertiesExt for Context {
     fn list_registered_global_properties(&self) -> Vec<String> {
         let properties = GLOBAL_PROPERTIES.lock().unwrap();
         let tmp = properties.borrow();
-        tmp.keys().map(std::string::ToString::to_string).collect()
+                tmp.keys().map(|a| a.clone()).collect()
     }
 
     fn get_serialized_value_by_string(&self, name: &str) -> Result<Option<String>, IxaError> {

--- a/src/global_properties.rs
+++ b/src/global_properties.rs
@@ -268,7 +268,7 @@ impl ContextGlobalPropertiesExt for Context {
     fn list_registered_global_properties(&self) -> Vec<String> {
         let properties = GLOBAL_PROPERTIES.lock().unwrap();
         let tmp = properties.borrow();
-                tmp.keys().map(|a| a.clone()).collect()
+        tmp.keys().cloned().collect()
     }
 
     fn get_serialized_value_by_string(&self, name: &str) -> Result<Option<String>, IxaError> {

--- a/src/global_properties.rs
+++ b/src/global_properties.rs
@@ -32,6 +32,13 @@ use std::sync::Mutex;
 type PropertySetterFn =
     dyn Fn(&mut Context, &str, serde_json::Value) -> Result<(), IxaError> + Send + Sync;
 
+type PropertyGetterFn = dyn Fn(&Context) -> Result<Option<String>, IxaError> + Send + Sync;
+
+pub struct PropertyAccessors {
+    setter: Box<PropertySetterFn>,
+    getter: Box<PropertyGetterFn>,
+}
+
 #[allow(clippy::type_complexity)]
 // This is a global list of all the global properties that
 // are compiled in. Fundamentally it's a HashMap of property
@@ -40,43 +47,69 @@ type PropertySetterFn =
 // shared and initialized at startup time while still being
 // safe.
 #[doc(hidden)]
-pub static GLOBAL_PROPERTIES: LazyLock<Mutex<RefCell<HashMap<String, Arc<PropertySetterFn>>>>> =
+pub static GLOBAL_PROPERTIES: LazyLock<Mutex<RefCell<HashMap<String, Arc<PropertyAccessors>>>>> =
     LazyLock::new(|| Mutex::new(RefCell::new(HashMap::new())));
 
 #[allow(clippy::missing_panics_doc)]
 pub fn add_global_property<T: GlobalProperty>(name: &str)
 where
-    for<'de> <T as GlobalProperty>::Value: serde::Deserialize<'de>,
+    for<'de> <T as GlobalProperty>::Value: serde::Deserialize<'de> + serde::Serialize,
 {
     let properties = GLOBAL_PROPERTIES.lock().unwrap();
     assert!(properties
         .borrow_mut()
         .insert(
             name.to_string(),
-            Arc::new(
-                |context: &mut Context, name, value| -> Result<(), IxaError> {
-                    let val: T::Value = serde_json::from_value(value)?;
-                    T::validate(&val)?;
-                    if context.get_global_property_value(T::new()).is_some() {
-                        return Err(IxaError::IxaError(format!("Duplicate property {name}")));
+            Arc::new(PropertyAccessors {
+                setter: Box::new(
+                    |context: &mut Context, name, value| -> Result<(), IxaError> {
+                        let val: T::Value = serde_json::from_value(value)?;
+                        T::validate(&val)?;
+                        if context.get_global_property_value(T::new()).is_some() {
+                            return Err(IxaError::IxaError(format!("Duplicate property {name}")));
+                        }
+                        context.set_global_property_value(T::new(), val)?;
+                        Ok(())
                     }
-                    context.set_global_property_value(T::new(), val)?;
-                    Ok(())
-                },
-            ),
+                ),
+                getter: Box::new(|context: &Context| -> Result<Option<String>, IxaError> {
+                    let value = context.get_global_property_value(T::new());
+                    match value {
+                        Some(val) => Ok(Some(serde_json::to_string(val)?)),
+                        None => Ok(None),
+                    }
+                }),
+            })
         )
         .is_none());
 }
 
-#[allow(clippy::missing_panics_doc)]
-fn get_global_property(name: &String) -> Option<Arc<PropertySetterFn>> {
+fn get_global_property_accessor(name: &str) -> Option<Arc<PropertyAccessors>> {
     let properties = GLOBAL_PROPERTIES.lock().unwrap();
     let tmp = properties.borrow();
-    match tmp.get(name) {
-        Some(func) => Some(Arc::clone(func)),
-        None => None,
-    }
+    tmp.get(name).map(Arc::clone)
 }
+
+// #[allow(clippy::missing_panics_doc)]
+// fn get_global_property_setter(name: &String) -> Option<Arc<PropertySetterFn>> {
+//     let properties = GLOBAL_PROPERTIES.lock().unwrap();
+//     let tmp = properties.borrow();
+//     match tmp.get(name) {
+//         Some(accessor) => Some(Arc::clone(&accessor.setter)),
+//         None => None,
+//     }
+// }
+
+// #[allow(clippy::missing_panics_doc)]
+// pub fn get_global_property_getter(name: &String) -> Option<Arc<PropertyGetterFn>> {
+//     let properties = GLOBAL_PROPERTIES.lock().unwrap();
+//     println!("Properties: {:?}", properties.borrow().keys());
+//     let tmp = properties.borrow();
+//     match tmp.get(name) {
+//         Some(accessor) => Some(Arc::clone(&accessor.getter)),
+//         None => None,
+//     }
+// }
 
 /// Defines a global property with the following parameters:
 /// * `$global_property`: Name for the identifier type of the global property
@@ -159,6 +192,15 @@ pub trait ContextGlobalPropertiesExt {
         &self,
         _property: T,
     ) -> Option<&T::Value>;
+
+    fn list_registered_global_properties(&self) -> Vec<String>;
+
+    /// Return the serialized value of a global property by fully qualified name
+    ///
+    /// # Errors
+    ///
+    /// Will return an `IxaError` if the property does not exist
+    fn get_serialized_value_by_string(&self, name: &str) -> Result<Option<String>, IxaError>;
 
     /// Given a file path for a valid json file, deserialize parameter values
     /// for a given struct T
@@ -244,6 +286,20 @@ impl ContextGlobalPropertiesExt for Context {
         None
     }
 
+    fn list_registered_global_properties(&self) -> Vec<String> {
+        let properties = GLOBAL_PROPERTIES.lock().unwrap();
+        let tmp = properties.borrow();
+        tmp.keys().map(std::string::ToString::to_string).collect()
+    }
+
+    fn get_serialized_value_by_string(&self, name: &str) -> Result<Option<String>, IxaError> {
+        let accessor = get_global_property_accessor(name);
+        match accessor {
+            Some(accessor) => (accessor.getter)(self),
+            None => Err(IxaError::from(format!("No global property: {name}"))),
+        }
+    }
+
     fn load_parameters_from_json<T: 'static + Debug + DeserializeOwned>(
         &mut self,
         file_name: &Path,
@@ -260,8 +316,8 @@ impl ContextGlobalPropertiesExt for Context {
         let val: serde_json::Map<String, serde_json::Value> = serde_json::from_reader(reader)?;
 
         for (k, v) in val {
-            if let Some(handler) = get_global_property(&k) {
-                handler(self, &k, v)?;
+            if let Some(accessor) = get_global_property_accessor(&k) {
+                (accessor.setter)(self, &k, v)?;
             } else {
                 return Err(IxaError::from(format!("No global property: {k}")));
             }
@@ -365,14 +421,14 @@ mod test {
         assert_eq!(params_read.diseases, params.diseases);
     }
 
-    #[derive(Deserialize)]
+    #[derive(Serialize, Deserialize)]
     pub struct Property1Type {
         field_int: u32,
         field_str: String,
     }
     define_global_property!(Property1, Property1Type);
 
-    #[derive(Deserialize)]
+    #[derive(Serialize, Deserialize)]
     pub struct Property2Type {
         field_int: u32,
     }
@@ -430,7 +486,7 @@ mod test {
         }
     }
 
-    #[derive(Deserialize)]
+    #[derive(Serialize, Deserialize)]
     pub struct Property3Type {
         field_int: u32,
     }
@@ -478,5 +534,30 @@ mod test {
             context.load_global_properties(&path),
             Err(IxaError::IxaError(_))
         ));
+    }
+
+    #[test]
+    fn list_registered_global_properties() {
+        let context = Context::new();
+        let properties = context.list_registered_global_properties();
+        assert!(properties.contains(&"ixa.DiseaseParams".to_string()));
+    }
+
+    #[test]
+    fn get_serialized_value_by_string() {
+        let mut context = Context::new();
+        context
+            .set_global_property_value(
+                DiseaseParams,
+                ParamType {
+                    days: 10,
+                    diseases: 2,
+                },
+            )
+            .unwrap();
+        let serialized = context
+            .get_serialized_value_by_string("ixa.DiseaseParams")
+            .unwrap();
+        assert_eq!(serialized, Some("{\"days\":10,\"diseases\":2}".to_string()));
     }
 }

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -157,7 +157,7 @@ where
 mod tests {
     use super::*;
     use crate::{define_global_property, define_rng};
-    use serde::Deserialize;
+    use serde::{Deserialize, Serialize};
 
     #[derive(Args, Debug)]
     struct CustomArgs {
@@ -210,7 +210,7 @@ mod tests {
         assert!(result.is_ok());
     }
 
-    #[derive(Deserialize)]
+    #[derive(Serialize, Deserialize)]
     pub struct RunnerPropertyType {
         field_int: u32,
     }


### PR DESCRIPTION
This PR adds a `global` command to the debugger, which prints the value of a registered global property to the console.

If you type `global` (with no argument) or with an invalid property name, you will see a list of available properties:
```
t=0 $ global
2 global properties registered:
runner.FavoriteNumber, runner.Name
```

If you provide a valid, fully qualified property name, you will see the value:
```
t=0 $ global runner.Name
"Sim123"
```