### PR TITLE
Added logging infrastructure. Fixes #158.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,9 @@ ctor = "^0.2.8"
 clap = { version = "^4.5.26", features = ["derive"] }
 shlex = "^1.3.0"
 rustyline = "^15.0.0"
+log = "^0.4.22"
+env_logger = "^0.11.6"
+log-reload = "^0.1.0"
 axum = "0.8.1"
 tokio = { version = "1", features = ["full"] }
 reqwest = { version = "0.12.12", features = ["blocking", "json"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,8 +24,7 @@ clap = { version = "^4.5.26", features = ["derive"] }
 shlex = "^1.3.0"
 rustyline = "^15.0.0"
 log = "^0.4.22"
-env_logger = "^0.11.6"
-log-reload = "^0.1.0"
+log4rs = { version = "^1.3.0", features = ["console_appender", "pattern_encoder"] }
 axum = "0.8.1"
 tokio = { version = "1", features = ["full"] }
 reqwest = { version = "0.12.12", features = ["blocking", "json"] }

--- a/examples/basic-infection/incidence_report.rs
+++ b/examples/basic-infection/incidence_report.rs
@@ -4,7 +4,7 @@ use ixa::context::Context;
 use ixa::error::IxaError;
 use ixa::report::ContextReportExt;
 use ixa::report::Report;
-use ixa::{create_report_trait, PersonId};
+use ixa::{create_report_trait, trace, PersonId};
 use serde::{Deserialize, Serialize};
 use std::path::PathBuf;
 
@@ -18,6 +18,12 @@ struct IncidenceReportItem {
 create_report_trait!(IncidenceReportItem);
 
 fn handle_infection_status_change(context: &mut Context, event: InfectionStatusEvent) {
+    trace!(
+        "Handling infection status change from {:?} to {:?} for {:?}",
+        event.previous,
+        event.current,
+        event.person_id
+    );
     context.send_report(IncidenceReportItem {
         time: context.get_current_time(),
         person_id: event.person_id,
@@ -26,6 +32,8 @@ fn handle_infection_status_change(context: &mut Context, event: InfectionStatusE
 }
 
 pub fn init(context: &mut Context) -> Result<(), IxaError> {
+    trace!("Initializing incidence_report");
+
     // In the configuration of report options below, we set `overwrite(true)`, which is not
     // recommended for production code in order to prevent accidental data loss. It is set
     // here so that newcomers won't have to deal with a confusing error while running

--- a/examples/basic-infection/main.rs
+++ b/examples/basic-infection/main.rs
@@ -1,6 +1,7 @@
 use ixa::context::Context;
 use ixa::error::IxaError;
 use ixa::random::ContextRandomExt;
+use ixa::run_with_args;
 
 mod incidence_report;
 mod infection_manager;
@@ -13,23 +14,20 @@ static MAX_TIME: f64 = 303.0;
 static FOI: f64 = 0.1;
 static INFECTION_DURATION: f64 = 5.0;
 
-fn initialize() -> Result<Context, IxaError> {
-    let mut context = Context::new();
-
+fn initialize(context: &mut Context) -> Result<(), IxaError> {
     context.init_random(SEED);
 
-    people::init(&mut context);
-    transmission_manager::init(&mut context);
-    infection_manager::init(&mut context);
-    incidence_report::init(&mut context)?;
+    people::init(context);
+    transmission_manager::init(context);
+    infection_manager::init(context);
+    incidence_report::init(context)?;
 
     context.add_plan(MAX_TIME, |context| {
         context.shutdown();
     });
-    Ok(context)
+    Ok(())
 }
 
 fn main() {
-    let mut context = initialize().expect("Error adding report.");
-    context.execute();
+    run_with_args(|ctx, _, _| initialize(ctx)).expect("failed to run the model");
 }

--- a/examples/basic-infection/people.rs
+++ b/examples/basic-infection/people.rs
@@ -1,5 +1,6 @@
 use ixa::context::Context;
 use ixa::{define_person_property_with_default, ContextPeopleExt};
+use log::trace;
 
 use serde::{Deserialize, Serialize};
 
@@ -21,6 +22,7 @@ define_person_property_with_default!(
 
 /// Populates the "world" with the `POPULATION` number of people.
 pub fn init(context: &mut Context) {
+    trace!("Initializing people");
     for _ in 0..POPULATION {
         context.add_person(()).unwrap();
     }

--- a/examples/basic-infection/transmission_manager.rs
+++ b/examples/basic-infection/transmission_manager.rs
@@ -1,6 +1,7 @@
 use ixa::context::Context;
 use ixa::random::ContextRandomExt;
 use ixa::{define_rng, ContextPeopleExt, PersonId};
+use log::trace;
 
 use crate::people::{InfectionStatus, InfectionStatusValue};
 use rand_distr::Exp;
@@ -11,6 +12,7 @@ use crate::MAX_TIME;
 define_rng!(TransmissionRng);
 
 fn attempt_infection(context: &mut Context) {
+    trace!("Attempting infection");
     let population_size: usize = context.get_current_population();
     let person_to_infect: PersonId = context.sample_person(TransmissionRng, ()).unwrap(); //.sample_range(TransmissionRng, 0..population_size);
 
@@ -43,6 +45,7 @@ fn attempt_infection(context: &mut Context) {
 }
 
 pub fn init(context: &mut Context) {
+    trace!("Initializing transmission manager");
     context.add_plan(0.0, attempt_infection);
 }
 

--- a/src/debugger.rs
+++ b/src/debugger.rs
@@ -6,6 +6,7 @@ use crate::IxaError;
 use clap::{ArgMatches, Command, FromArgMatches, Parser, Subcommand};
 use rustyline;
 
+use log::trace;
 use std::collections::HashMap;
 use std::io::Write;
 
@@ -237,6 +238,7 @@ pub trait ContextDebugExt {
 
 impl ContextDebugExt for Context {
     fn schedule_debugger(&mut self, t: f64) {
+        trace!("scheduling debugger");
         self.add_plan(t, |context| {
             init(context);
             run_with_plugin::<DebuggerPlugin>(context, |context, data_container| {

--- a/src/global_properties.rs
+++ b/src/global_properties.rs
@@ -17,6 +17,7 @@
 //! Global properties can be read with [`Context::get_global_property_value()`]
 use crate::context::Context;
 use crate::error::IxaError;
+use log::trace;
 use serde::de::DeserializeOwned;
 use std::any::{Any, TypeId};
 use std::cell::RefCell;
@@ -55,6 +56,7 @@ pub fn add_global_property<T: GlobalProperty>(name: &str)
 where
     for<'de> <T as GlobalProperty>::Value: serde::Deserialize<'de> + serde::Serialize,
 {
+    trace!("Adding global property {}", name);
     let properties = GLOBAL_PROPERTIES.lock().unwrap();
     assert!(properties
         .borrow_mut()
@@ -286,6 +288,7 @@ impl ContextGlobalPropertiesExt for Context {
         &mut self,
         file_name: &Path,
     ) -> Result<T, IxaError> {
+        trace!("Loading parameters from JSON: {:?}", file_name);
         let config_file = fs::File::open(file_name)?;
         let reader = BufReader::new(config_file);
         let config = serde_json::from_reader(reader)?;
@@ -293,6 +296,7 @@ impl ContextGlobalPropertiesExt for Context {
     }
 
     fn load_global_properties(&mut self, file_name: &Path) -> Result<(), IxaError> {
+        trace!("Loading global properties from {:?}", file_name);
         let config_file = fs::File::open(file_name)?;
         let reader = BufReader::new(config_file);
         let val: serde_json::Map<String, serde_json::Value> = serde_json::from_reader(reader)?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -58,5 +58,11 @@ pub use runner::{run_with_args, run_with_custom_args, BaseArgs};
 
 pub mod debugger;
 
+pub mod log;
+pub use log::{
+    debug, disable_logging, enable_logging, error, info, set_log_level, set_module_filter,
+    set_module_filters, trace, warn, LevelFilter,
+};
+
 pub mod external_api;
 pub mod web_api;

--- a/src/log.rs
+++ b/src/log.rs
@@ -1,0 +1,214 @@
+//! The `log` module defines an interface to Ixa's internal logging facilities. Logging messages about
+//! internal behavior of Ixa. This is not to be confused with _reporting_, which is model-level concept
+//! for Ixa users to record data about running models.
+//!
+//! Model authors can nonetheless use Ixa's logging facilities to output messages. This module
+//! (re)exports the five logging macros: `error!`, `warn!`, `info!`, `debug!` and `trace!` where
+//! `error!` represents the highest-priority log messages and `trace!` the lowest. To emit a log
+//! message, simply use one of these macros in your code:
+//!
+//! ```rust
+//! use ixa::{info};
+//!
+//! pub fn do_a_thing() {
+//!     info!("A thing is being done.");
+//! }
+//! ```
+//!
+//! Logging is _disabled_ by default. Log messages are enabled/disabled using the functions:
+//!
+//!  - `enable_logging()`: turns on all log messages
+//!  - `disable_logging()`: turns off all log messages
+//!  - `set_log_level(level: LevelFilter)`: enables only log messages with priority at least `level`
+//!
+//! In addition, per-module filtering of messages can be configured using `set_module_filter()` /
+//! `set_module_filters()` and `remove_module_filter()`:
+//!
+//! ```rust
+//! use ixa::log::{set_module_filter, remove_module_filter, set_module_filters, LevelFilter,
+//! enable_logging, set_log_level};
+//!
+//! pub fn setup_logging() {
+//!     // Enable `info` log messages globally.
+//!     set_log_level(LevelFilter::Info);
+//!     // Disable Ixa's internal logging messages.
+//!     set_module_filter("ixa", LevelFilter::Off);
+//!     // Enable all log messages for the `transmission_manager` module.
+//!     set_module_filter("transmission_manager", LevelFilter::Trace);
+//! }
+//! ```
+
+use env_logger::{Builder, Logger, WriteStyle};
+pub use log::{debug, error, info, trace, warn, LevelFilter};
+use log_reload::{ReloadHandle, ReloadLog};
+
+use std::cell::OnceCell;
+use std::collections::HashMap;
+use std::sync::Mutex;
+
+// Logging disabled.
+const DEFAULT_LOG_LEVEL: LevelFilter = LevelFilter::Off;
+// Automatically determine if output supports color.
+const DEFAULT_LOG_STYLE: WriteStyle = WriteStyle::Auto;
+// Default module specific filters
+const DEFAULT_MODULE_FILTERS: [(&str, LevelFilter); 1] = [
+    ("rustyline", LevelFilter::Off),
+    // ("ixa", LevelFilter::Off),
+];
+
+/// A global instance of the logging configuration.
+static mut LOG_CONFIGURATION: OnceCell<Mutex<LogConfiguration>> = OnceCell::new();
+
+/// Holds logging configuration so the configuration can persist across reinitialization of the
+/// global logger.
+///
+/// Neither `env_logger::Builder` nor `env_logger::Logger` can be modified once constructed. This
+/// struct serves as a mutable proxy for `env_logger::Builder`. Because the global logger cannot
+/// be initialized more than once, we use `log_reload::ReloadLog` as the global logger, which
+/// serves as a wrapper around the real logger that allows us to swap out the inner logger after
+/// initialization.
+struct LogConfiguration {
+    /// The "default" level filter for modules ("targets") without an explicitly set filter. A
+    /// global filter level of `LevelFilter::Off` disables logging.
+    global_log_level: LevelFilter,
+    /// Whether to colorize output.
+    log_style: WriteStyle,
+    /// Holds module ("target") specific level filters
+    module_level: HashMap<String, LevelFilter>,
+    /// A handle to the logger that can reload or modify its inner wrapped logger.
+    log_handle: Option<ReloadHandle<Logger>>,
+}
+
+impl Default for LogConfiguration {
+    fn default() -> Self {
+        let module_level = HashMap::from(
+            DEFAULT_MODULE_FILTERS.map(|(module, level)| (module.to_string(), level)),
+        );
+
+        LogConfiguration {
+            global_log_level: DEFAULT_LOG_LEVEL,
+            log_style: DEFAULT_LOG_STYLE,
+            module_level,
+            log_handle: None,
+        }
+    }
+}
+
+impl LogConfiguration {
+    /// Constructs an `env_logger::Logger` with the current configuration. This is analogous to
+    /// `env_logger::Builder::build()`. This method does not install the logger.
+    pub fn build(&self) -> Logger {
+        let mut builder = Builder::new();
+
+        builder
+            .filter_level(self.global_log_level)
+            .write_style(self.log_style);
+        // Add module specific filters.
+        for (module, filter) in &self.module_level {
+            builder.filter(Some(module), *filter);
+        }
+
+        builder.build()
+    }
+}
+
+/// Enables the logger with no global level filter / full logging. Equivalent to
+/// `set_log_level(LevelFilter::Trace)`.
+pub fn enable_logging() {
+    set_log_level(LevelFilter::Trace);
+}
+
+/// Disables logging completely. Equivalent to `set_log_level(LevelFilter::Off)`.
+pub fn disable_logging() {
+    set_log_level(LevelFilter::Off);
+}
+
+/// Sets the global log level. A global filter level of `LevelFilter::Off` disables logging.
+pub fn set_log_level(level: LevelFilter) {
+    {
+        let log_configuration = get_log_configuration();
+        log_configuration.global_log_level = level;
+    }
+    set_logger();
+}
+
+/// Sets a level filter for the given module path.
+pub fn set_module_filter(module_path: &str, level_filter: LevelFilter) {
+    {
+        let log_configuration = get_log_configuration();
+        log_configuration
+            .module_level
+            .insert(module_path.to_string(), level_filter);
+    }
+    set_logger();
+}
+
+/// Removes a module-specific level filter for the given module path. The global level filter will
+/// apply to the module.
+pub fn remove_module_filter(module_path: &str) {
+    {
+        let log_configuration = get_log_configuration();
+        log_configuration.module_level.remove(module_path);
+    }
+    set_logger();
+}
+
+/// Sets the level filters for a set of modules according to the provided map. Use this instead of
+/// `set_module_filter()` to set filters in bulk.
+#[allow(clippy::implicit_hasher)]
+pub fn set_module_filters(module_filters: &HashMap<&str, LevelFilter>) {
+    {
+        let log_configuration = get_log_configuration();
+        log_configuration.module_level.extend(
+            module_filters
+                .iter()
+                .map(|(module_path, level)| ((*module_path).to_string(), *level)),
+        );
+    }
+    set_logger();
+}
+
+/// Fetches a mutable reference to the global `LogConfiguration`.
+fn get_log_configuration() -> &'static mut LogConfiguration {
+    // Silence lint about mutable global variables.
+    #[allow(static_mut_refs)]
+    unsafe {
+        if let Some(mutex) = LOG_CONFIGURATION.get_mut() {
+            mutex.get_mut().unwrap()
+        } else {
+            _ = LOG_CONFIGURATION.set(Mutex::default());
+            LOG_CONFIGURATION.get_mut().unwrap().get_mut().unwrap()
+        }
+    }
+}
+
+/// Initializes or replaces the existing global logger with a logger described by the global
+/// log configuration.
+fn set_logger() {
+    let log_configuration = get_log_configuration();
+    let logger = log_configuration.build();
+    trace!("Setting logger");
+
+    match &log_configuration.log_handle {
+        None => {
+            // Logger has not been initialized.
+            let wrapping_logger = ReloadLog::new(logger);
+            log_configuration.log_handle = Some(wrapping_logger.handle());
+            let result = log::set_boxed_logger(Box::new(wrapping_logger))
+                .map(|()| log::set_max_level(log_configuration.global_log_level));
+            if let Err(error) = result {
+                error!(
+                    "tried to initialize a global logger that has already been set: {}",
+                    error
+                );
+            }
+        }
+
+        Some(handle) => {
+            // Replace the existing logger.
+            if let Err(error) = handle.replace(logger) {
+                error!("failed to set logger: {}", error);
+            }
+        }
+    }
+}

--- a/src/plan.rs
+++ b/src/plan.rs
@@ -9,6 +9,7 @@
 //! This queue is used by `Context` to store future events where some callback
 //! closure `FnOnce(&mut Context)` will be executed at a given point in time.
 
+use log::trace;
 use std::{
     cmp::Ordering,
     collections::{BinaryHeap, HashMap},
@@ -50,6 +51,7 @@ impl<T, P: Eq + PartialEq + Ord> Queue<T, P> {
     /// Returns a `PlanId` for the newly-added plan that can be used to cancel it
     /// if needed.
     pub fn add_plan(&mut self, time: f64, data: T, priority: P) -> PlanId {
+        trace!("adding plan at {}", time);
         // Add plan to queue, store data, and increment counter
         let plan_id = self.plan_counter;
         self.queue.push(Entry {
@@ -69,6 +71,7 @@ impl<T, P: Eq + PartialEq + Ord> Queue<T, P> {
     /// This function panics if you cancel a plan which has already
     /// been cancelled or executed.
     pub fn cancel_plan(&mut self, plan_id: &PlanId) {
+        trace!("cancel plan {:?}", plan_id);
         // Delete the plan from the map, but leave in the queue
         // It will be skipped when the plan is popped from the queue
         self.data_map
@@ -85,6 +88,7 @@ impl<T, P: Eq + PartialEq + Ord> Queue<T, P> {
     ///
     /// Returns the next plan if it exists or else `None` if the queue is empty
     pub fn get_next_plan(&mut self) -> Option<Plan<T>> {
+        trace!("getting next plan");
         loop {
             // Pop from queue until we find a plan with data or queue is empty
             match self.queue.pop() {

--- a/src/random.rs
+++ b/src/random.rs
@@ -1,4 +1,5 @@
 use crate::context::Context;
+use log::trace;
 use rand::distributions::uniform::{SampleRange, SampleUniform};
 use rand::distributions::WeightedIndex;
 use rand::prelude::Distribution;
@@ -79,6 +80,11 @@ fn get_rng<R: RngId + 'static>(context: &Context) -> RefMut<R::RngType> {
             .entry(TypeId::of::<R>())
             // Create a new rng holder if it doesn't exist yet
             .or_insert_with(|| {
+                trace!(
+                    "creating new RNG (seed={}) for type id {:?}",
+                    data_container.base_seed,
+                    TypeId::of::<R>()
+                );
                 let base_seed = data_container.base_seed;
                 let seed_offset = fxhash::hash64(R::get_name());
                 RngHolder {
@@ -147,6 +153,7 @@ impl ContextRandomExt for Context {
     /// Initializes the `RngPlugin` data container to store rngs as well as a base
     /// seed. Note that rngs are created lazily when `get_rng` is called.
     fn init_random(&mut self, base_seed: u64) {
+        trace!("initializing random module");
         let data_container = self.get_data_container_mut(RngPlugin);
         data_container.base_seed = base_seed;
 

--- a/src/report.rs
+++ b/src/report.rs
@@ -1,8 +1,8 @@
 use crate::context::Context;
 use crate::error::IxaError;
-use crate::{error, trace};
 use crate::people::ContextPeopleExt;
 use crate::Tabulator;
+use crate::{error, trace};
 use csv::Writer;
 use std::any::TypeId;
 use std::cell::{RefCell, RefMut};

--- a/src/report.rs
+++ b/src/report.rs
@@ -1,5 +1,6 @@
 use crate::context::Context;
 use crate::error::IxaError;
+use crate::{error, trace};
 use crate::people::ContextPeopleExt;
 use crate::Tabulator;
 use csv::Writer;
@@ -25,6 +26,7 @@ impl ConfigReportOptions {
     #[must_use]
     #[allow(clippy::missing_panics_doc)]
     pub fn new() -> Self {
+        trace!("new ConfigReportOptions");
         // Sets the defaults
         ConfigReportOptions {
             file_prefix: String::new(),
@@ -34,16 +36,19 @@ impl ConfigReportOptions {
     }
     /// Sets the file prefix option (e.g., "report_")
     pub fn file_prefix(&mut self, file_prefix: String) -> &mut ConfigReportOptions {
+        trace!("setting report prefix to {}", file_prefix);
         self.file_prefix = file_prefix;
         self
     }
     /// Sets the directory where reports will be output
     pub fn directory(&mut self, directory: PathBuf) -> &mut ConfigReportOptions {
+        trace!("setting report directory to {:?}", directory);
         self.output_dir = directory;
         self
     }
     /// Sets whether to overwrite existing reports of the same name if they exist
     pub fn overwrite(&mut self, overwrite: bool) -> &mut ConfigReportOptions {
+        trace!("setting report overwrite {}", overwrite);
         self.overwrite = overwrite;
         self
     }
@@ -144,6 +149,7 @@ pub trait ContextReportExt {
 
 impl ContextReportExt for Context {
     fn add_report_by_type_id(&mut self, type_id: TypeId, short_name: &str) -> Result<(), IxaError> {
+        trace!("adding report {} by type_id {:?}", short_name, type_id);
         let path = self.generate_filename(short_name);
 
         let data_container = self.get_data_container_mut(ReportPlugin);
@@ -156,7 +162,7 @@ impl ContextReportExt for Context {
                     if data_container.config.overwrite {
                         File::create(&path)?
                     } else {
-                        println!("File already exists: {}. Please set `overwrite` to true in the file configuration and rerun.", path.display());
+                        error!("File already exists: {}. Please set `overwrite` to true in the file configuration and rerun.", path.display());
                         return Err(IxaError::IoError(e));
                     }
                 }
@@ -171,6 +177,7 @@ impl ContextReportExt for Context {
         Ok(())
     }
     fn add_report<T: Report + 'static>(&mut self, short_name: &str) -> Result<(), IxaError> {
+        trace!("Adding report {}", short_name);
         self.add_report_by_type_id(TypeId::of::<T>(), short_name)
     }
     fn add_periodic_report<T: Tabulator + Clone + 'static>(
@@ -179,6 +186,8 @@ impl ContextReportExt for Context {
         period: f64,
         tabulator: T,
     ) -> Result<(), IxaError> {
+        trace!("Adding periodic report {}", short_name);
+
         self.add_report_by_type_id(TypeId::of::<T>(), short_name)?;
 
         {

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -5,6 +5,8 @@ use crate::global_properties::ContextGlobalPropertiesExt;
 use crate::random::ContextRandomExt;
 use crate::report::ContextReportExt;
 use crate::{context::Context, debugger::ContextDebugExt, web_api::ContextWebApiExt};
+use crate::{enable_logging, info};
+
 use clap::{Args, Command, FromArgMatches as _};
 
 /// Default cli arguments for ixa runner
@@ -22,17 +24,22 @@ pub struct BaseArgs {
     #[arg(short, long = "output")]
     pub output_dir: Option<PathBuf>,
 
-    // Optional prefix for report files
+    /// Optional prefix for report files
     #[arg(long = "prefix")]
     pub file_prefix: Option<String>,
 
-    // Overwrite existing report files?
+    /// Overwrite existing report files?
     #[arg(short, long)]
     pub force_overwrite: bool,
+
+    /// Enable logging
+    #[arg(short, long)]
+    pub enable_logging: bool,
 
     /// Set a breakpoint at a given time and start the debugger. Defaults to t=0.0
     #[arg(short, long)]
     pub debugger: Option<Option<f64>>,
+}
 
     /// Enable the Web API at a given time. Defaults to t=0.0
     #[arg(short, long)]
@@ -46,6 +53,7 @@ impl BaseArgs {
             output_dir: None,
             file_prefix: None,
             force_overwrite: false,
+            enable_logging: false,
             debugger: None,
             web: None,
         }
@@ -140,6 +148,13 @@ where
     }
     if args.force_overwrite {
         report_config.overwrite(true);
+    }
+    if args.enable_logging {
+        enable_logging();
+        info!("Logging enabled.");
+    } else {
+        // Not emitted.
+        info!("Logging disabled.");
     }
 
     context.init_random(args.random_seed);
@@ -272,6 +287,14 @@ mod tests {
             assert_eq!(c.unwrap().a, 42);
             Ok(())
         });
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn test_run_with_logging_enabled() {
+        let mut test_args = BaseArgs::new();
+        test_args.enable_logging = true;
+        let result = run_with_args_internal(test_args, None, |_, _, _: Option<()>| Ok(()));
         assert!(result.is_ok());
     }
 }

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -5,7 +5,7 @@ use crate::global_properties::ContextGlobalPropertiesExt;
 use crate::random::ContextRandomExt;
 use crate::report::ContextReportExt;
 use crate::{context::Context, debugger::ContextDebugExt, web_api::ContextWebApiExt};
-use crate::{enable_logging, info};
+use crate::{info, set_log_level, LevelFilter};
 
 use clap::{Args, Command, FromArgMatches as _};
 
@@ -34,17 +34,17 @@ pub struct BaseArgs {
 
     /// Enable logging
     #[arg(short, long)]
-    pub enable_logging: bool,
+    pub log_level: Option<LevelFilter>,
 
     /// Set a breakpoint at a given time and start the debugger. Defaults to t=0.0
     #[arg(short, long)]
     pub debugger: Option<Option<f64>>,
-}
 
     /// Enable the Web API at a given time. Defaults to t=0.0
     #[arg(short, long)]
     pub web: Option<Option<u16>>,
 }
+
 impl BaseArgs {
     fn new() -> Self {
         BaseArgs {
@@ -53,7 +53,7 @@ impl BaseArgs {
             output_dir: None,
             file_prefix: None,
             force_overwrite: false,
-            enable_logging: false,
+            log_level: None,
             debugger: None,
             web: None,
         }
@@ -104,7 +104,7 @@ where
 /// This function parses command line arguments allows you to define a setup function
 ///
 /// # Parameters
-/// - `setup_fn`: A function that takes a mutable reference to a `Context`and `BaseArgs` struct
+/// - `setup_fn`: A function that takes a mutable reference to a `Context` and `BaseArgs` struct
 ///
 /// # Errors
 /// Returns an error if argument parsing or the setup function fails
@@ -149,11 +149,10 @@ where
     if args.force_overwrite {
         report_config.overwrite(true);
     }
-    if args.enable_logging {
-        enable_logging();
-        info!("Logging enabled.");
+    if let Some(level) = args.log_level {
+        set_log_level(level);
+        info!("Logging enabled at level {level}");
     } else {
-        // Not emitted.
         info!("Logging disabled.");
     }
 
@@ -293,7 +292,7 @@ mod tests {
     #[test]
     fn test_run_with_logging_enabled() {
         let mut test_args = BaseArgs::new();
-        test_args.enable_logging = true;
+        test_args.log_level = Some(LevelFilter::Info);
         let result = run_with_args_internal(test_args, None, |_, _, _: Option<()>| Ok(()));
         assert!(result.is_ok());
     }


### PR DESCRIPTION
Added `trace!` statements to `basic-infection` and enabled logging.
Added `trace!` statements throughout Ixa proper.
Added a default set of module log level filters, as it turns out rustyline logs trace messages, which are noisy. Modified `examples/basic-infection` to accept command line arguments.