### PR TITLE
Upgraded rand crate dependency to v0.9.0. Fixes #238.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,14 +9,13 @@ homepage = "https://github.com/CDCgov/ixa"
 
 [dependencies]
 fxhash = "^0.2.1"
-rand = "^0.8.5"
+rand = "^0.9.0"
 csv = "^1.3.1"
 serde = { version = "^1.0.217", features = ["derive"] }
 serde_derive = "^1.0.217"
 serde_json = "^1.0.135"
 bincode = "^1.3.3"
 reikna = "^0.12.3"
-roots = "0.0.8"
 ixa-derive = { path = "ixa-derive" }
 seq-macro = "^0.3.5"
 paste = "^1.0.15"
@@ -25,20 +24,20 @@ clap = { version = "^4.5.26", features = ["derive"] }
 shlex = "^1.3.0"
 rustyline = "^15.0.0"
 log = "^0.4.22"
-log4rs = { version = "^1.3.0", features = ["console_appender", "pattern_encoder"] }
-axum = "0.8.1"
-tokio = { version = "1", features = ["full"] }
-reqwest = { version = "0.12.12", features = ["blocking", "json"] }
-uuid = "1.12.1"
-tower-http = { version = "0.6.2", features = ["full"] }
-mime = "0.3.17"
+log4rs = { version = "^1.3.0", default-features = false, features = ["console_appender"] }
+axum = "^0.8.1"
+tokio = { version = "^1", features = ["full"] }
+reqwest = { version = "^0.12.12", features = ["blocking", "json"] }
+uuid = "^1.12.1"
+tower-http = { version = "^0.6.2", features = ["full"] }
+mime = "^0.3.17"
 
 [dev-dependencies]
-rand_distr = "^0.4.3"
+rand_distr = "^0.5.1"
 tempfile = "^3.15.0"
-ordered-float = "^4.6.0"
 assert_cmd = "^2.0.16"
 criterion = "^0.5.1"
+roots = "0.0.8"
 
 # Example Libraries
 ixa_example_basic_infection = { path = "examples/basic-infection" }

--- a/examples/basic-infection/Cargo.toml
+++ b/examples/basic-infection/Cargo.toml
@@ -11,8 +11,8 @@ ixa-derive = { path = "../../ixa-derive" }
 
 csv = "^1.3.1"
 serde = "^1.0.217"
-rand = "^0.8.5"
-rand_distr = "^0.4.3"
+rand = "^0.9.0"
+rand_distr = "^0.5.1"
 paste = "^1.0.15"
 
 [[bin]]

--- a/examples/births-deaths/Cargo.toml
+++ b/examples/births-deaths/Cargo.toml
@@ -12,8 +12,8 @@ ixa-derive = { path = "../../ixa-derive" }
 csv = "^1.3.1"
 ctor = "^0.2.8"
 serde = "^1.0.217"
-rand = "^0.8.5"
-rand_distr = "^0.4.3"
+rand = "^0.9.0"
+rand_distr = "^0.5.1"
 paste = "^1.0.15"
 
 [[bin]]

--- a/examples/births-deaths/src/population_manager.rs
+++ b/examples/births-deaths/src/population_manager.rs
@@ -106,7 +106,7 @@ pub fn init(context: &mut Context) {
     for _ in 0..parameters.population {
         let age: u8 = context.sample_range(PeopleRng, 0..MAX_AGE);
         let person = context.add_person((Age, age)).unwrap();
-        let birthday = context.sample_distr(PeopleRng, Uniform::new(0.0, 365.0));
+        let birthday = context.sample_distr(PeopleRng, Uniform::new(0.0, 365.0).unwrap());
         context.add_plan(365.0 + birthday, move |context| {
             schedule_aging(context, person);
         });

--- a/examples/random/main.rs
+++ b/examples/random/main.rs
@@ -1,7 +1,7 @@
 use ixa::context::Context;
 use ixa::define_rng;
 use ixa::random::ContextRandomExt;
-use rand::distributions::Uniform;
+use rand::distr::Uniform;
 use rand::Rng;
 
 static SEED: u64 = 123;
@@ -26,9 +26,9 @@ fn main() {
     });
 
     let recovery_time = if context.sample_bool(MyRng, 0.5) {
-        context.sample_distr(MyRng, Uniform::new(2.0, 10.0))
+        context.sample_distr(MyRng, Uniform::new(2.0, 10.0).unwrap())
     } else {
-        context.sample(MyRng, |rng| rng.gen_range(10.0..20.0))
+        context.sample(MyRng, |rng| rng.random_range(10.0..20.0))
     };
 
     context.add_plan(recovery_time, {

--- a/src/random.rs
+++ b/src/random.rs
@@ -1,7 +1,7 @@
 use crate::context::Context;
 use log::trace;
-use rand::distributions::uniform::{SampleRange, SampleUniform};
-use rand::distributions::WeightedIndex;
+use rand::distr::uniform::{SampleRange, SampleUniform};
+use rand::distr::weighted::{Weight, WeightedIndex};
 use rand::prelude::Distribution;
 use rand::{Rng, SeedableRng};
 use std::any::{Any, TypeId};
@@ -146,7 +146,12 @@ pub trait ContextRandomExt {
     fn sample_weighted<R: RngId + 'static, T>(&self, rng_id: R, weights: &[T]) -> usize
     where
         R::RngType: Rng,
-        T: Clone + Default + SampleUniform + for<'a> std::ops::AddAssign<&'a T> + PartialOrd;
+        T: Clone
+            + Default
+            + SampleUniform
+            + for<'a> std::ops::AddAssign<&'a T>
+            + PartialOrd
+            + Weight;
 }
 
 impl ContextRandomExt for Context {
@@ -189,20 +194,25 @@ impl ContextRandomExt for Context {
         S: SampleRange<T>,
         T: SampleUniform,
     {
-        self.sample(rng_id, |rng| rng.gen_range(range))
+        self.sample(rng_id, |rng| rng.random_range(range))
     }
 
     fn sample_bool<R: RngId + 'static>(&self, rng_id: R, p: f64) -> bool
     where
         R::RngType: Rng,
     {
-        self.sample(rng_id, |rng| rng.gen_bool(p))
+        self.sample(rng_id, |rng| rng.random_bool(p))
     }
 
     fn sample_weighted<R: RngId + 'static, T>(&self, _rng_id: R, weights: &[T]) -> usize
     where
         R::RngType: Rng,
-        T: Clone + Default + SampleUniform + for<'a> std::ops::AddAssign<&'a T> + PartialOrd,
+        T: Clone
+            + Default
+            + SampleUniform
+            + for<'a> std::ops::AddAssign<&'a T>
+            + PartialOrd
+            + Weight,
     {
         let index = WeightedIndex::new(weights).unwrap();
         let mut rng = get_rng::<R>(self);
@@ -215,8 +225,7 @@ mod test {
     use crate::context::Context;
     use crate::define_data_plugin;
     use crate::random::ContextRandomExt;
-    use rand::RngCore;
-    use rand::{distributions::WeightedIndex, prelude::Distribution};
+    use rand::{distr::weighted::WeightedIndex, prelude::Distribution, RngCore};
 
     define_rng!(FooRng);
     define_rng!(BarRng);

--- a/src/web_api.rs
+++ b/src/web_api.rs
@@ -8,7 +8,7 @@ use axum::extract::{Json, Path, State};
 use axum::response::Redirect;
 use axum::routing::get;
 use axum::{http::StatusCode, routing::post, Router};
-use rand::RngCore;
+use rand::TryRngCore;
 use serde_json::json;
 use std::collections::HashMap;
 use std::thread;
@@ -222,7 +222,9 @@ impl ContextWebApiExt for Context {
 
         // Start the API server
         let mut random: [u8; 16] = [0; 16];
-        rand::rngs::OsRng.fill_bytes(&mut random);
+        rand::rngs::OsRng
+            .try_fill_bytes(&mut random)
+            .expect("Failed to generate random number");
         let secret = uuid::Builder::from_random_bytes(random)
             .into_uuid()
             .to_string();


### PR DESCRIPTION
- Upgraded rand crate dependency to v0.9.0, rand_distr to v0.5.1, and adjusted code throughout to accommodate breaking changes.
- Moved roots dependency to dev dependencies.
- Added "or higher" version syntax to web interface dependencies. 
- Removed unused ordered_float dependency.