### PR TITLE
Change range of lines of code to display define_rng!

### DIFF
--- a/docs/book/src/first_model/transmission.md
+++ b/docs/book/src/first_model/transmission.md
@@ -41,7 +41,7 @@ We need to import these constants into `transmission_manager`. To define a new r
 
 ```rust
 // transmission_manager.rs
-{{#include ../../models/disease_model/src/transmission_manager.rs:1:9}}
+{{#include ../../models/disease_model/src/transmission_manager.rs:1:10}}
 // ...the rest of the file...
 ```
 


### PR DESCRIPTION
I believe that the line
https://github.com/CDCgov/ixa/blob/4be6bca8e436481a935720caefefcd7fdac034ff/docs/book/models/disease_model/src/transmission_manager.rs#L10

is missing from the following code chunk:

![image](https://github.com/user-attachments/assets/b54f49a8-b08c-40f4-8207-f75335d63fcb)
