### PR TITLE
Made both `PersonId` and `PlandId` a tuple-style newtype. Fixes #149.

### DIFF
--- a/examples/basic-infection/incidence_report.rs
+++ b/examples/basic-infection/incidence_report.rs
@@ -1,17 +1,17 @@
 use crate::infection_manager::InfectionStatusEvent;
 use crate::people::InfectionStatusValue;
 use ixa::context::Context;
-use ixa::create_report_trait;
 use ixa::error::IxaError;
 use ixa::report::ContextReportExt;
 use ixa::report::Report;
+use ixa::{create_report_trait, PersonId};
 use serde::{Deserialize, Serialize};
 use std::path::PathBuf;
 
 #[derive(Serialize, Deserialize, Clone)]
 struct IncidenceReportItem {
     time: f64,
-    person_id: String,
+    person_id: PersonId,
     infection_status: InfectionStatusValue,
 }
 
@@ -20,7 +20,7 @@ create_report_trait!(IncidenceReportItem);
 fn handle_infection_status_change(context: &mut Context, event: InfectionStatusEvent) {
     context.send_report(IncidenceReportItem {
         time: context.get_current_time(),
-        person_id: event.person_id.to_string(),
+        person_id: event.person_id,
         infection_status: event.current,
     });
 }

--- a/examples/births-deaths/README.md
+++ b/examples/births-deaths/README.md
@@ -132,7 +132,7 @@ fn cancel_recovery_plans(context: &mut Context, person_id: PersonId) {
     let plans_set = plans_data_container
         .plans_map
         .get(&person_id)
-        .unwrap_or(&HashSet::<plan::Id>::new())
+        .unwrap_or(&HashSet::<plan::PlanId>::new())
         .clone();
 
     for plan_id in plans_set {

--- a/examples/births-deaths/infection_manager.rs
+++ b/examples/births-deaths/infection_manager.rs
@@ -7,7 +7,7 @@ use ixa::define_data_plugin;
 use ixa::define_rng;
 use ixa::global_properties::ContextGlobalPropertiesExt;
 use ixa::people::{ContextPeopleExt, PersonId, PersonPropertyChangeEvent};
-use ixa::plan::Id;
+use ixa::plan::PlanId;
 use ixa::random::ContextRandomExt;
 use rand_distr::Exp;
 use std::collections::{HashMap, HashSet};
@@ -17,13 +17,13 @@ define_data_plugin!(
     InfectionPlansPlugin,
     InfectionPlansData,
     InfectionPlansData {
-        plans_map: HashMap::<PersonId, HashSet::<Id>>::new(),
+        plans_map: HashMap::<PersonId, HashSet::<PlanId>>::new(),
     }
 );
 
 #[derive(Debug)]
 struct InfectionPlansData {
-    plans_map: HashMap<PersonId, HashSet<Id>>,
+    plans_map: HashMap<PersonId, HashSet<PlanId>>,
 }
 
 fn schedule_recovery(context: &mut Context, person_id: PersonId) {
@@ -58,7 +58,7 @@ fn cancel_recovery_plans(context: &mut Context, person_id: PersonId) {
     let plans_set = plans_data_container
         .plans_map
         .get(&person_id)
-        .unwrap_or(&HashSet::<Id>::new())
+        .unwrap_or(&HashSet::<PlanId>::new())
         .clone();
 
     for plan_id in plans_set {

--- a/examples/load-people/README.md
+++ b/examples/load-people/README.md
@@ -20,7 +20,7 @@ the population range):
 
 ```rust
  let person: PersonId = context.add_person();
- println!("Person {} was created", person.id)
+ println!("Person {} was created", person.0)
  ```
 
 ### Person Properties
@@ -155,7 +155,7 @@ that when properties are first set, they will *not* emit any change events;
             let person = event.person_id;
             println!(
                 "Person {} changed disease status from {:?} to {:?}",
-                person.id, event.previous, event.current,
+                person.0, event.previous, event.current,
             );
         },
     );

--- a/src/context.rs
+++ b/src/context.rs
@@ -8,7 +8,7 @@ use std::{
     rc::Rc,
 };
 
-use crate::plan::{Id, Queue};
+use crate::plan::{PlanId, Queue};
 
 /// The common callback used by multiple `Context` methods for future events
 type Callback = dyn FnOnce(&mut Context);
@@ -127,12 +127,12 @@ impl Context {
     /// Add a plan to the future event list at the specified time in the normal
     /// phase
     ///
-    /// Returns an `Id` for the newly-added plan that can be used to cancel it
+    /// Returns a `PlanId` for the newly-added plan that can be used to cancel it
     /// if needed.
     /// # Panics
     ///
     /// Panics if time is in the past, infinite, or NaN.
-    pub fn add_plan(&mut self, time: f64, callback: impl FnOnce(&mut Context) + 'static) -> Id {
+    pub fn add_plan(&mut self, time: f64, callback: impl FnOnce(&mut Context) + 'static) -> PlanId {
         self.add_plan_with_phase(time, callback, ExecutionPhase::Normal)
     }
 
@@ -140,7 +140,7 @@ impl Context {
     /// specified phase (first, normal, or last among plans at the
     /// specified time)
     ///
-    /// Returns an `Id` for the newly-added plan that can be used to cancel it
+    /// Returns a `PlanId` for the newly-added plan that can be used to cancel it
     /// if needed.
     /// # Panics
     ///
@@ -150,7 +150,7 @@ impl Context {
         time: f64,
         callback: impl FnOnce(&mut Context) + 'static,
         phase: ExecutionPhase,
-    ) -> Id {
+    ) -> PlanId {
         assert!(
             !time.is_nan() && !time.is_infinite() && time >= self.current_time,
             "Time is invalid"
@@ -206,7 +206,7 @@ impl Context {
     ///
     /// This function panics if you cancel a plan which has already been
     /// cancelled or executed.
-    pub fn cancel_plan(&mut self, id: &Id) {
+    pub fn cancel_plan(&mut self, id: &PlanId) {
         self.plan_queue.cancel_plan(id);
     }
 
@@ -382,7 +382,7 @@ mod tests {
         assert!(context.get_data_container(ComponentA).is_none());
     }
 
-    fn add_plan(context: &mut Context, time: f64, value: u32) -> Id {
+    fn add_plan(context: &mut Context, time: f64, value: u32) -> PlanId {
         context.add_plan(time, move |context| {
             context.get_data_container_mut(ComponentA).push(value);
         })
@@ -393,7 +393,7 @@ mod tests {
         time: f64,
         value: u32,
         phase: ExecutionPhase,
-    ) -> Id {
+    ) -> PlanId {
         context.add_plan_with_phase(
             time,
             move |context| {


### PR DESCRIPTION
Made both `PersonId` and `PlandId` a tuple-style newtype instead of a single field struct and modified usages accordingly.

Changed instances of `id` to `plan_id` or `person_id`.