### PR TITLE
Replace `Hash` with `Serialize` for `IndexValue`s. Fixes #189

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ csv = "^1.3.1"
 serde = { version = "^1.0.217", features = ["derive"] }
 serde_derive = "^1.0.217"
 serde_json = "^1.0.135"
+bincode = "^1.3.3"
 reikna = "^0.12.3"
 roots = "0.0.8"
 ixa-derive = { path = "ixa-derive" }

--- a/examples/load-people/population_loader.rs
+++ b/examples/load-people/population_loader.rs
@@ -5,8 +5,9 @@ use ixa::context::Context;
 use ixa::define_person_property;
 use ixa::{ContextPeopleExt, PersonId};
 use serde::Deserialize;
+use serde_derive::Serialize;
 
-#[derive(Deserialize, Copy, Clone, PartialEq, Eq, Debug, Hash)]
+#[derive(Serialize, Deserialize, Copy, Clone, PartialEq, Eq, Debug, Hash)]
 pub enum RiskCategoryValue {
     High,
     Low,

--- a/examples/load-people/sir.rs
+++ b/examples/load-people/sir.rs
@@ -3,8 +3,9 @@ use ixa::{
     define_person_property_with_default,
     people::{ContextPeopleExt, PersonCreatedEvent},
 };
+use serde_derive::Serialize;
 
-#[derive(Copy, Clone, PartialEq, Eq, Debug, Hash)]
+#[derive(Serialize, Copy, Clone, PartialEq, Eq, Debug)]
 pub enum DiseaseStatusValue {
     S,
     I,

--- a/examples/load-people/vaccine.rs
+++ b/examples/load-people/vaccine.rs
@@ -1,23 +1,21 @@
-use std::hash::Hash;
-
 use crate::population_loader::{Age, RiskCategoryValue};
 use ixa::{
     context::Context, define_person_property, define_rng, people::ContextPeopleExt,
     random::ContextRandomExt,
 };
-use ordered_float::OrderedFloat;
+use serde_derive::Serialize;
 
 define_rng!(VaccineRng);
 
 #[allow(clippy::module_name_repetitions)]
-#[derive(Copy, Clone, PartialEq, Eq, Debug, Hash)]
+#[derive(Serialize, Copy, Clone, PartialEq, Eq, Debug)]
 pub enum VaccineTypeValue {
     A,
     B,
 }
 
 define_person_property!(VaccineType, VaccineTypeValue);
-define_person_property!(VaccineEfficacy, OrderedFloat<f64>);
+define_person_property!(VaccineEfficacy, f64);
 define_person_property!(VaccineDoses, u8, |context: &Context, person_id| {
     let age = context.get_person_property(person_id, Age);
     if age > 10 {
@@ -28,18 +26,15 @@ define_person_property!(VaccineDoses, u8, |context: &Context, person_id| {
 });
 
 pub trait ContextVaccineExt {
-    fn get_vaccine_props(&self, risk: RiskCategoryValue) -> (VaccineTypeValue, OrderedFloat<f64>);
+    fn get_vaccine_props(&self, risk: RiskCategoryValue) -> (VaccineTypeValue, f64);
 }
 
 impl ContextVaccineExt for Context {
-    fn get_vaccine_props(
-        self: &Context,
-        risk: RiskCategoryValue,
-    ) -> (VaccineTypeValue, OrderedFloat<f64>) {
+    fn get_vaccine_props(self: &Context, risk: RiskCategoryValue) -> (VaccineTypeValue, f64) {
         if risk == RiskCategoryValue::High {
-            (VaccineTypeValue::A, OrderedFloat(0.9))
+            (VaccineTypeValue::A, 0.9)
         } else {
-            (VaccineTypeValue::B, OrderedFloat(0.8))
+            (VaccineTypeValue::B, 0.8)
         }
     }
 }

--- a/examples/network-hhmodel/loader.rs
+++ b/examples/network-hhmodel/loader.rs
@@ -5,11 +5,12 @@ use ixa::context::Context;
 use ixa::define_person_property;
 use ixa::{ContextPeopleExt, PersonId};
 use serde::Deserialize;
+use serde_derive::Serialize;
 use std::fs::File;
 
 define_person_property!(Id, u16);
 
-#[derive(Deserialize, Copy, Clone, PartialEq, Eq, Debug, Hash)]
+#[derive(Serialize, Deserialize, Copy, Clone, PartialEq, Eq, Debug)]
 pub enum AgeGroupValue {
     AgeUnder5,
     Age5to17,
@@ -18,7 +19,7 @@ pub enum AgeGroupValue {
 }
 define_person_property!(AgeGroup, AgeGroupValue);
 
-#[derive(Deserialize, Copy, Clone, PartialEq, Eq, Debug, Hash)]
+#[derive(Serialize, Deserialize, Copy, Clone, PartialEq, Eq, Debug, Hash)]
 pub enum SexValue {
     Female,
     Male,
@@ -70,7 +71,6 @@ pub fn init(context: &mut Context) -> Vec<PersonId> {
 
 #[cfg(test)]
 mod tests {
-
     use super::*;
     use ixa::{context::Context, random::ContextRandomExt};
 

--- a/examples/network-hhmodel/seir.rs
+++ b/examples/network-hhmodel/seir.rs
@@ -9,8 +9,9 @@ use ixa::{
     ContextGlobalPropertiesExt, ExecutionPhase, PersonId,
 };
 use rand_distr::{Bernoulli, Gamma};
+use serde_derive::Serialize;
 
-#[derive(Copy, Clone, PartialEq, Eq, Debug, Hash)]
+#[derive(Serialize, Copy, Clone, PartialEq, Eq, Debug)]
 pub enum DiseaseStatusValue {
     S,
     E,

--- a/examples/time-varying-infection/exposure_manager.rs
+++ b/examples/time-varying-infection/exposure_manager.rs
@@ -2,13 +2,12 @@ use ixa::define_rng;
 use ixa::people::{ContextPeopleExt, PersonCreatedEvent};
 use ixa::random::ContextRandomExt;
 use ixa::{context::Context, global_properties::ContextGlobalPropertiesExt};
-use ordered_float::OrderedFloat;
 use std::rc::Rc;
 
 use crate::parameters_loader::Parameters;
 use crate::population_loader::{DiseaseStatus, DiseaseStatusValue, InfectionTime};
-use rand_distr::Exp1;
 
+use rand_distr::Exp1;
 use reikna::func;
 use reikna::func::Function;
 use reikna::integral::integrate;
@@ -26,7 +25,7 @@ fn expose_person_to_deviled_eggs(context: &mut Context, person_created_event: Pe
         context.set_person_property(person_id, DiseaseStatus, DiseaseStatusValue::I);
         // For reasons that will become apparent with the recovery rate example,
         // we also need to record the time at which a person becomes infected.
-        context.set_person_property(person_id, InfectionTime, Some(OrderedFloat(t)));
+        context.set_person_property(person_id, InfectionTime, Some(t));
     });
 }
 

--- a/examples/time-varying-infection/infection_manager.rs
+++ b/examples/time-varying-infection/infection_manager.rs
@@ -33,7 +33,7 @@ fn evaluate_recovery(
 ) -> Option<f64> {
     // get time person has spent infected
     let time_spent_infected = context.get_current_time()
-        - *context
+        - context
             .get_person_property(person_id, InfectionTime)
             .unwrap();
     // evaluate whether recovery has happened by this time or not
@@ -88,7 +88,6 @@ mod test {
     use ixa::context::Context;
     use ixa::people::{ContextPeopleExt, PersonPropertyChangeEvent};
     use ixa::random::ContextRandomExt;
-    use ordered_float::OrderedFloat;
 
     use crate::parameters_loader::ParametersValues;
     use crate::population_loader::{DiseaseStatus, DiseaseStatusValue};
@@ -124,9 +123,7 @@ mod test {
         init(&mut context);
 
         for _ in 0..parameters.population {
-            let person_id = context
-                .add_person((InfectionTime, Some(OrderedFloat(0.0))))
-                .unwrap();
+            let person_id = context.add_person((InfectionTime, Some(0.0))).unwrap();
             context.set_person_property(person_id, DiseaseStatus, DiseaseStatusValue::I);
         }
 
@@ -212,9 +209,7 @@ mod test {
                 .unwrap();
             context.init_random(seed);
             init(&mut context);
-            let person_id = context
-                .add_person((InfectionTime, Some(OrderedFloat(0.0))))
-                .unwrap();
+            let person_id = context.add_person((InfectionTime, Some(0.0))).unwrap();
             context.set_person_property(person_id, DiseaseStatus, DiseaseStatusValue::I);
             // there should only be one infected person in the simulation
             assert_eq!(

--- a/examples/time-varying-infection/population_loader.rs
+++ b/examples/time-varying-infection/population_loader.rs
@@ -2,7 +2,6 @@ use ixa::context::Context;
 use ixa::define_person_property_with_default;
 use ixa::global_properties::ContextGlobalPropertiesExt;
 use ixa::people::ContextPeopleExt;
-use ordered_float::OrderedFloat;
 use serde::{Deserialize, Serialize};
 
 use crate::parameters_loader::Parameters;
@@ -15,7 +14,7 @@ pub enum DiseaseStatusValue {
 }
 
 define_person_property_with_default!(DiseaseStatus, DiseaseStatusValue, DiseaseStatusValue::S);
-define_person_property_with_default!(InfectionTime, Option<OrderedFloat<f64>>, None);
+define_person_property_with_default!(InfectionTime, Option<f64>, None);
 
 pub fn init(context: &mut Context) {
     let parameters = context

--- a/src/people/context_extension.rs
+++ b/src/people/context_extension.rs
@@ -587,12 +587,13 @@ mod tests {
         define_person_property_with_default, Context, ContextGlobalPropertiesExt, ContextPeopleExt,
         IxaError, PersonId, PersonPropertyChangeEvent,
     };
+    use serde_derive::Serialize;
     use std::any::TypeId;
     use std::cell::RefCell;
     use std::rc::Rc;
 
     define_person_property!(Age, u8);
-    #[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
+    #[derive(Serialize, Copy, Clone, Debug, PartialEq, Eq)]
     pub enum AgeGroupValue {
         Child,
         Adult,
@@ -619,7 +620,7 @@ mod tests {
         }
     });
 
-    #[derive(Copy, Clone, PartialEq, Eq, Debug, Hash)]
+    #[derive(Serialize, Copy, Clone, PartialEq, Eq, Debug)]
     pub enum RiskCategoryValue {
         High,
         Low,

--- a/src/people/event.rs
+++ b/src/people/event.rs
@@ -38,11 +38,12 @@ mod tests {
         define_person_property_with_default, Context, ContextPeopleExt, PersonCreatedEvent,
         PersonId, PersonPropertyChangeEvent,
     };
+    use serde_derive::Serialize;
     use std::cell::RefCell;
     use std::rc::Rc;
 
     define_person_property!(Age, u8);
-    #[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
+    #[derive(Serialize, Copy, Clone, Debug, PartialEq, Eq, Hash)]
     pub enum AgeGroupValue {
         Child,
         Adult,
@@ -60,7 +61,7 @@ mod tests {
         }
     });
 
-    #[derive(Copy, Clone, PartialEq, Eq, Debug, Hash)]
+    #[derive(Serialize, Copy, Clone, PartialEq, Eq, Debug)]
     pub enum RiskCategoryValue {
         High,
         Low,

--- a/src/people/property.rs
+++ b/src/people/property.rs
@@ -1,16 +1,16 @@
 use crate::people::data::PersonPropertyHolder;
 use crate::{Context, PersonId};
+use serde::Serialize;
 use std::fmt::Debug;
-use std::hash::Hash;
 
 /// An individual characteristic or state related to a person, such as age or
 /// disease status.
 ///
-/// Person properties should defined with the [`define_person_property!()`],
+/// Person properties should be defined with the [`define_person_property!()`],
 /// [`define_person_property_with_default!()`] and [`define_derived_property!()`]
 /// macros.
 pub trait PersonProperty: Copy {
-    type Value: Copy + Debug + PartialEq + Hash;
+    type Value: Copy + Debug + PartialEq + Serialize;
     #[must_use]
     fn is_derived() -> bool {
         false

--- a/src/people/query.rs
+++ b/src/people/query.rs
@@ -124,11 +124,12 @@ mod tests {
     use crate::people::PeoplePlugin;
     use crate::people::{Query, QueryAnd};
     use crate::{define_derived_property, define_person_property, Context, ContextPeopleExt};
+    use serde_derive::Serialize;
     use std::any::TypeId;
 
     define_person_property!(Age, u8);
 
-    #[derive(Copy, Clone, PartialEq, Eq, Debug, Hash)]
+    #[derive(Serialize, Copy, Clone, PartialEq, Eq, Debug)]
     pub enum RiskCategoryValue {
         High,
         Low,


### PR DESCRIPTION
This changes replaces the requirement that `PersonProperty::Value` implement `Hash` with the requirement that `PersonProperty::Value` implement `Serialize`. This allows for `f64` to be used in properties without the need to be wrapped in `OrderedFloat`.