### PR TITLE
Restructure debugger to use the clap derived API.

### DIFF
--- a/src/debugger.rs
+++ b/src/debugger.rs
@@ -4,7 +4,7 @@ use crate::Context;
 use crate::ContextGlobalPropertiesExt;
 use crate::ContextPeopleExt;
 use crate::IxaError;
-use clap::{ArgMatches, Command, FromArgMatches as _, Parser, Subcommand};
+use clap::{ArgMatches, Command, FromArgMatches, Parser, Subcommand};
 use rustyline;
 
 use std::collections::HashMap;


### PR DESCRIPTION
This is groundwork for the Web API, where I want to use JSON as the interchange language, and this will allow us to use common for the debugger and the Web API once you get past the parser.