### PR TITLE
Added query_and utility

### DIFF
--- a/src/people/context_extension.rs
+++ b/src/people/context_extension.rs
@@ -268,7 +268,7 @@ impl ContextPeopleExt for Context {
             return Vec::new();
         }
 
-        T::setup(self);
+        T::setup(&q, self);
         let mut result = Vec::new();
         self.query_people_internal(
             |person| {
@@ -285,7 +285,7 @@ impl ContextPeopleExt for Context {
             return 0;
         }
 
-        T::setup(self);
+        T::setup(&q, self);
         let mut count: usize = 0;
         self.query_people_internal(
             |_person| {
@@ -297,7 +297,7 @@ impl ContextPeopleExt for Context {
     }
 
     fn match_person<T: Query>(&self, person_id: PersonId, q: T) -> bool {
-        T::setup(self);
+        T::setup(&q, self);
         // This cannot fail because someone must have been made by now.
         let data_container = self.get_data_container(PeoplePlugin).unwrap();
 
@@ -405,7 +405,7 @@ impl ContextPeopleExt for Context {
             return Ok(PersonId(result));
         }
 
-        T::setup(self);
+        T::setup(&query, self);
 
         // This function implements "Algorithm L" from KIM-HUNG LI
         // Reservoir-Sampling Algorithms of Time Complexity O(n(1 + log(N/n)))

--- a/src/people/mod.rs
+++ b/src/people/mod.rs
@@ -76,7 +76,7 @@ mod index;
 pub(crate) mod methods;
 mod property;
 mod query;
-pub use query::{query_and, QueryAnd};
+pub use query::{query_and, Query, QueryAnd};
 
 use crate::{context::Context, define_data_plugin};
 pub use context_extension::ContextPeopleExt;

--- a/src/people/mod.rs
+++ b/src/people/mod.rs
@@ -76,6 +76,7 @@ mod index;
 pub(crate) mod methods;
 mod property;
 mod query;
+pub use query::{query_and, QueryAnd};
 
 use crate::{context::Context, define_data_plugin};
 pub use context_extension::ContextPeopleExt;

--- a/src/people/mod.rs
+++ b/src/people/mod.rs
@@ -76,7 +76,7 @@ mod index;
 pub(crate) mod methods;
 mod property;
 mod query;
-pub use query::{query_and, Query, QueryAnd};
+pub use query::{Query, QueryAnd};
 
 use crate::{context::Context, define_data_plugin};
 pub use context_extension::ContextPeopleExt;

--- a/src/people/query.rs
+++ b/src/people/query.rs
@@ -9,12 +9,12 @@ use std::any::TypeId;
 /// we implement Query for tuples of up to size 20, that's invisible
 /// to the caller. Do not use this trait directly.
 pub trait Query {
-    fn setup(context: &Context);
+    fn setup(&self, context: &Context);
     fn get_query(&self) -> Vec<(TypeId, IndexValue)>;
 }
 
 impl Query for () {
-    fn setup(_: &Context) {}
+    fn setup(&self, _: &Context) {}
 
     fn get_query(&self) -> Vec<(TypeId, IndexValue)> {
         vec![]
@@ -23,7 +23,7 @@ impl Query for () {
 
 // Implement the query version with one parameter.
 impl<T1: PersonProperty + 'static> Query for (T1, T1::Value) {
-    fn setup(context: &Context) {
+    fn setup(&self, context: &Context) {
         context.register_property::<T1>();
     }
 
@@ -46,7 +46,7 @@ macro_rules! impl_query {
                 )*
             )
             {
-                fn setup(context: &Context) {
+                fn setup(&self, context: &Context) {
                     #(
                         context.register_property::<T~N>();
                     )*
@@ -68,8 +68,52 @@ seq!(Z in 1..20 {
     impl_query!(Z);
 });
 
+pub struct QueryAnd<Q1, Q2>
+where
+    Q1: Query,
+    Q2: Query,
+{
+    queries: (Q1, Q2),
+}
+
+/// Helper utility for combining two queries, useful if you want
+/// to iteratively construct a query in multiple parts.
+///
+/// Example:
+/// ```
+/// let q1 = (Age, 42);
+/// let q2 = (RiskCategory, RiskCategoryValue::High);
+/// context.query_people(query_and(q1, q2));
+/// ```
+pub fn query_and<Q1, Q2>(q1: Q1, q2: Q2) -> QueryAnd<Q1, Q2>
+where
+    Q1: Query,
+    Q2: Query,
+{
+    QueryAnd { queries: (q1, q2) }
+}
+
+impl<Q1, Q2> Query for QueryAnd<Q1, Q2>
+where
+    Q1: Query,
+    Q2: Query,
+{
+    fn setup(&self, context: &Context) {
+        Q1::setup(&self.queries.0, context);
+        Q2::setup(&self.queries.1, context);
+    }
+
+    fn get_query(&self) -> Vec<(TypeId, IndexValue)> {
+        let mut query = Vec::new();
+        query.extend_from_slice(&self.queries.0.get_query());
+        query.extend_from_slice(&self.queries.1.get_query());
+        query
+    }
+}
+
 #[cfg(test)]
 mod tests {
+    use crate::people::query_and;
     use crate::people::PeoplePlugin;
     use crate::{define_derived_property, define_person_property, Context, ContextPeopleExt};
     use std::any::TypeId;
@@ -335,5 +379,33 @@ mod tests {
 
         assert_eq!(seniors.len(), 2, "Two seniors");
         assert_eq!(not_seniors.len(), 0, "No non-seniors");
+    }
+
+    #[test]
+    fn query_and_returns_people() {
+        let mut context = Context::new();
+        context
+            .add_person(((Age, 42), (RiskCategory, RiskCategoryValue::High)))
+            .unwrap();
+
+        let q1 = (Age, 42);
+        let q2 = (RiskCategory, RiskCategoryValue::High);
+
+        let people = context.query_people(query_and(q1, q2));
+        assert_eq!(people.len(), 1);
+    }
+
+    #[test]
+    fn query_and_conflicting() {
+        let mut context = Context::new();
+        context
+            .add_person(((Age, 42), (RiskCategory, RiskCategoryValue::High)))
+            .unwrap();
+
+        let q1 = (Age, 42);
+        let q2 = (Age, 64);
+
+        let people = context.query_people(query_and(q1, q2));
+        assert_eq!(people.len(), 0);
     }
 }

--- a/src/people/query.rs
+++ b/src/people/query.rs
@@ -81,8 +81,12 @@ where
 ///
 /// Example:
 /// ```
+/// use ixa::{define_person_property, people::query_and, Context, ContextPeopleExt};
+/// define_person_property!(Age, u8);
+/// define_person_property!(Alive, bool);
+/// let context = Context::new();
 /// let q1 = (Age, 42);
-/// let q2 = (RiskCategory, RiskCategoryValue::High);
+/// let q2 = (Alive, true);
 /// context.query_people(query_and(q1, q2));
 /// ```
 pub fn query_and<Q1, Q2>(q1: Q1, q2: Q2) -> QueryAnd<Q1, Q2>


### PR DESCRIPTION
My use case here is that I'd like to support being able to construct queries across function boundaries, for example:

```rust
fn get_susceptible_people<Q>(context: &Context, q) where Q: Query {
    let base_query = ((Alive, true), (InfectionStatus, InfectionStatusValue::Susceptible));
    context.query_people(query_add(q, base_query));
}

let other_properties = ((RiskCategory, RiskCategory::High), (Region, CA));
let people = get_susceptible_people(context, extra_query); 

```