### PR TITLE
Integrate Benchmarks Into CI

### DIFF
--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -14,10 +14,12 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v4
-    - name: Build
-      run: cargo build --verbose
-    - name: Run tests
-      run: cargo test --verbose
-    - name: Run examples
-      run: cargo test --examples
+      - uses: actions/checkout@v4
+      - name: Build
+        run: cargo build --verbose
+      - name: Build benchmarks
+        run: cargo bench --no-run
+      - name: Run tests
+        run: cargo test --verbose
+      - name: Run examples
+        run: cargo test --examples

--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -1,0 +1,12 @@
+name: Benchmark Pull Requests
+on: [ pull_request ]
+jobs:
+  runBenchmark:
+    name: run benchmark
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: boa-dev/criterion-compare-action@v3
+        with:
+          # Needed. The name of the branch to compare with, uses the branch which is being pulled against
+          branchName: ${{ github.base_ref }}


### PR DESCRIPTION
This WIP PR integrates benchmarks into CI. There are two primary tasks:

1. Build benchmarks
2. Run benchmarks and compare to baseline to detect performance regressions

The first is trivial. The second is complicated.