### PR TITLE
Disabled the libtest benchmark harness in Cargo.toml. Fixes #217.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,13 +48,20 @@ ixa_example_births_deaths = { path = "examples/births-deaths" }
 pedantic = { level = "warn", priority = -1 }
 module-name-repetitions = "allow"
 
+[lib]
+# Prevent Cargo from implicitly linking `libtest` for Criterion.rs compatibility.
+# See https://github.com/CDCgov/ixa/issues/217
+bench = false
+
 [[bin]]
 name = "runner_test_custom_args"
 path = "tests/bin/runner_test_custom_args.rs"
+bench = false
 
 [[bin]]
 name = "runner_test_debug"
 path = "tests/bin/runner_test_debug.rs"
+bench = false
 
 [[bench]]
 name = "example_basic_infection"


### PR DESCRIPTION
Addresses issue #217 and unblocks more sophisticated interactions with the benchmarks both locally and in CI. Issue #217 and[the Criterion FAQ](https://bheisler.github.io/criterion.rs/book/faq.html#cargo-bench-gives-unrecognized-option-errors-for-valid-command-line-options) have the technical details.

Setting `bench = false` to make the benchmarks work is confusing, so I included a comment in Cargo.toml.