### PR TITLE
Fix double borrow during property registration

### DIFF
--- a/src/people/data.rs
+++ b/src/people/data.rs
@@ -31,7 +31,7 @@ pub(super) struct PeopleData {
     pub(super) current_population: usize,
     pub(super) methods: RefCell<HashMap<TypeId, Methods>>,
     pub(super) properties_map: RefCell<HashMap<TypeId, StoredPeopleProperties>>,
-    pub(super) registered_derived_properties: RefCell<HashSet<TypeId>>,
+    pub(super) registered_properties: RefCell<HashSet<TypeId>>,
     pub(super) dependency_map: RefCell<HashMap<TypeId, Vec<Box<dyn PersonPropertyHolder>>>>,
     pub(super) property_indexes: RefCell<HashMap<TypeId, Index>>,
     pub(super) people_types: RefCell<HashMap<String, TypeId>>,

--- a/src/people/mod.rs
+++ b/src/people/mod.rs
@@ -103,7 +103,7 @@ define_data_plugin!(
         current_population: 0,
         methods: RefCell::new(HashMap::new()),
         properties_map: RefCell::new(HashMap::new()),
-        registered_derived_properties: RefCell::new(HashSet::new()),
+        registered_properties: RefCell::new(HashSet::new()),
         dependency_map: RefCell::new(HashMap::new()),
         property_indexes: RefCell::new(HashMap::new()),
         people_types: RefCell::new(HashMap::new()),

--- a/src/people/property.rs
+++ b/src/people/property.rs
@@ -23,6 +23,9 @@ pub trait PersonProperty: Copy {
     fn dependencies() -> Vec<Box<dyn PersonPropertyHolder>> {
         panic!("Dependencies not implemented");
     }
+    fn register_dependencies(_: &Context) {
+        panic!("Dependencies not implemented");
+    }
     fn compute(context: &Context, person_id: PersonId) -> Self::Value;
     fn get_instance() -> Self;
     fn name() -> &'static str;
@@ -130,6 +133,9 @@ macro_rules! define_derived_property {
             fn is_derived() -> bool { true }
             fn dependencies() -> Vec<Box<dyn $crate::people::PersonPropertyHolder>> {
                 vec![$(Box::new($dependency)),+]
+            }
+            fn register_dependencies(context: &$crate::context::Context) {
+                $(context.register_property::<$dependency>();)+
             }
             fn get_instance() -> Self {
                 $derived_property


### PR DESCRIPTION
AFAICT the bug seemed to be introduced by ee3c219bed26fd8251ea8644b5ecd263c0186023 when we started registering all properties during get_person_property etc.

I agree we should take a look at refactoring/cleaning a bunch of this up but it would be good to add some more tests about initialization semantics/indexing before we do that. 
