### PR TITLE
Cleanup dependencies. Fixes #151

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,29 +8,27 @@ license = "Apache-2.0"
 homepage = "https://github.com/CDCgov/ixa"
 
 [dependencies]
-fxhash = "0.2.1"
-rand = "0.8.5"
-csv = "1.3"
-serde = { version = "1.0", features = ["derive"] }
-serde_derive = "1.0"
-serde_json = "1.0.128"
-reikna = "0.12.3"
+fxhash = "^0.2.1"
+rand = "^0.8.5"
+csv = "^1.3.1"
+serde = { version = "^1.0.217", features = ["derive"] }
+serde_derive = "^1.0.217"
+serde_json = "^1.0.135"
+reikna = "^0.12.3"
 roots = "0.0.8"
 ixa-derive = { path = "ixa-derive" }
-seq-macro = "0.3.5"
-paste = "1.0.15"
-ctor = "0.2.8"
-once_cell = "1.20.2"
-clap = { version = "4.5.21", features = ["derive"] }
-shlex = "1.3.0"
-rustyline = "15.0.0"
+seq-macro = "^0.3.5"
+paste = "^1.0.15"
+ctor = "^0.2.8"
+clap = { version = "^4.5.26", features = ["derive"] }
+shlex = "^1.3.0"
+rustyline = "^15.0.0"
 
 [dev-dependencies]
-rand_distr = "0.4.3"
-tempfile = "3.3"
-ordered-float = "4.3.0"
-predicates = "3.1.2"
-assert_cmd = "2.0.16"
+rand_distr = "^0.4.3"
+tempfile = "^3.15.0"
+ordered-float = "^4.6.0"
+assert_cmd = "^2.0.16"
 
 [[bin]]
 name = "runner_test_custom_args"

--- a/ixa-derive/Cargo.toml
+++ b/ixa-derive/Cargo.toml
@@ -4,9 +4,8 @@ version = "0.0.0"
 edition = "2021"
 
 [dependencies]
-proc-macro2 = "1.0"
-quote = "1.0"
-syn = "2.0.85"
+quote = "^1.0.38"
+syn = "^2.0.95"
 
 [lib]
 proc-macro = true


### PR DESCRIPTION
Bump all outdated dependency versions. Added the "nonbreaking changes" annotation `^` on dependency versions. Removed unused dependencies.