### PR TITLE
Add global properties to derived property macro

### DIFF
--- a/src/global_properties.rs
+++ b/src/global_properties.rs
@@ -228,6 +228,9 @@ impl GlobalPropertiesDataContainer {
                 entry.insert(Box::new(value));
                 Ok(())
             }
+            // Note: If we change global properties to be mutable, we'll need to
+            // update define_derived_property to either handle updates or only
+            // allow immutable properties.
             Entry::Occupied(_) => Err(IxaError::from("Entry already exists")),
         }
     }

--- a/src/people.rs
+++ b/src/people.rs
@@ -656,7 +656,8 @@ macro_rules! define_derived_property {
                 let ($($param,)*) = (
                     $(context.get_person_property(person_id, $dependency)),*,
                     $(
-                        *context.get_global_property_value($global_dependency).unwrap()
+                        *context.get_global_property_value($global_dependency)
+                            .expect(&format!("Global property {} not initialized", stringify!($global_dependency))),
                     ),*
                 );
                 (|$($param),+| $derive_fn)($($param),+)


### PR DESCRIPTION
Fixes #165 by adding support for global properties which are assumed to be immutable, and read the first time the property is accessed. Note that there is no infrastructure to watch for changes to global properties.

I kind of prefer version A (which is what I've implemented here) but I think we could consider B

```rust
// A, combined arguments
define_derived_property!(IsEligible, bool, [Age], |age| age >= 18);
define_derived_property!(IsEligible, bool, [Age], [Threshold], |age, threshold| {
    age >= threshold
});

// B, tuples
define_derived_property!(IsEligible, bool, [Age], |(age)| age >= 18);
define_derived_property!(IsEligible, bool, [Age], [Threshold], |(age), (threshold)| {
    age >= threshold
});
```