### PR TITLE
Breakpoint, "next", and "halt" implementation. Fixes #163.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,11 +1,6 @@
-[workspace]
-resolver = "2"
-members = ["ixa-derive"]
-
-
 [package]
 name = "ixa"
-version = "0.1.0"
+version = "0.0.1"
 edition = "2021"
 description = "A framework for building agent-based models"
 repository = "https://github.com/CDCgov/ixa"
@@ -13,7 +8,6 @@ license = "Apache-2.0"
 homepage = "https://github.com/CDCgov/ixa"
 
 [dependencies]
-ixa-derive = { version = "0.0.1", path = "ixa-derive" }
 rand = "^0.8.5"
 csv = "^1.3.1"
 serde = { version = "^1.0.217", features = ["derive"] }
@@ -21,7 +15,7 @@ serde_derive = "^1.0.217"
 serde_json = "^1.0.135"
 bincode = "^1.3.3"
 reikna = "^0.12.3"
-roots = "0.0.8"
+ixa-derive = { path = "ixa-derive" }
 seq-macro = "^0.3.5"
 paste = "^1.0.15"
 ctor = "^0.2.8"
@@ -29,24 +23,22 @@ clap = { version = "^4.5.26", features = ["derive"] }
 shlex = "^1.3.0"
 rustyline = "^15.0.0"
 log = "^0.4.22"
-log4rs = { version = "^1.3.0", features = [
-  "console_appender",
-  "pattern_encoder",
-] }
-axum = "0.8.1"
-tokio = { version = "1", features = ["full"] }
-reqwest = { version = "0.12.12", features = ["blocking", "json"] }
-uuid = "1.12.1"
-tower-http = { version = "0.6.2", features = ["full"] }
-mime = "0.3.17"
+log4rs = { version = "^1.3.0", default-features = false, features = ["console_appender"] }
+axum = "^0.8.1"
+tokio = { version = "^1", features = ["full"] }
+reqwest = { version = "^0.12.12", features = ["blocking", "json"] }
+uuid = "^1.12.1"
+tower-http = { version = "^0.6.2", features = ["full"] }
+mime = "^0.3.17"
 rustc-hash = "^2.1.1"
 
 [dev-dependencies]
 rand_distr = "^0.4.3"
 tempfile = "^3.15.0"
-ordered-float = "^4.6.0"
 assert_cmd = "^2.0.16"
 criterion = "^0.5.1"
+roots = "0.0.8"
+assert_approx_eq = "1.1.0"
 
 # Example Libraries
 ixa_example_basic_infection = { path = "examples/basic-infection" }

--- a/src/context.rs
+++ b/src/context.rs
@@ -40,7 +40,7 @@ pub enum ExecutionPhase {
 
 impl Display for ExecutionPhase {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{:?}", self)
+        write!(f, "{self:?}")
     }
 }
 
@@ -80,6 +80,7 @@ pub struct Context {
     current_time: f64,
     shutdown_requested: bool,
     break_requested: bool,
+    breakpoints_enabled: bool,
 }
 
 impl Context {
@@ -95,6 +96,7 @@ impl Context {
             current_time: 0.0,
             shutdown_requested: false,
             break_requested: false,
+            breakpoints_enabled: true,
         }
     }
 

--- a/src/context.rs
+++ b/src/context.rs
@@ -3,14 +3,14 @@
 //! Defines a `Context` that is intended to provide the foundational mechanism
 //! for storing and manipulating the state of a given simulation.
 use crate::{HashMap, HashMapExt};
+use crate::debugger::enter_debugger;
+use crate::plan::{PlanId, Queue};
+use crate::trace;
 use std::{
     any::{Any, TypeId},
     collections::VecDeque,
     rc::Rc,
 };
-
-use crate::plan::{PlanId, Queue};
-use crate::trace;
 
 /// The common callback used by multiple `Context` methods for future events
 type Callback = dyn FnOnce(&mut Context);

--- a/src/debugger-commands.md
+++ b/src/debugger-commands.md
@@ -27,7 +27,7 @@ command might require an `--id` argument but optionally take a set of properties
 
 ## Command Categories
 
-In addition to some control flow commands (`next`, `continue`, `help`), we
+In addition to some control flow commands (`next`, `continue`, `halt`, `help`), we
 might consider the following commands:
 
 ### 1. Breakpoints
@@ -37,7 +37,7 @@ Note that this will require storing some internal state.
 
 - **`breakpoint set <t>]`**
 
-  Set a breakpoint a given time
+  Set a breakpoint at a given time
 
   Example: `breakpoint set 4.0`
 
@@ -45,12 +45,20 @@ Note that this will require storing some internal state.
 
   List all active breakpoints.
 
-- **`breakpoint delete <id> [--all]`**
+- **`breakpoint delete [<id> | --all]`**
 
   Delete the breakpoint with the specified id.
   Providing the `--all` option removes all breakpoints.
 
   Example: `breakpoint delete 1`
+
+- **`breakpoint disable`**
+
+  Disables all breakpoints globally but does not delete them.
+
+- **`breakpoint enable`**
+
+  Enables all breakpoints globally.
 
 ### 2. Globals
 
@@ -180,7 +188,7 @@ impl DebuggerCommand for GlobalPropertyCommand {
         subcommand
             .subcommand_required(true)
             .subcommand(
-              Command::new("list").about("List all global properties"))
+                Command::new("list").about("List all global properties"))
             .subcommand(
                 Command::new("get")
                     .about("Get the value of a global property")

--- a/src/debugger.rs
+++ b/src/debugger.rs
@@ -252,13 +252,13 @@ fn init(context: &mut Context) {
     if debugger.is_none() {
         trace!("initializing debugger");
         let mut commands: HashMap<&'static str, Box<dyn DebuggerCommand>> = HashMap::new();
-        commands.insert("people", Box::new(PeopleCommand));
-        commands.insert("population", Box::new(PopulationCommand));
-        commands.insert("next", Box::new(NextCommand));
         commands.insert("breakpoint", Box::new(BreakpointCommand));
         commands.insert("continue", Box::new(ContinueCommand));
-        commands.insert("halt", Box::new(HaltCommand));
         commands.insert("global", Box::new(GlobalPropertyCommand));
+        commands.insert("halt", Box::new(HaltCommand));
+        commands.insert("next", Box::new(NextCommand));
+        commands.insert("people", Box::new(PeopleCommand));
+        commands.insert("population", Box::new(PopulationCommand));
 
         let mut cli = Command::new("repl")
             .multicall(true)

--- a/src/debugger.rs
+++ b/src/debugger.rs
@@ -8,8 +8,7 @@ use crate::{HashMap, HashMapExt};
 use clap::{ArgMatches, Command, FromArgMatches, Parser, Subcommand};
 use rustyline;
 
-use std::collections::HashMap;
-use std::io::Write;
+use std::fmt::Write;
 
 trait DebuggerCommand {
     /// Handle the command and any inputs; returning true will exit the debugger
@@ -206,7 +205,7 @@ impl DebuggerCommand for BreakpointCommand {
             Ok(return_value) => {
                 match return_value {
                     breakpoint::Retval::List(bp_list) => {
-                        let mut msg = format!("Scheduled breakpoints: {}", bp_list.len());
+                        let mut msg = format!("Scheduled breakpoints: {}\n", bp_list.len());
                         for bp in bp_list {
                             _ = writeln!(&mut msg, "\t{bp}");
                         }
@@ -391,7 +390,8 @@ mod tests {
 	0: t=1 (First)
 	1: t=2 (First)
 	2: t=3 (Normal)
-	3: t=4 (Last)";
+	3: t=4 (Last)
+";
 
         let (quits, output) = process_line("breakpoint list\n", context);
 
@@ -583,12 +583,7 @@ mod tests {
     fn test_cli_next() {
         let context = &mut Context::new();
         assert_eq!(context.remaining_plan_count(), 0);
-        let (quits, _) = process_line("next 2\n", context);
-        assert!(quits, "should exit");
-        assert_eq!(
-            context.remaining_plan_count(),
-            1,
-            "should schedule a plan for the debugger to pause"
-        );
+        let (quits, _) = process_line("next\n", context);
+        assert!(!quits, "should not exit");
     }
 }

--- a/src/debugger.rs
+++ b/src/debugger.rs
@@ -1,13 +1,17 @@
 use crate::context::run_with_plugin;
 use crate::define_data_plugin;
-use crate::external_api::{global_properties, next, people, population, run_ext_api, EmptyArgs};
+use crate::external_api::{
+    breakpoint, global_properties, halt, next, people, population, run_ext_api, EmptyArgs,
+};
 use crate::Context;
 use crate::IxaError;
+use crate::{info, trace};
+use crate::{HashMap, HashMapExt};
+
 use clap::{ArgMatches, Command, FromArgMatches, Parser, Subcommand};
 use rustyline;
 
-use crate::{HashMap, HashMapExt};
-use log::trace;
+use std::collections::HashMap;
 use std::io::Write;
 
 trait DebuggerCommand {

--- a/src/external_api.rs
+++ b/src/external_api.rs
@@ -189,7 +189,7 @@ pub(crate) mod breakpoint {
                         context.schedule_debugger(*time, None, Box::new(enter_web_debugger));
                     }
 
-                    info!("Breakpoint set at t={}", time);
+                    info!("Breakpoint set at t={time}");
                     Ok(Retval::Ok)
                 }
 

--- a/src/external_api.rs
+++ b/src/external_api.rs
@@ -102,7 +102,7 @@ pub(crate) mod global_properties {
     }
 }
 
-pub(crate) mod next {
+pub(crate) mod breakpoint {
     use crate::context::Context;
     use crate::IxaError;
     use clap::Parser;
@@ -111,9 +111,9 @@ pub(crate) mod next {
     #[derive(Parser, Debug, Deserialize)]
     pub(crate) enum Args {
         /// Continue until the given time and then pause again
-        Next {
+        Breakpoint {
             /// The time to pause at
-            next_time: f64,
+            time: f64,
         },
     }
     #[derive(Serialize)]
@@ -124,12 +124,64 @@ pub(crate) mod next {
         type Retval = Retval;
 
         fn run(context: &mut Context, args: &Args) -> Result<Retval, IxaError> {
-            let Args::Next { next_time } = args;
-            if *next_time < context.get_current_time() {
+            let Args::Breakpoint { time } = args;
+            if *time < context.get_current_time() {
                 return Err(IxaError::from(format!(
-                    "Breakpoint time {next_time} is in the past"
+                    "Breakpoint time {time} is in the past"
                 )));
             }
+            Ok(Retval {})
+        }
+    }
+}
+
+pub(crate) mod next {
+    use crate::context::Context;
+    use crate::IxaError;
+    use clap::Parser;
+    use serde::{Deserialize, Serialize};
+
+    #[derive(Parser, Debug, Deserialize)]
+    pub(crate) enum Args {
+        /// Execute the next callback or scheduled plan and return to debugger
+        Next,
+    }
+    #[derive(Serialize)]
+    pub(crate) struct Retval {}
+    #[allow(unused)]
+    pub(crate) struct Api {}
+    impl super::ExtApi for Api {
+        type Args = Args;
+        type Retval = Retval;
+
+        fn run(_context: &mut Context, _args: &Args) -> Result<Retval, IxaError> {
+            // This is a no-op which allows for arg checking.
+            Ok(Retval {})
+        }
+    }
+}
+
+pub(crate) mod halt {
+    use crate::context::Context;
+    use crate::IxaError;
+    use clap::Parser;
+    use serde::{Deserialize, Serialize};
+
+    #[derive(Parser, Debug, Deserialize)]
+    pub(crate) enum Args {
+        /// Execute the next callback or scheduled plan and return to debugger
+        Halt,
+    }
+    #[derive(Serialize)]
+    pub(crate) struct Retval {}
+    #[allow(unused)]
+    pub(crate) struct Api {}
+    impl super::ExtApi for Api {
+        type Args = Args;
+        type Retval = Retval;
+
+        fn run(_context: &mut Context, _args: &Args) -> Result<Retval, IxaError> {
+            // This is a no-op which allows for arg checking.
             Ok(Retval {})
         }
     }

--- a/src/external_api.rs
+++ b/src/external_api.rs
@@ -39,7 +39,7 @@ pub(crate) mod population {
         pub population: usize,
     }
     impl super::ExtApi for Api {
-        type Args = super::EmptyArgs;
+        type Args = EmptyArgs;
         type Retval = Retval;
 
         fn run(context: &mut Context, _args: &EmptyArgs) -> Result<Retval, IxaError> {
@@ -131,7 +131,7 @@ pub(crate) mod breakpoint {
             id: Option<u32>,
 
             /// Remove all breakpoints
-            #[arg(long)]
+            #[arg(long, action)]
             all: bool,
         },
         /// Disables but does not delete breakpoints globally
@@ -195,7 +195,7 @@ pub(crate) mod breakpoint {
 
                 ArgsEnum::Delete { id, all } => {
                     if let Some(id) = id {
-                        assert!(!*all);
+                        assert!(!all);
                         trace!("Deleting breakpoint {id}");
                         let cancelled = context.delete_breakpoint(u64::from(*id));
                         if cancelled.is_none() {
@@ -206,7 +206,7 @@ pub(crate) mod breakpoint {
                             Ok(Retval::Ok)
                         }
                     } else {
-                        assert!(*all);
+                        assert!(all);
                         trace!("Deleting all breakpoints");
                         context.clear_breakpoints();
                         Ok(Retval::Ok)
@@ -231,75 +231,92 @@ pub(crate) mod breakpoint {
 
 pub(crate) mod next {
     use crate::context::Context;
+    use crate::external_api::EmptyArgs;
     use crate::IxaError;
     use clap::Parser;
-    use serde::{Deserialize, Serialize};
+    use serde::Serialize;
+    use serde_derive::Deserialize;
 
-    #[derive(Parser, Debug, Deserialize)]
-    pub(crate) enum Args {
-        /// Execute the next callback or scheduled plan and return to debugger
+    #[derive(Parser, Debug, Serialize, Deserialize)]
+    pub enum Args {
+        /// Execute the next item in the event loop
         Next,
     }
+
     #[derive(Serialize)]
-    pub(crate) struct Retval {}
+    pub(crate) enum Retval {
+        Ok,
+    }
     #[allow(unused)]
     pub(crate) struct Api {}
     impl super::ExtApi for Api {
-        type Args = Args;
+        type Args = EmptyArgs;
         type Retval = Retval;
 
-        fn run(_context: &mut Context, _args: &Args) -> Result<Retval, IxaError> {
+        fn run(_context: &mut Context, _args: &EmptyArgs) -> Result<Retval, IxaError> {
             // This is a no-op which allows for arg checking.
-            Ok(Retval {})
+            Ok(Retval::Ok)
         }
     }
 }
 
 pub(crate) mod halt {
     use crate::context::Context;
+    use crate::external_api::EmptyArgs;
     use crate::IxaError;
     use clap::Parser;
-    use serde::{Deserialize, Serialize};
+    use serde::Serialize;
+    use serde_derive::Deserialize;
 
-    #[derive(Parser, Debug, Deserialize)]
-    pub(crate) enum Args {
-        /// Execute the next callback or scheduled plan and return to debugger
+    #[derive(Parser, Debug, Serialize, Deserialize)]
+    pub enum Args {
+        /// End the simulation
         Halt,
     }
+
     #[derive(Serialize)]
-    pub(crate) struct Retval {}
+    pub(crate) enum Retval {
+        Ok,
+    }
     #[allow(unused)]
     pub(crate) struct Api {}
     impl super::ExtApi for Api {
-        type Args = Args;
+        type Args = EmptyArgs;
         type Retval = Retval;
 
-        fn run(_context: &mut Context, _args: &Args) -> Result<Retval, IxaError> {
+        fn run(_context: &mut Context, _args: &EmptyArgs) -> Result<Retval, IxaError> {
             // This is a no-op which allows for arg checking.
-            Ok(Retval {})
+            Ok(Retval::Ok)
         }
     }
 }
 
 pub(crate) mod r#continue {
     use crate::context::Context;
+    use crate::external_api::EmptyArgs;
     use crate::IxaError;
     use clap::Parser;
-    use serde::{Deserialize, Serialize};
+    use serde_derive::{Deserialize, Serialize};
 
-    #[derive(Parser, Debug, Deserialize)]
-    pub(crate) enum Args {}
+    #[derive(Parser, Debug, Serialize, Deserialize)]
+    pub enum Args {
+        /// Continue running the simulation
+        Continue,
+    }
+
     #[derive(Serialize)]
-    pub(crate) struct Retval {}
+    pub(crate) enum Retval {
+        Ok,
+    }
     #[allow(unused)]
     pub(crate) struct Api {}
     impl super::ExtApi for Api {
-        type Args = Args;
+        type Args = EmptyArgs;
         type Retval = Retval;
 
-        fn run(_context: &mut Context, _args: &Args) -> Result<Retval, IxaError> {
+        fn run(_context: &mut Context, _args: &EmptyArgs) -> Result<Retval, IxaError> {
             // This is a no-op which allows for arg checking.
-            Ok(Retval {})
+            Ok(Retval::Ok)
         }
     }
 }

--- a/src/plan.rs
+++ b/src/plan.rs
@@ -82,6 +82,23 @@ impl<T, P: Eq + PartialEq + Ord> Queue<T, P> {
         self.queue.is_empty()
     }
 
+    #[must_use]
+    pub fn next_time(&self) -> Option<f64> {
+        self.queue.peek().map(|e| e.time)
+    }
+
+    #[must_use]
+    pub(crate) fn peek(&self) -> Option<(&Entry<P>, &T)> {
+        // Iterate over queue until we find a plan with data or queue is empty
+        for entry in self.queue.iter() {
+            // Skip plans that have been cancelled and thus have no data
+            if let Some(data) = self.data_map.get(&entry.plan_id) {
+                return Some((entry, data));
+            }
+        }
+        None
+    }
+
     /// Retrieve the earliest plan in the queue
     ///
     /// Returns the next plan if it exists or else `None` if the queue is empty

--- a/src/plan.rs
+++ b/src/plan.rs
@@ -64,7 +64,7 @@ impl<T, P: Eq + PartialEq + Ord> Queue<T, P> {
 
     /// Cancel a plan that has been added to the queue
     pub fn cancel_plan(&mut self, plan_id: &PlanId) -> Option<T> {
-        trace!("cancel plan {:?}", plan_id);
+        trace!("cancel plan {plan_id:?}");
         // Delete the plan from the map, but leave in the queue
         // It will be skipped when the plan is popped from the queue
         self.data_map.remove(&plan_id.0)

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -359,7 +359,7 @@ mod tests {
                 // Check if the output contains some of the expected log messages
                 assert!(s.contains("Logging enabled for rustyline at level DEBUG"));
                 assert!(s.contains("Logging enabled for ixa at level TRACE"));
-                assert!(s.contains("TRACE ixa::plan - adding plan at 1.000000"));
+                assert!(s.contains("TRACE ixa::plan - adding plan at 1"));
             }
             Err(e) => {
                 println!("Failed to convert: {e}");

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -5,7 +5,7 @@ use crate::error::IxaError;
 use crate::global_properties::ContextGlobalPropertiesExt;
 use crate::random::ContextRandomExt;
 use crate::report::ContextReportExt;
-use crate::{context::Context, debugger::ContextDebugExt, web_api::ContextWebApiExt};
+use crate::{context::Context, web_api::ContextWebApiExt};
 use crate::{info, set_log_level, set_module_filters, LevelFilter};
 
 use clap::{Args, Command, FromArgMatches as _};
@@ -195,7 +195,14 @@ where
             args.web.is_none(),
             "Cannot run with both the debugger and the Web API"
         );
-        context.schedule_debugger(t.unwrap_or(0.0));
+        match t {
+            None => {
+                context.request_debugger();
+            }
+            Some(time) => {
+                context.schedule_debugger(time, None);
+            }
+        }
     }
 
     // If the Web API is provided, stop there.

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -8,6 +8,7 @@ use crate::report::ContextReportExt;
 use crate::{context::Context, web_api::ContextWebApiExt};
 use crate::{info, set_log_level, set_module_filters, LevelFilter};
 
+use crate::debugger::enter_debugger;
 use clap::{Args, Command, FromArgMatches as _};
 
 /// Custom parser for log levels
@@ -200,7 +201,7 @@ where
                 context.request_debugger();
             }
             Some(time) => {
-                context.schedule_debugger(time, None);
+                context.schedule_debugger(time, None, Box::new(enter_debugger));
             }
         }
     }

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -359,7 +359,7 @@ mod tests {
                 // Check if the output contains some of the expected log messages
                 assert!(s.contains("Logging enabled for rustyline at level DEBUG"));
                 assert!(s.contains("Logging enabled for ixa at level TRACE"));
-                assert!(s.contains("TRACE ixa::debugger - scheduling debugger"));
+                assert!(s.contains("TRACE ixa::plan - adding plan at 1.000000"));
             }
             Err(e) => {
                 println!("Failed to convert: {e}");

--- a/src/web_api.rs
+++ b/src/web_api.rs
@@ -2,7 +2,7 @@ use crate::context::{run_with_plugin, Context};
 use crate::define_data_plugin;
 use crate::error::IxaError;
 use crate::external_api::{
-    breakpoint, global_properties, people, population, run_ext_api, time, EmptyArgs, ExtApi,
+    breakpoint, global_properties, people, population, run_ext_api, time, EmptyArgs,
 };
 use crate::{HashMap, HashMapExt};
 use axum::extract::{Json, Path, State};

--- a/src/web_api.rs
+++ b/src/web_api.rs
@@ -44,6 +44,12 @@ struct ApiData {
     handlers: HashMap<String, Box<WebApiHandler>>,
 }
 
+pub(crate) fn enter_web_debugger(context: &mut Context) {
+    run_with_plugin::<ApiPlugin>(context, |context, data_container| {
+        handle_web_api(context, data_container.as_mut().unwrap());
+    });
+}
+
 define_data_plugin!(ApiPlugin, Option<ApiData>, None);
 
 // Input to the API handler.

--- a/src/web_api.rs
+++ b/src/web_api.rs
@@ -2,7 +2,7 @@ use crate::context::{run_with_plugin, Context};
 use crate::define_data_plugin;
 use crate::error::IxaError;
 use crate::external_api::{
-    breakpoint, global_properties, people, population, run_ext_api, time, EmptyArgs,
+    breakpoint, global_properties, people, population, run_ext_api, time, EmptyArgs, ExtApi,
 };
 use crate::{HashMap, HashMapExt};
 use axum::extract::{Json, Path, State};
@@ -171,19 +171,6 @@ fn handle_web_api(context: &mut Context, api: &mut ApiData) {
                 });
             }
         };
-
-        // Special case the functions which require exiting
-        // the loop.
-        if req.cmd == "next" {
-            // This was already type checked in the handler so .unwrap() cannot fail.
-            let breakpoint::Args::Breakpoint { time: next_time } =
-                serde_json::from_value(req.arguments).unwrap();
-            context.schedule_web_api(next_time);
-            return;
-        }
-        if req.cmd == "continue" {
-            return;
-        }
     }
 }
 

--- a/src/web_api.rs
+++ b/src/web_api.rs
@@ -2,7 +2,7 @@ use crate::context::{run_with_plugin, Context};
 use crate::define_data_plugin;
 use crate::error::IxaError;
 use crate::external_api::{
-    global_properties, next, people, population, run_ext_api, time, EmptyArgs,
+    breakpoint, global_properties, people, population, run_ext_api, time, EmptyArgs,
 };
 use crate::{HashMap, HashMapExt};
 use axum::extract::{Json, Path, State};
@@ -176,7 +176,8 @@ fn handle_web_api(context: &mut Context, api: &mut ApiData) {
         // the loop.
         if req.cmd == "next" {
             // This was already type checked in the handler so .unwrap() cannot fail.
-            let next::Args::Next { next_time } = serde_json::from_value(req.arguments).unwrap();
+            let breakpoint::Args::Breakpoint { time: next_time } =
+                serde_json::from_value(req.arguments).unwrap();
             context.schedule_web_api(next_time);
             return;
         }
@@ -241,7 +242,7 @@ impl ContextWebApiExt for Context {
             "global",
         );
         register_api_handler::<population::Api, EmptyArgs>(&mut api_data, "population");
-        register_api_handler::<next::Api, next::Args>(&mut api_data, "next");
+        register_api_handler::<breakpoint::Api, breakpoint::Args>(&mut api_data, "next");
         register_api_handler::<people::Api, people::Args>(&mut api_data, "people");
         register_api_handler::<time::Api, EmptyArgs>(&mut api_data, "time");
         // Record the data container.

--- a/static/src/api.js
+++ b/static/src/api.js
@@ -1,169 +1,170 @@
 function Api() {
-  function getBaseUrl() {
-    let url = new URL(window.location);
-    const prefix = url.pathname.split("/")[1];
-    if (prefix.length != 36) {
-      throw Error("Malformed URL");
-    }
-    url.pathname = `/${prefix}`;
-    return url;
-  }
-
-  async function makeApiCall(cmd, body) {
-    const url = new URL(baseUrl);
-    url.pathname += `/cmd/${cmd}`;
-    console.log(`makeApiCall ${url.toString()}`);
-
-    let response = await fetch(url.toString(), {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-      },
-      body: JSON.stringify(body),
-    });
-
-    if (!response.ok) {
-      throw new Error((await response.json()).error);
+    function getBaseUrl() {
+        let url = new URL(window.location);
+        const prefix = url.pathname.split("/")[1];
+        if (prefix.length != 36) {
+            throw Error("Malformed URL");
+        }
+        url.pathname = `/${prefix}`;
+        return url;
     }
 
-    return await response.json();
-  }
+    async function makeApiCall(cmd, body) {
+        const url = new URL(baseUrl);
+        url.pathname += `/cmd/${cmd}`;
+        console.log(`makeApiCall ${url.toString()}`);
 
-  async function getPopulation() {
-    let response = await makeApiCall("population", {});
+        let response = await fetch(url.toString(), {
+            method: "POST",
+            headers: {
+                "Content-Type": "application/json",
+            },
+            body: JSON.stringify(body),
+        });
 
-    return response.population;
-  }
-
-  async function getTime() {
-    let response = await makeApiCall("time", {});
-
-    return response.time;
-  }
-
-  async function getGlobalSettingsList() {
-    let response = await makeApiCall("global", {
-      Global: "List",
-    });
-
-    return response.List;
-  }
-
-  async function getGlobalSettingValue(setting) {
-    let response = await makeApiCall("global", {
-      Global: { Get: { property: setting } },
-    });
-
-    return response.Value;
-  }
-
-  async function next() {
-    await makeApiCall("next", {});
-  }
-
-  async function halt() {
-    await makeApiCall("halt", {});
-  }
-
-  async function continueSimulation() {
-    await makeApiCall("continue", {});
-  }
-
-  async function setBreakpoint(t) {
-    await makeApiCall("breaktpoint", {
-        Breakpoint: {
-            Set: {
-                time: t
-            }
+        if (!response.ok) {
+            throw new Error((await response.json()).error);
         }
-    });
-  }
 
-  async function listBreakpoints() {
-    let response = await makeApiCall("breaktpoint", {
-        Breakpoint: "List"
-    });
+        return await response.json();
+    }
 
-    return response.List;
-  }
+    async function getPopulation() {
+        let response = await makeApiCall("population", {});
 
-  async function deleteBreakpoint(breakpoint_id) {
-    await makeApiCall("breaktpoint", {
-        Breakpoint: {
-            Delete: {
-                id: breakpoint_id
+        return response.population;
+    }
+
+    async function getTime() {
+        let response = await makeApiCall("time", {});
+
+        return response.time;
+    }
+
+    async function getGlobalSettingsList() {
+        let response = await makeApiCall("global", {
+            Global: "List",
+        });
+
+        return response.List;
+    }
+
+    async function getGlobalSettingValue(setting) {
+        let response = await makeApiCall("global", {
+            Global: {Get: {property: setting}},
+        });
+
+        return response.Value;
+    }
+
+    async function next() {
+        await makeApiCall("next", {});
+    }
+
+    async function halt() {
+        await makeApiCall("halt", {});
+    }
+
+    async function continueSimulation() {
+        await makeApiCall("continue", {});
+    }
+
+    async function setBreakpoint(t) {
+        await makeApiCall("breakpoint", {
+            Breakpoint: {
+                Set: {
+                    time: t,
+                    console: false
+                }
             }
-        }
-    });
-  }
+        });
+    }
 
-  async function clearBreakpoints() {
-    await makeApiCall("breaktpoint", {
-        Breakpoint: {
-            Delete: {
-                all: true
+    async function listBreakpoints() {
+        let response = await makeApiCall("breakpoint", {
+            Breakpoint: "List"
+        });
+
+        return response.List;
+    }
+
+    async function deleteBreakpoint(breakpoint_id) {
+        await makeApiCall("breakpoint", {
+            Breakpoint: {
+                Delete: {
+                    id: breakpoint_id
+                }
             }
-        }
-    });
-  }
+        });
+    }
 
-  async function enableBreakpoints() {
-    await makeApiCall("breakpoint", {
-        Breakpoint: "Enable"
-    });
-  }
+    async function clearBreakpoints() {
+        await makeApiCall("breakpoint", {
+            Breakpoint: {
+                Delete: {
+                    all: true
+                }
+            }
+        });
+    }
 
-  async function disableBreakpoints() {
-    await makeApiCall("breakpoint", {
-        Breakpoint: "Disable"
-    });
-  }
+    async function enableBreakpoints() {
+        await makeApiCall("breakpoint", {
+            Breakpoint: "Enable"
+        });
+    }
 
-  async function tabulateProperties(props) {
-    let response = await makeApiCall("people", {
-      People: {
-        Tabulate: {
-          properties: props,
-        },
-      },
-    });
-    return response.Tabulated;
-  }
+    async function disableBreakpoints() {
+        await makeApiCall("breakpoint", {
+            Breakpoint: "Disable"
+        });
+    }
 
-  async function getPeoplePropertiesList() {
-    let response = await makeApiCall("people", {
-      People: "Properties",
-    });
+    async function tabulateProperties(props) {
+        let response = await makeApiCall("people", {
+            People: {
+                Tabulate: {
+                    properties: props,
+                },
+            },
+        });
+        return response.Tabulated;
+    }
 
-    return response.PropertyNames;
-  }
+    async function getPeoplePropertiesList() {
+        let response = await makeApiCall("people", {
+            People: "Properties",
+        });
 
-  const baseUrl = getBaseUrl();
+        return response.PropertyNames;
+    }
 
-  return {
-    getPopulation,
-    getTime,
-    getGlobalSettingsList,
-    getGlobalSettingValue,
-    next,
-    halt,
-    continueSimulation,
-    listBreakpoints,
-    setBreakpoint,
-    deleteBreakpoint,
-    clearBreakpoints,
-    enableBreakpoints,
-    disableBreakpoints,
-    tabulateProperties,
-    getPeoplePropertiesList,
-  };
+    const baseUrl = getBaseUrl();
+
+    return {
+        getPopulation,
+        getTime,
+        getGlobalSettingsList,
+        getGlobalSettingValue,
+        next,
+        halt,
+        continueSimulation,
+        listBreakpoints,
+        setBreakpoint,
+        deleteBreakpoint,
+        clearBreakpoints,
+        enableBreakpoints,
+        disableBreakpoints,
+        tabulateProperties,
+        getPeoplePropertiesList,
+    };
 }
 
 let api = null;
 
 export default function getApi() {
-  if (!api) {
-    api = Api();
-  }
-  return api;
+    if (!api) {
+        api = Api();
+    }
+    return api;
 }

--- a/static/src/api.js
+++ b/static/src/api.js
@@ -57,11 +57,65 @@ function Api() {
     return response.Value;
   }
 
-  async function nextTime(t) {
-    await makeApiCall("next", {
-      Next: {
-        next_time: t,
-      },
+  async function next() {
+    await makeApiCall("next", {});
+  }
+
+  async function halt() {
+    await makeApiCall("halt", {});
+  }
+
+  async function continueSimulation() {
+    await makeApiCall("continue", {});
+  }
+
+  async function setBreakpoint(t) {
+    await makeApiCall("breaktpoint", {
+        Breakpoint: {
+            Set: {
+                time: t
+            }
+        }
+    });
+  }
+
+  async function listBreakpoints() {
+    let response = await makeApiCall("breaktpoint", {
+        Breakpoint: "List"
+    });
+
+    return response.List;
+  }
+
+  async function deleteBreakpoint(breakpoint_id) {
+    await makeApiCall("breaktpoint", {
+        Breakpoint: {
+            Delete: {
+                id: breakpoint_id
+            }
+        }
+    });
+  }
+
+  async function clearBreakpoints() {
+    await makeApiCall("breaktpoint", {
+        Breakpoint: {
+            Delete: {
+                all: true
+            }
+        }
+    });
+  }
+
+  async function enableBreakpoints() {
+    await makeApiCall("breakpoint", {
+        Breakpoint: "Enable"
+    });
+  }
+
+  async function disableBreakpoints() {
+    await makeApiCall("breakpoint", {
+        Breakpoint: "Disable"
     });
   }
 
@@ -91,7 +145,15 @@ function Api() {
     getTime,
     getGlobalSettingsList,
     getGlobalSettingValue,
-    nextTime,
+    next,
+    halt,
+    continueSimulation,
+    listBreakpoints,
+    setBreakpoint,
+    deleteBreakpoint,
+    clearBreakpoints,
+    enableBreakpoints,
+    disableBreakpoints,
     tabulateProperties,
     getPeoplePropertiesList,
   };

--- a/static/src/app-state.js
+++ b/static/src/app-state.js
@@ -23,7 +23,8 @@ export function SimulationContextProvider({ children }) {
   async function goNext() {
     let now = currentTime;
     setIsLoading(true);
-    api.nextTime(currentTime + 1.0);
+    api.setBreakpoint(currentTime + 1.0);
+    api.continueSimulation()
     // Busy wait on the API until time changes.
     while (now === currentTime) {
       now = await api.getTime();


### PR DESCRIPTION
# Breakpoints and Next

- It reuses `plan::Queue` for `Context::breakpoints_scheduled`, but I implemented `next_time()` and `peek()` on it, the latter of which required that `Entry<P>` be `pub(crate)`. 

- `Context::request_debugger()` and `Context::cancel_debugger_request()` are a setter and resetter respectively for `Context::break_requested`, which works like `Context::shutdown_requested()` but takes priority.

- Breakpoints scheduled at a particular time run before the next scheduled plan if the time of the next scheduled plan is `<=` or `<`, according to whether the breakpoint was scheduled with `ExecutionPhase::First` or `ExecutionPhase::Last`. (What about `ExecutionPhase::Normal`?)

- The "next" command that takes a time has been renamed to "breakpoint", and a new "next" command was created. In other words: `breakpoint 1.2` sets a breakpoint at time `1.2`, while `next` executes the next thing.

- Method `schedule_debugger()` is now implemented directly on `Context`, because the data member `breakpoints_scheduled` is in `Context`. There is now no need for `ContextDebuggerExt`

  

Vanity changes:

- Format times to 6 decimal places when printed in debugger, trace statements. I think I should also strip trailing zeros past the decimal point.
- Added a "halt" debugger command (Related: #244 )



I'm not sure I'm happy with this implementation. My least favorite thing about this is it kind of makes a mess of `plan::Queue`. 