### PR TITLE
Add an external tabulate API.

### DIFF
--- a/src/people/external_api.rs
+++ b/src/people/external_api.rs
@@ -1,3 +1,7 @@
+use std::any::TypeId;
+use std::collections::HashMap;
+
+use crate::people::ContextPeopleExt;
 use crate::people::PeoplePlugin;
 use crate::Context;
 use crate::IxaError;
@@ -9,6 +13,16 @@ pub(crate) trait ContextPeopleExtCrate {
         name: &str,
         person_id: PersonId,
     ) -> Result<String, IxaError>;
+
+    fn tabulate_person_properties_by_name<F>(
+        &self,
+        properties: Vec<String>,
+        print_fn: F,
+    ) -> Result<(), IxaError>
+    where
+        F: Fn(&Context, &[String], usize);
+
+    fn index_property_by_id(&self, type_id: TypeId);
 }
 
 impl ContextPeopleExtCrate for Context {
@@ -26,14 +40,54 @@ impl ContextPeopleExtCrate for Context {
         let methods = data_container.get_methods(type_id);
         Ok((methods.get_display)(self, person_id))
     }
+
+    fn tabulate_person_properties_by_name<F>(
+        &self,
+        properties: Vec<String>,
+        print_fn: F,
+    ) -> Result<(), IxaError>
+    where
+        F: Fn(&Context, &[String], usize),
+    {
+        let data_container = self.get_data_container(PeoplePlugin);
+        if data_container.is_none() {
+            return Ok(());
+        }
+        let data_container = data_container.unwrap();
+        let people_types = data_container.people_types.borrow();
+
+        let mut query = Vec::new();
+        for name in properties {
+            let type_id = people_types
+                .get(&name.to_string())
+                .ok_or(IxaError::IxaError(format!("No property '{name}'")))?;
+
+            query.push((*type_id, name.to_string()));
+        }
+
+        self.tabulate_person_properties(&query, print_fn);
+        Ok(())
+    }
+
+    fn index_property_by_id(&self, type_id: TypeId) {
+        let data_container = self.get_data_container(PeoplePlugin).unwrap();
+
+        let mut index = data_container.get_index_ref_mut(type_id).unwrap();
+        if index.lookup.is_none() {
+            index.lookup = Some(HashMap::new());
+        }
+    }
 }
 
 #[cfg(test)]
 mod test {
+    use std::cell::RefCell;
+    use std::collections::HashSet;
+
     use super::ContextPeopleExtCrate;
     use crate::people::{define_person_property, ContextPeopleExt};
-    use crate::Context;
     use crate::ContextRandomExt;
+    use crate::{define_person_property_with_default, Context};
 
     define_person_property!(Age, u8);
 
@@ -55,5 +109,55 @@ mod test {
         let person1 = context.add_person((Age, 10)).unwrap();
         let age = context.get_person_property_by_name("Unknown", person1);
         assert!(age.is_err());
+    }
+
+    define_person_property_with_default!(IsRunner, bool, false);
+    define_person_property_with_default!(IsSwimmer, bool, false);
+
+    fn tabulate_properties_test_setup(
+        tabulator: Vec<String>,
+        setup: impl FnOnce(&mut Context),
+        expected_values: &HashSet<(Vec<String>, usize)>,
+    ) {
+        let mut context = Context::new();
+        setup(&mut context);
+
+        let results: RefCell<HashSet<(Vec<String>, usize)>> = RefCell::new(HashSet::new());
+        context
+            .tabulate_person_properties_by_name(tabulator, |_context, values, count| {
+                results.borrow_mut().insert((values.to_vec(), count));
+            })
+            .unwrap();
+
+        let results = &*results.borrow();
+        assert_eq!(results, expected_values);
+    }
+
+    #[test]
+    fn test_get_counts_multi_by_name() {
+        let tabulator = vec![String::from("IsRunner"), String::from("IsSwimmer")];
+        let mut expected = HashSet::new();
+        expected.insert((vec!["false".to_string(), "false".to_string()], 3));
+        expected.insert((vec!["false".to_string(), "true".to_string()], 1));
+        expected.insert((vec!["true".to_string(), "false".to_string()], 1));
+        expected.insert((vec!["true".to_string(), "true".to_string()], 1));
+
+        tabulate_properties_test_setup(
+            tabulator,
+            |context| {
+                context.add_person(()).unwrap();
+                context.add_person(()).unwrap();
+                context.add_person(()).unwrap();
+                let bob = context.add_person(()).unwrap();
+                let anne = context.add_person(()).unwrap();
+                let charlie = context.add_person(()).unwrap();
+
+                context.set_person_property(bob, IsRunner, true);
+                context.set_person_property(charlie, IsRunner, true);
+                context.set_person_property(anne, IsSwimmer, true);
+                context.set_person_property(charlie, IsSwimmer, true);
+            },
+            &expected,
+        );
     }
 }

--- a/src/report.rs
+++ b/src/report.rs
@@ -202,8 +202,6 @@ impl ContextReportExt for Context {
                 .expect("Failed to write header");
         }
 
-        tabulator.setup(self);
-
         self.add_periodic_plan_with_phase(
             period,
             move |context: &mut Context| {

--- a/src/web_api.rs
+++ b/src/web_api.rs
@@ -295,6 +295,7 @@ mod tests {
     // TODO(cym4@cdc.gov): Consider using some kind of static
     // object to isolate the test cases.
 
+    #[allow(clippy::too_many_lines)]
     #[test]
     fn web_api_test() {
         #[derive(Serialize)]
@@ -360,7 +361,7 @@ mod tests {
             })
         );
 
-        // Test the global property get API point.
+        // Next time.
         let res = send_request(
             &url,
             "next",
@@ -372,6 +373,7 @@ mod tests {
         );
         assert_eq!(res, json!({}));
 
+        // Person properties API.
         let res = send_request(
             &url,
             "people",
@@ -391,6 +393,33 @@ mod tests {
             ]}
             )
         );
+
+        // Tabulate API.
+        let res = send_request(
+            &url,
+            "people",
+            &json!({
+                "People" : {
+                    "Tabulate" : {
+                        "properties": ["Age"]
+                    }
+                }
+            }),
+        );
+
+        // This is a hack to deal with these arriving in
+        // arbitrary order.
+        assert!(
+            (res == json!({"Tabulated" : [
+                [{ "Age" :  "1" }, 1],
+                [{ "Age" :  "2" }, 1]
+            ]})) || (res
+                == json!({"Tabulated" : [
+                    [{ "Age" :  "2" }, 1],
+                    [{ "Age" :  "1" }, 1]
+                ]})),
+        );
+
         // Valid JSON but wrong type.
         let res = send_request_text(
             &url,


### PR DESCRIPTION
This exposes an external API to allow you to tabulate person properties. The major difference from the internal API is that it takes property names as strings. This API is plumbed up to the Web API but could also be plumbed to the debugger.