### PR TITLE
feat: Support multi-property indexes

### DIFF
--- a/examples/network-hhmodel/seir.rs
+++ b/examples/network-hhmodel/seir.rs
@@ -142,12 +142,10 @@ pub fn init(context: &mut Context, initial_infections: &Vec<PersonId>) {
     );
 
     context.subscribe_to_event(
-        move |context, event: PersonPropertyChangeEvent<DiseaseStatus>| {
-            match event.current {
-                DiseaseStatusValue::E => schedule_infection(context, event.person_id),
-                DiseaseStatusValue::I => schedule_recovery(context, event.person_id),
-                _ => (),
-            };
+        move |context, event: PersonPropertyChangeEvent<DiseaseStatus>| match event.current {
+            DiseaseStatusValue::E => schedule_infection(context, event.person_id),
+            DiseaseStatusValue::I => schedule_recovery(context, event.person_id),
+            _ => (),
         },
     );
 

--- a/src/people/context_extension.rs
+++ b/src/people/context_extension.rs
@@ -1,4 +1,4 @@
-use crate::people::index::{Index, IndexValue};
+use crate::people::index::{get_multi_property_hash, get_multi_property_index, Index, IndexValue};
 use crate::people::query::Query;
 use crate::people::{index, InitializationList, PeoplePlugin, PersonPropertyHolder};
 use crate::{
@@ -510,8 +510,21 @@ impl ContextPeopleExtInternal for Context {
             index.index_unindexed_people(self, &methods);
         }
 
+        // TODO: explain...
+        let mut property_hashs_working_set = property_hashes.clone();
+        if property_hashs_working_set.len() > 1 {
+            if let Some(combined_index) = get_multi_property_index(&property_hashes) {
+                let combined_hash = get_multi_property_hash(&property_hashes);
+                property_hashs_working_set = vec![(combined_index, combined_hash)];
+                let mut index = data_container.get_index_ref_mut(combined_index)
+                .expect("Multi-property index must be registered, call context.index_property() before calling a query.");
+                let methods = data_container.get_methods(combined_index);
+                index.index_unindexed_people(self, &methods);
+            }
+        }
+
         // 2. Collect the index entry corresponding to the value.
-        for (t, hash) in property_hashes {
+        for (t, hash) in property_hashs_working_set {
             let index = data_container.get_index_ref(t).unwrap();
             if let Ok(lookup) = Ref::filter_map(index, |x| x.lookup.as_ref()) {
                 if let Ok(matching_people) =

--- a/src/people/context_extension.rs
+++ b/src/people/context_extension.rs
@@ -1,4 +1,6 @@
-use crate::people::index::{get_multi_property_hash, get_multi_property_index, Index, IndexValue};
+use crate::people::index::{
+    get_and_register_multi_property_index, get_multi_property_hash, Index, IndexValue,
+};
 use crate::people::query::Query;
 use crate::people::{index, InitializationList, PeoplePlugin, PersonPropertyHolder};
 use crate::{
@@ -510,16 +512,14 @@ impl ContextPeopleExtInternal for Context {
             index.index_unindexed_people(self, &methods);
         }
 
-        // TODO: explain...
         let mut property_hashs_working_set = property_hashes.clone();
+        // intercept multi-property queries
         if property_hashs_working_set.len() > 1 {
-            if let Some(combined_index) = get_multi_property_index(&property_hashes) {
+            if let Some(combined_index) =
+                get_and_register_multi_property_index(&property_hashes, self)
+            {
                 let combined_hash = get_multi_property_hash(&property_hashes);
                 property_hashs_working_set = vec![(combined_index, combined_hash)];
-                let mut index = data_container.get_index_ref_mut(combined_index)
-                .expect("Multi-property index must be registered, call context.index_property() before calling a query.");
-                let methods = data_container.get_methods(combined_index);
-                index.index_unindexed_people(self, &methods);
             }
         }
 

--- a/src/people/context_extension.rs
+++ b/src/people/context_extension.rs
@@ -505,13 +505,6 @@ impl ContextPeopleExtInternal for Context {
         let data_container = self.get_data_container(PeoplePlugin)
             .expect("PeoplePlugin is not initialized; make sure you add a person before accessing properties");
 
-        // 1. Walk through each property and update the indexes.
-        for (t, _) in &property_hashes {
-            let mut index = data_container.get_index_ref_mut(*t).unwrap();
-            let methods = data_container.get_methods(*t);
-            index.index_unindexed_people(self, &methods);
-        }
-
         let mut property_hashs_working_set = property_hashes.clone();
         // intercept multi-property queries
         if property_hashs_working_set.len() > 1 {
@@ -521,6 +514,13 @@ impl ContextPeopleExtInternal for Context {
                 let combined_hash = get_multi_property_hash(&property_hashes);
                 property_hashs_working_set = vec![(combined_index, combined_hash)];
             }
+        }
+
+        // 1. Walk through each property and update the indexes.
+        for (t, _) in &property_hashs_working_set {
+            let mut index = data_container.get_index_ref_mut(*t).unwrap();
+            let methods = data_container.get_methods(*t);
+            index.index_unindexed_people(self, &methods);
         }
 
         // 2. Collect the index entry corresponding to the value.

--- a/src/people/index.rs
+++ b/src/people/index.rs
@@ -128,10 +128,10 @@ pub struct MultiIndex {
     type_id: TypeId,
 }
 
-// / A static map of multi-property indices. This is used to register multi-property property indices
-// / when they are first created. The map is keyed by the property IDs of the properties that are
-// / indexed. The values are the `MultiIndex` objects that contain the registration function and
-// / the type ID of the index.
+// A static map of multi-property indices. This is used to register multi-property property indices
+// when they are first created. The map is keyed by the property IDs of the properties that are
+// indexed. The values are the `MultiIndex` objects that contain the registration function and
+// the type ID of the index.
 #[doc(hidden)]
 #[allow(clippy::type_complexity)]
 pub static MULTI_PROPERTY_INDEX_MAP: LazyLock<

--- a/src/people/property.rs
+++ b/src/people/property.rs
@@ -157,29 +157,27 @@ macro_rules! define_derived_property {
 pub use define_derived_property;
 
 #[macro_export]
-macro_rules! define_multi_index_property {
+macro_rules! multi_index_property {
     (
         $derived_property:ident,
         [$($dependency:ident),+],
         |$($param:ident),+|
     ) => {
-
-        define_derived_property!($derived_property, IndexValue, [$($dependency),*],
+        define_derived_property!($derived_property, $crate::people::index::IndexValue, [$($dependency),*],
             | $(
                 $param
             ),+ | {
             let mut combined = vec!(
                 $(
                     (std::any::TypeId::of::<$dependency>(),
-                    IndexValue::compute(&$param))
+                    $crate::people::index::IndexValue::compute(&$param))
                 ),*
             );
             combined.sort_by(|a, b| a.0.cmp(&b.0));
             let values = combined.iter().map(|x| x.1).collect::<Vec<_>>();
-            IndexValue::compute(&values)
+            $crate::people::index::IndexValue::compute(&values)
         });
-        use $crate::people::index::add_multi_property_index;
-        add_multi_property_index(
+        $crate::people::index::add_multi_property_index::<$derived_property>(
             &vec![
                 $(
                     std::any::TypeId::of::<$dependency>(),
@@ -191,52 +189,45 @@ macro_rules! define_multi_index_property {
 }
 
 #[macro_export]
-macro_rules! define_xyz {
-    ($derived_property:ident, [$d1:ident, $d2:ident])  => { define_multi_index_property!($derived_property, [$d1, $d2], |d1, d2|); };
-    ($derived_property:ident, [$d1:ident, $d2:ident, $d3:ident])  => { define_multi_index_property!($derived_property, [$d1, $d2, $d3], |d1, d2, d3|); };
-    ($derived_property:ident, [$d1:ident, $d2:ident, $d3:ident, $d4:ident])  => { define_multi_index_property!($derived_property, [$d1, $d2, $d3, $d4], |d1, d2, d3, d4|); };
-    ($derived_property:ident, [$d1:ident, $d2:ident, $d3:ident, $d4:ident, $d5:ident])  => { define_multi_index_property!($derived_property, [$d1, $d2, $d3, $d4, $d5], |d1, d2, d3, d4, d5|); };
-    ($derived_property:ident, [$d1:ident, $d2:ident, $d3:ident, $d4:ident, $d5:ident, $d6:ident])  => { define_multi_index_property!($derived_property, [$d1, $d2, $d3, $d4, $d5, $d6], |d1, d2, d3, d4, d5, d6|); };
-    ($derived_property:ident, [$d1:ident, $d2:ident, $d3:ident, $d4:ident, $d5:ident, $d6:ident, $d7:ident])  => { define_multi_index_property!($derived_property, [$d1, $d2, $d3, $d4, $d5, $d6, $d7], |d1, d2, d3, d4, d5, d6, d7|); };
-    ($derived_property:ident, [$d1:ident, $d2:ident, $d3:ident, $d4:ident, $d5:ident, $d6:ident, $d7:ident, $d8:ident])  => { define_multi_index_property!($derived_property, [$d1, $d2, $d3, $d4, $d5, $d6, $d7, $d8], |d1, d2, d3, d4, d5, d6, d7, d8|); };
-    ($derived_property:ident, [$d1:ident, $d2:ident, $d3:ident, $d4:ident, $d5:ident, $d6:ident, $d7:ident, $d8:ident, $d9:ident])  => { define_multi_index_property!($derived_property, [$d1, $d2, $d3, $d4, $d5, $d6, $d7, $d8, $d9], |d1, d2, d3, d4, d5, d6, d7, d8, d9|); };
-    ($derived_property:ident, [$d1:ident, $d2:ident, $d3:ident, $d4:ident, $d5:ident, $d6:ident, $d7:ident, $d8:ident, $d9:ident, $d10:ident])  => { define_multi_index_property!($derived_property, [$d1, $d2, $d3, $d4, $d5, $d6, $d7, $d8, $d9, $d10], |d1, d2, d3, d4, d5, d6, d7, d8, d9, d10|); };
-    ($derived_property:ident, [$d1:ident, $d2:ident, $d3:ident, $d4:ident, $d5:ident, $d6:ident, $d7:ident, $d8:ident, $d9:ident, $d10:ident, $d11:ident])  => { define_multi_index_property!($derived_property, [$d1, $d2, $d3, $d4, $d5, $d6, $d7, $d8, $d9, $d10, $d11], |d1, d2, d3, d4, d5, d6, d7, d8, d9, d10, d11|); };
-    ($derived_property:ident, [$d1:ident, $d2:ident, $d3:ident, $d4:ident, $d5:ident, $d6:ident, $d7:ident, $d8:ident, $d9:ident, $d10:ident, $d11:ident, $d12:ident])  => { define_multi_index_property!($derived_property, [$d1, $d2, $d3, $d4, $d5, $d6, $d7, $d8, $d9, $d10, $d11, $d12], |d1, d2, d3, d4, d5, d6, d7, d8, d9, d10, d11, d12|); };
-    ($derived_property:ident, [$d1:ident, $d2:ident, $d3:ident, $d4:ident, $d5:ident, $d6:ident, $d7:ident, $d8:ident, $d9:ident, $d10:ident, $d11:ident, $d12:ident, $d13:ident])  => { define_multi_index_property!($derived_property, [$d1, $d2, $d3, $d4, $d5, $d6, $d7, $d8, $d9, $d10, $d11, $d12, $d13], |d1, d2, d3, d4, d5, d6, d7, d8, d9, d10, d11, d12, d13|); };
-    ($derived_property:ident, [$d1:ident, $d2:ident, $d3:ident, $d4:ident, $d5:ident, $d6:ident, $d7:ident, $d8:ident, $d9:ident, $d10:ident, $d11:ident, $d12:ident, $d13:ident, $d14:ident])  => { define_multi_index_property!($derived_property, [$d1, $d2, $d3, $d4, $d5, $d6, $d7, $d8, $d9, $d10, $d11, $d12, $d13, $d14], |d1, d2, d3, d4, d5, d6, d7, d8, d9, d10, d11, d12, d13, d14|); };
-    ($derived_property:ident, [$d1:ident, $d2:ident, $d3:ident, $d4:ident, $d5:ident, $d6:ident, $d7:ident, $d8:ident, $d9:ident, $d10:ident, $d11:ident, $d12:ident, $d13:ident, $d14:ident, $d15:ident])  => { define_multi_index_property!($derived_property, [$d1, $d2, $d3, $d4, $d5, $d6, $d7, $d8, $d9, $d10, $d11, $d12, $d13, $d14, $d15] |d1, d2, d3, d4, d5, d6, d7, d8, d9, d10, d11, d12, d13, d14, d15|); };
-    ($derived_property:ident, [$d1:ident, $d2:ident, $d3:ident, $d4:ident, $d5:ident, $d6:ident, $d7:ident, $d8:ident, $d9:ident, $d10:ident, $d11:ident, $d12:ident, $d13:ident, $d14:ident, $d15:ident, $d16:ident])  => { define_multi_index_property!($derived_property, [$d1, $d2, $d3, $d4, $d5, $d6, $d7, $d8, $d9, $d10, $d11, $d12, $d13, $d14, $d15, $d16] |d1, d2, d3, d4, d5, d6, d7, d8, d9, d10, d11, d12, d13, d14, d15, d16|); };
-    ($derived_property:ident, [$d1:ident, $d2:ident, $d3:ident, $d4:ident, $d5:ident, $d6:ident, $d7:ident, $d8:ident, $d9:ident, $d10:ident, $d11:ident, $d12:ident, $d13:ident, $d14:ident, $d15:ident, $d16:ident, $d17:ident])  => { define_multi_index_property!($derived_property, [$d1, $d2, $d3, $d4, $d5, $d6, $d7, $d8, $d9, $d10, $d11, $d12, $d13, $d14, $d15, $d16, $d17] |d1, d2, d3, d4, d5, d6, d7, d8, d9, d10, d11, d12, d13, d14, d15, d16, d17|); };
-    ($derived_property:ident, [$d1:ident, $d2:ident, $d3:ident, $d4:ident, $d5:ident, $d6:ident, $d7:ident, $d8:ident, $d9:ident, $d10:ident, $d11:ident, $d12:ident, $d13:ident, $d14:ident, $d15:ident, $d16:ident, $d17:ident, $d18:ident])  => { define_multi_index_property!($derived_property, [$d1, $d2, $d3, $d4, $d5, $d6, $d7, $d8, $d9, $d10, $d11, $d12, $d13, $d14, $d15, $d16, $d17, $d18] |d1, d2, d3, d4, d5, d6, d7, d8, d9, d10, d11, d12, d13, d14, d15, d16, d17, d18|); };
-    ($derived_property:ident, [$d1:ident, $d2:ident, $d3:ident, $d4:ident, $d5:ident, $d6:ident, $d7:ident, $d8:ident, $d9:ident, $d10:ident, $d11:ident, $d12:ident, $d13:ident, $d14:ident, $d15:ident, $d16:ident, $d17:ident, $d18:ident, $d19:ident])  => { define_multi_index_property!($derived_property, [$d1, $d2, $d3, $d4, $d5, $d6, $d7, $d8, $d9, $d10, $d11, $d12, $d13, $d14, $d15, $d16, $d17, $d18] |d1, d2, d3, d4, d5, d6, d7, d8, d9, d10, d11, d12, d13, d14, d15, d16, d17, d18, d19|); };
-    ($derived_property:ident, [$d1:ident, $d2:ident, $d3:ident, $d4:ident, $d5:ident, $d6:ident, $d7:ident, $d8:ident, $d9:ident, $d10:ident, $d11:ident, $d12:ident, $d13:ident, $d14:ident, $d15:ident, $d16:ident, $d17:ident, $d18:ident, $d19:ident, $d20:ident])  => { define_multi_index_property!($derived_property, [$d1, $d2, $d3, $d4, $d5, $d6, $d7, $d8, $d9, $d10, $d11, $d12, $d13, $d14, $d15, $d16, $d17, $d18, $d19, $d20] |d1, d2, d3, d4, d5, d6, d7, d8, d9, d10, d11, d12, d13, d14, d15, d16, d17, d18, d19, d20|); };
+macro_rules! define_multi_property_index {
+    ($derived_property:ident, [$d1:ident]) =>
+        { $crate::multi_index_property!($derived_property, [$d1], |d1|); };
+    ($derived_property:ident, [$d1:ident, $d2:ident]) =>
+        { $crate::multi_index_property!($derived_property, [$d1, $d2], |d1, d2|); };
+    ($derived_property:ident, [$d1:ident, $d2:ident, $d3:ident]) =>
+        { $crate::multi_index_property!($derived_property, [$d1, $d2, $d3], |d1, d2, d3|); };
+    ($derived_property:ident, [$d1:ident, $d2:ident, $d3:ident, $d4:ident]) =>
+        { $crate::multi_index_property!($derived_property, [$d1, $d2, $d3, $d4], |d1, d2, d3, d4|); };
+    ($derived_property:ident, [$d1:ident, $d2:ident, $d3:ident, $d4:ident, $d5:ident]) =>
+        { $crate::multi_index_property!($derived_property, [$d1, $d2, $d3, $d4, $d5], |d1, d2, d3, d4, d5|); };
+    ($derived_property:ident, [$d1:ident, $d2:ident, $d3:ident, $d4:ident, $d5:ident, $d6:ident]) =>
+        { $crate::multi_index_property!($derived_property, [$d1, $d2, $d3, $d4, $d5, $d6], |d1, d2, d3, d4, d5, d6|); };
+    ($derived_property:ident, [$d1:ident, $d2:ident, $d3:ident, $d4:ident, $d5:ident, $d6:ident, $d7:ident]) =>
+        { $crate::multi_index_property!($derived_property, [$d1, $d2, $d3, $d4, $d5, $d6, $d7], |d1, d2, d3, d4, d5, d6, d7|); };
+    ($derived_property:ident, [$d1:ident, $d2:ident, $d3:ident, $d4:ident, $d5:ident, $d6:ident, $d7:ident, $d8:ident]) =>
+        { $crate::multi_index_property!($derived_property, [$d1, $d2, $d3, $d4, $d5, $d6, $d7, $d8], |d1, d2, d3, d4, d5, d6, d7, d8|); };
+    ($derived_property:ident, [$d1:ident, $d2:ident, $d3:ident, $d4:ident, $d5:ident, $d6:ident, $d7:ident, $d8:ident, $d9:ident]) =>
+        { $crate::multi_index_property!($derived_property, [$d1, $d2, $d3, $d4, $d5, $d6, $d7, $d8, $d9], |d1, d2, d3, d4, d5, d6, d7, d8, d9|); };
+    ($derived_property:ident, [$d1:ident, $d2:ident, $d3:ident, $d4:ident, $d5:ident, $d6:ident, $d7:ident, $d8:ident, $d9:ident, $d10:ident]) =>
+        { $crate::multi_index_property!($derived_property, [$d1, $d2, $d3, $d4, $d5, $d6, $d7, $d8, $d9, $d10], |d1, d2, d3, d4, d5, d6, d7, d8, d9, d10|); };
+    ($derived_property:ident, [$d1:ident, $d2:ident, $d3:ident, $d4:ident, $d5:ident, $d6:ident, $d7:ident, $d8:ident, $d9:ident, $d10:ident, $d11:ident]) =>
+        { $crate::multi_index_property!($derived_property, [$d1, $d2, $d3, $d4, $d5, $d6, $d7, $d8, $d9, $d10, $d11], |d1, d2, d3, d4, d5, d6, d7, d8, d9, d10, d11|); };
+    ($derived_property:ident, [$d1:ident, $d2:ident, $d3:ident, $d4:ident, $d5:ident, $d6:ident, $d7:ident, $d8:ident, $d9:ident, $d10:ident, $d11:ident, $d12:ident]) =>
+        { $crate::multi_index_property!($derived_property, [$d1, $d2, $d3, $d4, $d5, $d6, $d7, $d8, $d9, $d10, $d11, $d12], |d1, d2, d3, d4, d5, d6, d7, d8, d9, d10, d11, d12|); };
+    ($derived_property:ident, [$d1:ident, $d2:ident, $d3:ident, $d4:ident, $d5:ident, $d6:ident, $d7:ident, $d8:ident, $d9:ident, $d10:ident, $d11:ident, $d12:ident, $d13:ident]) =>
+        { $crate::multi_index_property!($derived_property, [$d1, $d2, $d3, $d4, $d5, $d6, $d7, $d8, $d9, $d10, $d11, $d12, $d13], |d1, d2, d3, d4, d5, d6, d7, d8, d9, d10, d11, d12, d13|); };
+    ($derived_property:ident, [$d1:ident, $d2:ident, $d3:ident, $d4:ident, $d5:ident, $d6:ident, $d7:ident, $d8:ident, $d9:ident, $d10:ident, $d11:ident, $d12:ident, $d13:ident, $d14:ident]) =>
+        { $crate::multi_index_property!($derived_property, [$d1, $d2, $d3, $d4, $d5, $d6, $d7, $d8, $d9, $d10, $d11, $d12, $d13, $d14], |d1, d2, d3, d4, d5, d6, d7, d8, d9, d10, d11, d12, d13, d14|); };
+    ($derived_property:ident, [$d1:ident, $d2:ident, $d3:ident, $d4:ident, $d5:ident, $d6:ident, $d7:ident, $d8:ident, $d9:ident, $d10:ident, $d11:ident, $d12:ident, $d13:ident, $d14:ident, $d15:ident]) =>
+        { $crate::multi_index_property!($derived_property, [$d1, $d2, $d3, $d4, $d5, $d6, $d7, $d8, $d9, $d10, $d11, $d12, $d13, $d14, $d15] |d1, d2, d3, d4, d5, d6, d7, d8, d9, d10, d11, d12, d13, d14, d15|); };
+    ($derived_property:ident, [$d1:ident, $d2:ident, $d3:ident, $d4:ident, $d5:ident, $d6:ident, $d7:ident, $d8:ident, $d9:ident, $d10:ident, $d11:ident, $d12:ident, $d13:ident, $d14:ident, $d15:ident, $d16:ident]) =>
+        { $crate::multi_index_property!($derived_property, [$d1, $d2, $d3, $d4, $d5, $d6, $d7, $d8, $d9, $d10, $d11, $d12, $d13, $d14, $d15, $d16] |d1, d2, d3, d4, d5, d6, d7, d8, d9, d10, d11, d12, d13, d14, d15, d16|); };
+    ($derived_property:ident, [$d1:ident, $d2:ident, $d3:ident, $d4:ident, $d5:ident, $d6:ident, $d7:ident, $d8:ident, $d9:ident, $d10:ident, $d11:ident, $d12:ident, $d13:ident, $d14:ident, $d15:ident, $d16:ident, $d17:ident]) =>
+        { $crate::multi_index_property!($derived_property, [$d1, $d2, $d3, $d4, $d5, $d6, $d7, $d8, $d9, $d10, $d11, $d12, $d13, $d14, $d15, $d16, $d17] |d1, d2, d3, d4, d5, d6, d7, d8, d9, d10, d11, d12, d13, d14, d15, d16, d17|); };
+    ($derived_property:ident, [$d1:ident, $d2:ident, $d3:ident, $d4:ident, $d5:ident, $d6:ident, $d7:ident, $d8:ident, $d9:ident, $d10:ident, $d11:ident, $d12:ident, $d13:ident, $d14:ident, $d15:ident, $d16:ident, $d17:ident, $d18:ident]) =>
+        { $crate::multi_index_property!($derived_property, [$d1, $d2, $d3, $d4, $d5, $d6, $d7, $d8, $d9, $d10, $d11, $d12, $d13, $d14, $d15, $d16, $d17, $d18] |d1, d2, d3, d4, d5, d6, d7, d8, d9, d10, d11, d12, d13, d14, d15, d16, d17, d18|); };
+    ($derived_property:ident, [$d1:ident, $d2:ident, $d3:ident, $d4:ident, $d5:ident, $d6:ident, $d7:ident, $d8:ident, $d9:ident, $d10:ident, $d11:ident, $d12:ident, $d13:ident, $d14:ident, $d15:ident, $d16:ident, $d17:ident, $d18:ident, $d19:ident]) =>
+        { $crate::multi_index_property!($derived_property, [$d1, $d2, $d3, $d4, $d5, $d6, $d7, $d8, $d9, $d10, $d11, $d12, $d13, $d14, $d15, $d16, $d17, $d18, $d19] |d1, d2, d3, d4, d5, d6, d7, d8, d9, d10, d11, d12, d13, d14, d15, d16, d17, d18, d19|); };
+    ($derived_property:ident, [$d1:ident, $d2:ident, $d3:ident, $d4:ident, $d5:ident, $d6:ident, $d7:ident, $d8:ident, $d9:ident, $d10:ident, $d11:ident, $d12:ident, $d13:ident, $d14:ident, $d15:ident, $d16:ident, $d17:ident, $d18:ident, $d19:ident, $d20:ident]) =>
+        { $crate::multi_index_property!($derived_property, [$d1, $d2, $d3, $d4, $d5, $d6, $d7, $d8, $d9, $d10, $d11, $d12, $d13, $d14, $d15, $d16, $d17, $d18, $d19, $d20] |d1, d2, d3, d4, d5, d6, d7, d8, d9, d10, d11, d12, d13, d14, d15, d16, d17, d18, d19, d20|); };
 }
-/*
-use seq_macro::seq;
-
-
-seq!(N in 1..=10 {
-    #[macro_export]
-    macro_rules! define_xyz {
-        ( $derived_property:ident, $( $param:expr ),{N} ) => {
-            $func($( $param ),*);
-        };
-    }
-});
-
-#[macro_export]
-macro_rules! define_xyz {
-    ($derived_property:ident, [$($d:ident),*]) => {
-        seq!(N in 1..=20 {
-            match ($($d),*) {
-                ($d~N),*) => {
-                    define_multi_index_property!(
-                        $derived_property,
-                        [$( $d ),*],
-                        |$( $d ),*|
-                    );
-                }
-            }
-}
-*/

--- a/src/people/property.rs
+++ b/src/people/property.rs
@@ -155,3 +155,88 @@ macro_rules! define_derived_property {
     };
 }
 pub use define_derived_property;
+
+#[macro_export]
+macro_rules! define_multi_index_property {
+    (
+        $derived_property:ident,
+        [$($dependency:ident),+],
+        |$($param:ident),+|
+    ) => {
+
+        define_derived_property!($derived_property, IndexValue, [$($dependency),*],
+            | $(
+                $param
+            ),+ | {
+            let mut combined = vec!(
+                $(
+                    (std::any::TypeId::of::<$dependency>(),
+                    IndexValue::compute(&$param))
+                ),*
+            );
+            combined.sort_by(|a, b| a.0.cmp(&b.0));
+            let values = combined.iter().map(|x| x.1).collect::<Vec<_>>();
+            IndexValue::compute(&values)
+        });
+        use $crate::people::index::add_multi_property_index;
+        add_multi_property_index(
+            &vec![
+                $(
+                    std::any::TypeId::of::<$dependency>(),
+                )*
+            ],
+            std::any::TypeId::of::<$derived_property>(),
+        );
+    };
+}
+
+#[macro_export]
+macro_rules! define_xyz {
+    ($derived_property:ident, [$d1:ident, $d2:ident])  => { define_multi_index_property!($derived_property, [$d1, $d2], |d1, d2|); };
+    ($derived_property:ident, [$d1:ident, $d2:ident, $d3:ident])  => { define_multi_index_property!($derived_property, [$d1, $d2, $d3], |d1, d2, d3|); };
+    ($derived_property:ident, [$d1:ident, $d2:ident, $d3:ident, $d4:ident])  => { define_multi_index_property!($derived_property, [$d1, $d2, $d3, $d4], |d1, d2, d3, d4|); };
+    ($derived_property:ident, [$d1:ident, $d2:ident, $d3:ident, $d4:ident, $d5:ident])  => { define_multi_index_property!($derived_property, [$d1, $d2, $d3, $d4, $d5], |d1, d2, d3, d4, d5|); };
+    ($derived_property:ident, [$d1:ident, $d2:ident, $d3:ident, $d4:ident, $d5:ident, $d6:ident])  => { define_multi_index_property!($derived_property, [$d1, $d2, $d3, $d4, $d5, $d6], |d1, d2, d3, d4, d5, d6|); };
+    ($derived_property:ident, [$d1:ident, $d2:ident, $d3:ident, $d4:ident, $d5:ident, $d6:ident, $d7:ident])  => { define_multi_index_property!($derived_property, [$d1, $d2, $d3, $d4, $d5, $d6, $d7], |d1, d2, d3, d4, d5, d6, d7|); };
+    ($derived_property:ident, [$d1:ident, $d2:ident, $d3:ident, $d4:ident, $d5:ident, $d6:ident, $d7:ident, $d8:ident])  => { define_multi_index_property!($derived_property, [$d1, $d2, $d3, $d4, $d5, $d6, $d7, $d8], |d1, d2, d3, d4, d5, d6, d7, d8|); };
+    ($derived_property:ident, [$d1:ident, $d2:ident, $d3:ident, $d4:ident, $d5:ident, $d6:ident, $d7:ident, $d8:ident, $d9:ident])  => { define_multi_index_property!($derived_property, [$d1, $d2, $d3, $d4, $d5, $d6, $d7, $d8, $d9], |d1, d2, d3, d4, d5, d6, d7, d8, d9|); };
+    ($derived_property:ident, [$d1:ident, $d2:ident, $d3:ident, $d4:ident, $d5:ident, $d6:ident, $d7:ident, $d8:ident, $d9:ident, $d10:ident])  => { define_multi_index_property!($derived_property, [$d1, $d2, $d3, $d4, $d5, $d6, $d7, $d8, $d9, $d10], |d1, d2, d3, d4, d5, d6, d7, d8, d9, d10|); };
+    ($derived_property:ident, [$d1:ident, $d2:ident, $d3:ident, $d4:ident, $d5:ident, $d6:ident, $d7:ident, $d8:ident, $d9:ident, $d10:ident, $d11:ident])  => { define_multi_index_property!($derived_property, [$d1, $d2, $d3, $d4, $d5, $d6, $d7, $d8, $d9, $d10, $d11], |d1, d2, d3, d4, d5, d6, d7, d8, d9, d10, d11|); };
+    ($derived_property:ident, [$d1:ident, $d2:ident, $d3:ident, $d4:ident, $d5:ident, $d6:ident, $d7:ident, $d8:ident, $d9:ident, $d10:ident, $d11:ident, $d12:ident])  => { define_multi_index_property!($derived_property, [$d1, $d2, $d3, $d4, $d5, $d6, $d7, $d8, $d9, $d10, $d11, $d12], |d1, d2, d3, d4, d5, d6, d7, d8, d9, d10, d11, d12|); };
+    ($derived_property:ident, [$d1:ident, $d2:ident, $d3:ident, $d4:ident, $d5:ident, $d6:ident, $d7:ident, $d8:ident, $d9:ident, $d10:ident, $d11:ident, $d12:ident, $d13:ident])  => { define_multi_index_property!($derived_property, [$d1, $d2, $d3, $d4, $d5, $d6, $d7, $d8, $d9, $d10, $d11, $d12, $d13], |d1, d2, d3, d4, d5, d6, d7, d8, d9, d10, d11, d12, d13|); };
+    ($derived_property:ident, [$d1:ident, $d2:ident, $d3:ident, $d4:ident, $d5:ident, $d6:ident, $d7:ident, $d8:ident, $d9:ident, $d10:ident, $d11:ident, $d12:ident, $d13:ident, $d14:ident])  => { define_multi_index_property!($derived_property, [$d1, $d2, $d3, $d4, $d5, $d6, $d7, $d8, $d9, $d10, $d11, $d12, $d13, $d14], |d1, d2, d3, d4, d5, d6, d7, d8, d9, d10, d11, d12, d13, d14|); };
+    ($derived_property:ident, [$d1:ident, $d2:ident, $d3:ident, $d4:ident, $d5:ident, $d6:ident, $d7:ident, $d8:ident, $d9:ident, $d10:ident, $d11:ident, $d12:ident, $d13:ident, $d14:ident, $d15:ident])  => { define_multi_index_property!($derived_property, [$d1, $d2, $d3, $d4, $d5, $d6, $d7, $d8, $d9, $d10, $d11, $d12, $d13, $d14, $d15] |d1, d2, d3, d4, d5, d6, d7, d8, d9, d10, d11, d12, d13, d14, d15|); };
+    ($derived_property:ident, [$d1:ident, $d2:ident, $d3:ident, $d4:ident, $d5:ident, $d6:ident, $d7:ident, $d8:ident, $d9:ident, $d10:ident, $d11:ident, $d12:ident, $d13:ident, $d14:ident, $d15:ident, $d16:ident])  => { define_multi_index_property!($derived_property, [$d1, $d2, $d3, $d4, $d5, $d6, $d7, $d8, $d9, $d10, $d11, $d12, $d13, $d14, $d15, $d16] |d1, d2, d3, d4, d5, d6, d7, d8, d9, d10, d11, d12, d13, d14, d15, d16|); };
+    ($derived_property:ident, [$d1:ident, $d2:ident, $d3:ident, $d4:ident, $d5:ident, $d6:ident, $d7:ident, $d8:ident, $d9:ident, $d10:ident, $d11:ident, $d12:ident, $d13:ident, $d14:ident, $d15:ident, $d16:ident, $d17:ident])  => { define_multi_index_property!($derived_property, [$d1, $d2, $d3, $d4, $d5, $d6, $d7, $d8, $d9, $d10, $d11, $d12, $d13, $d14, $d15, $d16, $d17] |d1, d2, d3, d4, d5, d6, d7, d8, d9, d10, d11, d12, d13, d14, d15, d16, d17|); };
+    ($derived_property:ident, [$d1:ident, $d2:ident, $d3:ident, $d4:ident, $d5:ident, $d6:ident, $d7:ident, $d8:ident, $d9:ident, $d10:ident, $d11:ident, $d12:ident, $d13:ident, $d14:ident, $d15:ident, $d16:ident, $d17:ident, $d18:ident])  => { define_multi_index_property!($derived_property, [$d1, $d2, $d3, $d4, $d5, $d6, $d7, $d8, $d9, $d10, $d11, $d12, $d13, $d14, $d15, $d16, $d17, $d18] |d1, d2, d3, d4, d5, d6, d7, d8, d9, d10, d11, d12, d13, d14, d15, d16, d17, d18|); };
+    ($derived_property:ident, [$d1:ident, $d2:ident, $d3:ident, $d4:ident, $d5:ident, $d6:ident, $d7:ident, $d8:ident, $d9:ident, $d10:ident, $d11:ident, $d12:ident, $d13:ident, $d14:ident, $d15:ident, $d16:ident, $d17:ident, $d18:ident, $d19:ident])  => { define_multi_index_property!($derived_property, [$d1, $d2, $d3, $d4, $d5, $d6, $d7, $d8, $d9, $d10, $d11, $d12, $d13, $d14, $d15, $d16, $d17, $d18] |d1, d2, d3, d4, d5, d6, d7, d8, d9, d10, d11, d12, d13, d14, d15, d16, d17, d18, d19|); };
+    ($derived_property:ident, [$d1:ident, $d2:ident, $d3:ident, $d4:ident, $d5:ident, $d6:ident, $d7:ident, $d8:ident, $d9:ident, $d10:ident, $d11:ident, $d12:ident, $d13:ident, $d14:ident, $d15:ident, $d16:ident, $d17:ident, $d18:ident, $d19:ident, $d20:ident])  => { define_multi_index_property!($derived_property, [$d1, $d2, $d3, $d4, $d5, $d6, $d7, $d8, $d9, $d10, $d11, $d12, $d13, $d14, $d15, $d16, $d17, $d18, $d19, $d20] |d1, d2, d3, d4, d5, d6, d7, d8, d9, d10, d11, d12, d13, d14, d15, d16, d17, d18, d19, d20|); };
+}
+/*
+use seq_macro::seq;
+
+
+seq!(N in 1..=10 {
+    #[macro_export]
+    macro_rules! define_xyz {
+        ( $derived_property:ident, $( $param:expr ),{N} ) => {
+            $func($( $param ),*);
+        };
+    }
+});
+
+#[macro_export]
+macro_rules! define_xyz {
+    ($derived_property:ident, [$($d:ident),*]) => {
+        seq!(N in 1..=20 {
+            match ($($d),*) {
+                ($d~N),*) => {
+                    define_multi_index_property!(
+                        $derived_property,
+                        [$( $d ),*],
+                        |$( $d ),*|
+                    );
+                }
+            }
+}
+*/

--- a/src/people/property.rs
+++ b/src/people/property.rs
@@ -157,77 +157,37 @@ macro_rules! define_derived_property {
 pub use define_derived_property;
 
 #[macro_export]
-macro_rules! multi_index_property {
-    (
-        $derived_property:ident,
-        [$($dependency:ident),+],
-        |$($param:ident),+|
-    ) => {
-        define_derived_property!($derived_property, $crate::people::index::IndexValue, [$($dependency),*],
-            | $(
-                $param
-            ),+ | {
-            let mut combined = vec!(
-                $(
-                    (std::any::TypeId::of::<$dependency>(),
-                    $crate::people::index::IndexValue::compute(&$param))
-                ),*
-            );
-            combined.sort_by(|a, b| a.0.cmp(&b.0));
-            let values = combined.iter().map(|x| x.1).collect::<Vec<_>>();
-            $crate::people::index::IndexValue::compute(&values)
-        });
-        $crate::people::index::add_multi_property_index::<$derived_property>(
-            &vec![
-                $(
-                    std::any::TypeId::of::<$dependency>(),
-                )*
-            ],
-            std::any::TypeId::of::<$derived_property>(),
-        );
-    };
-}
-
-#[macro_export]
 macro_rules! define_multi_property_index {
-    ($derived_property:ident, [$d1:ident]) =>
-        { $crate::multi_index_property!($derived_property, [$d1], |d1|); };
-    ($derived_property:ident, [$d1:ident, $d2:ident]) =>
-        { $crate::multi_index_property!($derived_property, [$d1, $d2], |d1, d2|); };
-    ($derived_property:ident, [$d1:ident, $d2:ident, $d3:ident]) =>
-        { $crate::multi_index_property!($derived_property, [$d1, $d2, $d3], |d1, d2, d3|); };
-    ($derived_property:ident, [$d1:ident, $d2:ident, $d3:ident, $d4:ident]) =>
-        { $crate::multi_index_property!($derived_property, [$d1, $d2, $d3, $d4], |d1, d2, d3, d4|); };
-    ($derived_property:ident, [$d1:ident, $d2:ident, $d3:ident, $d4:ident, $d5:ident]) =>
-        { $crate::multi_index_property!($derived_property, [$d1, $d2, $d3, $d4, $d5], |d1, d2, d3, d4, d5|); };
-    ($derived_property:ident, [$d1:ident, $d2:ident, $d3:ident, $d4:ident, $d5:ident, $d6:ident]) =>
-        { $crate::multi_index_property!($derived_property, [$d1, $d2, $d3, $d4, $d5, $d6], |d1, d2, d3, d4, d5, d6|); };
-    ($derived_property:ident, [$d1:ident, $d2:ident, $d3:ident, $d4:ident, $d5:ident, $d6:ident, $d7:ident]) =>
-        { $crate::multi_index_property!($derived_property, [$d1, $d2, $d3, $d4, $d5, $d6, $d7], |d1, d2, d3, d4, d5, d6, d7|); };
-    ($derived_property:ident, [$d1:ident, $d2:ident, $d3:ident, $d4:ident, $d5:ident, $d6:ident, $d7:ident, $d8:ident]) =>
-        { $crate::multi_index_property!($derived_property, [$d1, $d2, $d3, $d4, $d5, $d6, $d7, $d8], |d1, d2, d3, d4, d5, d6, d7, d8|); };
-    ($derived_property:ident, [$d1:ident, $d2:ident, $d3:ident, $d4:ident, $d5:ident, $d6:ident, $d7:ident, $d8:ident, $d9:ident]) =>
-        { $crate::multi_index_property!($derived_property, [$d1, $d2, $d3, $d4, $d5, $d6, $d7, $d8, $d9], |d1, d2, d3, d4, d5, d6, d7, d8, d9|); };
-    ($derived_property:ident, [$d1:ident, $d2:ident, $d3:ident, $d4:ident, $d5:ident, $d6:ident, $d7:ident, $d8:ident, $d9:ident, $d10:ident]) =>
-        { $crate::multi_index_property!($derived_property, [$d1, $d2, $d3, $d4, $d5, $d6, $d7, $d8, $d9, $d10], |d1, d2, d3, d4, d5, d6, d7, d8, d9, d10|); };
-    ($derived_property:ident, [$d1:ident, $d2:ident, $d3:ident, $d4:ident, $d5:ident, $d6:ident, $d7:ident, $d8:ident, $d9:ident, $d10:ident, $d11:ident]) =>
-        { $crate::multi_index_property!($derived_property, [$d1, $d2, $d3, $d4, $d5, $d6, $d7, $d8, $d9, $d10, $d11], |d1, d2, d3, d4, d5, d6, d7, d8, d9, d10, d11|); };
-    ($derived_property:ident, [$d1:ident, $d2:ident, $d3:ident, $d4:ident, $d5:ident, $d6:ident, $d7:ident, $d8:ident, $d9:ident, $d10:ident, $d11:ident, $d12:ident]) =>
-        { $crate::multi_index_property!($derived_property, [$d1, $d2, $d3, $d4, $d5, $d6, $d7, $d8, $d9, $d10, $d11, $d12], |d1, d2, d3, d4, d5, d6, d7, d8, d9, d10, d11, d12|); };
-    ($derived_property:ident, [$d1:ident, $d2:ident, $d3:ident, $d4:ident, $d5:ident, $d6:ident, $d7:ident, $d8:ident, $d9:ident, $d10:ident, $d11:ident, $d12:ident, $d13:ident]) =>
-        { $crate::multi_index_property!($derived_property, [$d1, $d2, $d3, $d4, $d5, $d6, $d7, $d8, $d9, $d10, $d11, $d12, $d13], |d1, d2, d3, d4, d5, d6, d7, d8, d9, d10, d11, d12, d13|); };
-    ($derived_property:ident, [$d1:ident, $d2:ident, $d3:ident, $d4:ident, $d5:ident, $d6:ident, $d7:ident, $d8:ident, $d9:ident, $d10:ident, $d11:ident, $d12:ident, $d13:ident, $d14:ident]) =>
-        { $crate::multi_index_property!($derived_property, [$d1, $d2, $d3, $d4, $d5, $d6, $d7, $d8, $d9, $d10, $d11, $d12, $d13, $d14], |d1, d2, d3, d4, d5, d6, d7, d8, d9, d10, d11, d12, d13, d14|); };
-    ($derived_property:ident, [$d1:ident, $d2:ident, $d3:ident, $d4:ident, $d5:ident, $d6:ident, $d7:ident, $d8:ident, $d9:ident, $d10:ident, $d11:ident, $d12:ident, $d13:ident, $d14:ident, $d15:ident]) =>
-        { $crate::multi_index_property!($derived_property, [$d1, $d2, $d3, $d4, $d5, $d6, $d7, $d8, $d9, $d10, $d11, $d12, $d13, $d14, $d15] |d1, d2, d3, d4, d5, d6, d7, d8, d9, d10, d11, d12, d13, d14, d15|); };
-    ($derived_property:ident, [$d1:ident, $d2:ident, $d3:ident, $d4:ident, $d5:ident, $d6:ident, $d7:ident, $d8:ident, $d9:ident, $d10:ident, $d11:ident, $d12:ident, $d13:ident, $d14:ident, $d15:ident, $d16:ident]) =>
-        { $crate::multi_index_property!($derived_property, [$d1, $d2, $d3, $d4, $d5, $d6, $d7, $d8, $d9, $d10, $d11, $d12, $d13, $d14, $d15, $d16] |d1, d2, d3, d4, d5, d6, d7, d8, d9, d10, d11, d12, d13, d14, d15, d16|); };
-    ($derived_property:ident, [$d1:ident, $d2:ident, $d3:ident, $d4:ident, $d5:ident, $d6:ident, $d7:ident, $d8:ident, $d9:ident, $d10:ident, $d11:ident, $d12:ident, $d13:ident, $d14:ident, $d15:ident, $d16:ident, $d17:ident]) =>
-        { $crate::multi_index_property!($derived_property, [$d1, $d2, $d3, $d4, $d5, $d6, $d7, $d8, $d9, $d10, $d11, $d12, $d13, $d14, $d15, $d16, $d17] |d1, d2, d3, d4, d5, d6, d7, d8, d9, d10, d11, d12, d13, d14, d15, d16, d17|); };
-    ($derived_property:ident, [$d1:ident, $d2:ident, $d3:ident, $d4:ident, $d5:ident, $d6:ident, $d7:ident, $d8:ident, $d9:ident, $d10:ident, $d11:ident, $d12:ident, $d13:ident, $d14:ident, $d15:ident, $d16:ident, $d17:ident, $d18:ident]) =>
-        { $crate::multi_index_property!($derived_property, [$d1, $d2, $d3, $d4, $d5, $d6, $d7, $d8, $d9, $d10, $d11, $d12, $d13, $d14, $d15, $d16, $d17, $d18] |d1, d2, d3, d4, d5, d6, d7, d8, d9, d10, d11, d12, d13, d14, d15, d16, d17, d18|); };
-    ($derived_property:ident, [$d1:ident, $d2:ident, $d3:ident, $d4:ident, $d5:ident, $d6:ident, $d7:ident, $d8:ident, $d9:ident, $d10:ident, $d11:ident, $d12:ident, $d13:ident, $d14:ident, $d15:ident, $d16:ident, $d17:ident, $d18:ident, $d19:ident]) =>
-        { $crate::multi_index_property!($derived_property, [$d1, $d2, $d3, $d4, $d5, $d6, $d7, $d8, $d9, $d10, $d11, $d12, $d13, $d14, $d15, $d16, $d17, $d18, $d19] |d1, d2, d3, d4, d5, d6, d7, d8, d9, d10, d11, d12, d13, d14, d15, d16, d17, d18, d19|); };
-    ($derived_property:ident, [$d1:ident, $d2:ident, $d3:ident, $d4:ident, $d5:ident, $d6:ident, $d7:ident, $d8:ident, $d9:ident, $d10:ident, $d11:ident, $d12:ident, $d13:ident, $d14:ident, $d15:ident, $d16:ident, $d17:ident, $d18:ident, $d19:ident, $d20:ident]) =>
-        { $crate::multi_index_property!($derived_property, [$d1, $d2, $d3, $d4, $d5, $d6, $d7, $d8, $d9, $d10, $d11, $d12, $d13, $d14, $d15, $d16, $d17, $d18, $d19, $d20] |d1, d2, d3, d4, d5, d6, d7, d8, d9, d10, d11, d12, d13, d14, d15, d16, d17, d18, d19, d20|); };
+    (
+        $($dependency:ident),+
+    ) => {
+        $crate::paste::paste! {
+            define_derived_property!(
+                [< $($dependency)+ Query >],
+                $crate::people::index::IndexValue,
+                [$($dependency),+],
+                |$([< $dependency:lower >]),+| {
+                    let mut combined = vec!(
+                        $(
+                            (std::any::TypeId::of::<$dependency>(),
+                            $crate::people::index::IndexValue::compute(&[< $dependency:lower >]))
+                        ),*
+                    );
+                    combined.sort_by(|a, b| a.0.cmp(&b.0));
+                    let values = combined.iter().map(|x| x.1).collect::<Vec<_>>();
+                    $crate::people::index::IndexValue::compute(&values)
+                }
+            );
+
+            $crate::people::index::add_multi_property_index::<[< $($dependency)+ Query >]>(
+                #[allow(clippy::useless_vec)]
+                &vec![
+                    $(
+                        std::any::TypeId::of::<$dependency>(),
+                    )*
+                ],
+                std::any::TypeId::of::<[< $($dependency)+ Query >]>(),
+            );
+        }
+    };
 }

--- a/src/people/query.rs
+++ b/src/people/query.rs
@@ -53,11 +53,13 @@ macro_rules! impl_query {
                 }
 
                 fn get_query(&self) -> Vec<(TypeId, IndexValue)> {
-                    vec![
+                    let mut ordered_items = vec![
                     #(
                         (std::any::TypeId::of::<T~N>(), IndexValue::compute(&self.N.1)),
                     )*
-                    ]
+                    ];
+                    ordered_items.sort_by(|a, b| a.0.cmp(&b.0));
+                    ordered_items
                 }
             }
         });
@@ -115,19 +117,27 @@ where
         let mut query = Vec::new();
         query.extend_from_slice(&self.queries.0.get_query());
         query.extend_from_slice(&self.queries.1.get_query());
+        query.sort_by(|a, b| a.0.cmp(&b.0));
         query
     }
 }
 
 #[cfg(test)]
 mod tests {
+    use crate::people::index::IndexValue;
     use crate::people::PeoplePlugin;
     use crate::people::{Query, QueryAnd};
-    use crate::{define_derived_property, define_person_property, Context, ContextPeopleExt};
+    use crate::{
+        define_derived_property, define_multi_index_property, define_person_property, define_xyz,
+        Context, ContextPeopleExt,
+    };
     use serde_derive::Serialize;
     use std::any::TypeId;
 
     define_person_property!(Age, u8);
+    define_person_property!(County, u32);
+    define_person_property!(Height, u32);
+    define_derived_property!(AgeGroup, u8, [Age], |age| (age / 5));
 
     #[derive(Serialize, Copy, Clone, PartialEq, Eq, Debug)]
     pub enum RiskCategoryValue {
@@ -388,6 +398,67 @@ mod tests {
 
         assert_eq!(seniors.len(), 2, "Two seniors");
         assert_eq!(not_seniors.len(), 0, "No non-seniors");
+    }
+
+    #[test]
+    #[allow(clippy::uninlined_format_args)]
+    fn query_derived_prop_with_optimized_index() {
+        let mut context = Context::new();
+        // create a 'regular' derived property
+        define_derived_property!(
+            Ach,
+            (u8, u32, u32),
+            [Age, County, Height],
+            |age, county, height| { (age, county, height) }
+        );
+
+        // create a multi-property index
+        define_xyz!(AgeCountyHeight, [Age, County, Height]);
+        context.index_property(AgeCountyHeight);
+
+        // add some people
+        let _person = context
+            .add_person(((Age, 64), (County, 2), (Height, 120)))
+            .unwrap();
+        let _ = context
+            .add_person(((Age, 88), (County, 2), (Height, 130)))
+            .unwrap();
+        let _ = context
+            .add_person(((Age, 8), (County, 1), (Height, 140)))
+            .unwrap();
+        let p3 = context
+            .add_person(((Age, 28), (County, 1), (Height, 140)))
+            .unwrap();
+        let p4 = context
+            .add_person(((Age, 28), (County, 2), (Height, 160)))
+            .unwrap();
+        let p5 = context
+            .add_person(((Age, 28), (County, 2), (Height, 160)))
+            .unwrap();
+
+        let ach_people = context.query_people((Ach, (28, 2, 160)));
+        assert_eq!(ach_people.len(), 2, "Should have 2 matches");
+        assert!(ach_people.contains(&p4));
+        assert!(ach_people.contains(&p5));
+
+        let age_county_height2 = context.query_people(((Age, 28), (County, 2), (Height, 160)));
+        assert_eq!(age_county_height2.len(), 2, "Should have 2 matches");
+        assert!(age_county_height2.contains(&p4));
+        assert!(age_county_height2.contains(&p5));
+
+        let age_county_height3 = context.query_people(((County, 2), (Height, 160), (Age, 28)));
+        assert_eq!(age_county_height3.len(), 2, "Should have 2 matches");
+        assert!(age_county_height3.contains(&p4));
+        assert!(age_county_height3.contains(&p5));
+
+        let age_county_height4 = context.query_people(((Height, 160), (County, 2), (Age, 28)));
+        assert_eq!(age_county_height4.len(), 2, "Should have 2 matches");
+        assert!(age_county_height4.contains(&p4));
+        assert!(age_county_height4.contains(&p5));
+
+        let age_county_height5 = context.query_people(((Height, 140), (County, 1), (Age, 28)));
+        assert_eq!(age_county_height5.len(), 1, "Should have 1 matches");
+        assert!(age_county_height5.contains(&p3));
     }
 
     #[test]

--- a/src/people/query.rs
+++ b/src/people/query.rs
@@ -411,7 +411,8 @@ mod tests {
         );
 
         // create a multi-property index
-        define_multi_property_index!(AgeCountyHeight, [Age, County, Height]);
+        define_multi_property_index!(Age, County, Height);
+        define_multi_property_index!(County, Height);
 
         // add some people
         let _person = context
@@ -465,6 +466,11 @@ mod tests {
         context.set_person_property(p2, Age, 28);
         // multi-property index again after changing the value
         let age_county_height5 = context.query_people(((Height, 140), (County, 1), (Age, 28)));
+        assert_eq!(age_county_height5.len(), 2, "Should have 2 matches");
+        assert!(age_county_height5.contains(&p2));
+        assert!(age_county_height5.contains(&p3));
+
+        let age_county_height5 = context.query_people(((Height, 140), (County, 1)));
         assert_eq!(age_county_height5.len(), 2, "Should have 2 matches");
         assert!(age_county_height5.contains(&p2));
         assert!(age_county_height5.contains(&p3));


### PR DESCRIPTION
Adding support for multi property index

usage:
if you have the following properties defined: Age, County, Height
in your function you can call:
   define_multi_property_index!(AgeCountyHeight, [Age, County, Height]);

and now you can just query the defined properties, like:
  let result = context.query_people(((Height, 140), (County, 1), (Age, 28)));