### PR TITLE
docs: Use rustdoc_include to link to full files in ixa book

### DIFF
--- a/docs/book/src/first_model/infection.md
+++ b/docs/book/src/first_model/infection.md
@@ -8,21 +8,21 @@ Modules can subscribe to events. The infection manager registers a function with
 
 ```rust
 // in infection_manager.rs
-{{#include ../../models/disease_model/src/infection_manager.rs:11}}
+{{#rustdoc_include ../../models/disease_model/src/infection_manager.rs:11}}
 ```
 
 This line isn't defining a new struct or even a new type. Rather, it defines an alias for `PersonPropertyChangeEvent\<T>` with the generic type  `T` instantiated with the property we want to monitor, `InfectionStatus`. This is effectively the name of the event we subscribe to in the module's `init()` function:
 
 ```rust
 // in infection_manager.rs
-{{#include ../../models/disease_model/src/infection_manager.rs:40:43}}
+{{#rustdoc_include ../../models/disease_model/src/infection_manager.rs:40:43}}
 ```
 
 The event handler is just a regular Rust function that takes a `Context` and an `InfectionStatusEvent`, the latter of which holds the `PersonId` of the person whose `InfectionStatus` changed, the current `InfectionStatusValue`, and the previous `InfectionStatusValue`.
 
 ```rust
 // in infection_manager.rs
-{{#include ../../models/disease_model/src/infection_manager.rs:28:38}}
+{{#rustdoc_include ../../models/disease_model/src/infection_manager.rs:28:38}}
 ```
 
 We only care about new infections in this model.
@@ -32,7 +32,7 @@ We only care about new infections in this model.
 As in `attempt_infection()`, we sample the recovery time from the exponential distribution with mean `INFECTION_DURATION`. We define a random number source for this module's exclusive use with `define_rng!(InfectionRng)`.
 
 ```rust
-{{#include ../../models/disease_model/src/infection_manager.rs:15:26}}
+{{#rustdoc_include ../../models/disease_model/src/infection_manager.rs:15:26}}
 ```
 
 Notice that the plan is again just a Rust function, but this time it takes the form of a closure rather than a traditionally define function. This is convenient when the function is only a line or two.

--- a/docs/book/src/first_model/next-steps.md
+++ b/docs/book/src/first_model/next-steps.md
@@ -4,7 +4,7 @@ We have created several new modules. We need to make sure they are each initiali
 
 ```rust
 // main.rs
-{{#include ../../models/disease_model/src/main.rs}}
+{{#rustdoc_include ../../models/disease_model/src/main.rs}}
 ```
 
 Exercises:

--- a/docs/book/src/first_model/people.md
+++ b/docs/book/src/first_model/people.md
@@ -10,7 +10,7 @@ Ixa is a framework for developing *agent*-based models. In most of our models, t
 ## `PersonProperty`
 
 ```rust
-{{#include ../../models/disease_model/src/people.rs:5:10}}
+{{#rustdoc_include ../../models/disease_model/src/people.rs:5:10}}
 ```
 
 To each person we will associate a value of the enum (short for “enumeration”) named `InfectionStatusValue`. An enum is a way to create a type that can be one of several predefined values. Here, we have three values:
@@ -34,7 +34,7 @@ The attributes written above the enum declaration, such as `#[derive(Debug, Hash
 All of our "person properties" in our models will "derive" these attributes. It is not enough to define this enum. We have to tell Ixa that it will be a `PersonProperty`:
 
 ```rust
-{{#include ../../models/disease_model/src/people.rs:12:16}}
+{{#rustdoc_include ../../models/disease_model/src/people.rs:12:16}}
 ```
 
 > [!NOTE] Name Tags and Values
@@ -71,7 +71,7 @@ The `context.add_person()` method call might look a little odd, because we are n
 Having "magic numbers" embedded in your code, such as the constant `1000` here representing the total number of people in our model, is ***bad practice***. What if we want to change this value later? Will we even be able to find it in all of our source code? Ixa has a formal mechanism for managing these kinds of model parameters, but for now we will just define a "static constant" near the top of `src/main.rs` named `POPULATION` and replace the literal `1000` with `POPULATION`:
 
 ```rust
-{{#include ../../models/disease_model/src/people.rs:18:24}}
+{{#rustdoc_include ../../models/disease_model/src/people.rs:18:24}}
 ```
 
 Let's revisit `src/main.rs`:
@@ -113,5 +113,5 @@ Turning back to `src/people.rs`, your IDE might have been complaining to you abo
 
 ```rust
 //people.rs
-{{#include ../../models/disease_model/src/people.rs}}
+{{#rustdoc_include ../../models/disease_model/src/people.rs}}
 ```

--- a/docs/book/src/first_model/reporter.md
+++ b/docs/book/src/first_model/reporter.md
@@ -6,19 +6,19 @@ Our model will only have a single report that records the current in-simulation 
 
 ```rust
 // in incidence_report.rs
-{{#include ../../models/disease_model/src/incidence_report.rs:7:12}}
+{{#rustdoc_include ../../models/disease_model/src/incidence_report.rs:7:12}}
 ```
 
 The fact that `IncidenceReportItem` derives `Serialize` is what makes this magic work. We define a report for this struct using the `create_report_trait!` macro.
 
 ```rust
-{{#include ../../models/disease_model/src/incidence_report.rs:14}}
+{{#rustdoc_include ../../models/disease_model/src/incidence_report.rs:14}}
 ```
 
 The way we listen to events is almost identical to how we did it in the `infection` module. First let's make the event handler, that is, the callback that will be called whenever an event is emitted.
 
 ```rust
-{{#include ../../models/disease_model/src/incidence_report.rs:16:28}}
+{{#rustdoc_include ../../models/disease_model/src/incidence_report.rs:16:28}}
 ```
 
 Just pass a `IncidenceReportItem` to `context.send_report()`! We also emit a trace log message so we can trace the execution of our model.
@@ -26,7 +26,7 @@ Just pass a `IncidenceReportItem` to `context.send_report()`! We also emit a tra
 In the `init()` function there is a little bit of setup needed. Also, we can't forget to register this callback to listen to `InfectionStatusEvent`s.
 
 ```rust
-{{#include ../../models/disease_model/src/incidence_report.rs:30:44}}
+{{#rustdoc_include ../../models/disease_model/src/incidence_report.rs:30:44}}
 ```
 
 Note that:
@@ -43,5 +43,5 @@ Note that:
 If your IDE isn't capable of adding imports for you, the external symbols we need for this module are as follows.
 
 ```rust
-{{#include ../../models/disease_model/src/incidence_report.rs:1:5}}
+{{#rustdoc_include ../../models/disease_model/src/incidence_report.rs:1:5}}
 ```

--- a/docs/book/src/first_model/setup.md
+++ b/docs/book/src/first_model/setup.md
@@ -81,7 +81,7 @@ a good idea to get into the habit of adding at least the author(s) and a brief d
 
 ```toml
 # Cargo.toml
-{{ #include ../../models/disease_model/Cargo.toml}}
+{{ #rustdoc_include ../../models/disease_model/Cargo.toml}}
 ```
 
 ## Executing the Ixa model
@@ -90,7 +90,7 @@ We are almost ready to execute our first model. Edit `src/main.rs` to look like 
 
 ```rust
 // main.rs
-{{ #include ../../models/basic/main.rs}}
+{{ #rustdoc_include ../../models/basic/main.rs}}
 ```
 
 Don't let this code intimidate you—it's really quite simple. The first line says we want to use symbols from the `ixa`

--- a/docs/book/src/first_model/transmission.md
+++ b/docs/book/src/first_model/transmission.md
@@ -41,7 +41,7 @@ We need to import these constants into `transmission_manager`. To define a new r
 
 ```rust
 // transmission_manager.rs
-{{#include ../../models/disease_model/src/transmission_manager.rs:1:10}}
+{{#rustdoc_include ../../models/disease_model/src/transmission_manager.rs:1:10}}
 // ...the rest of the file...
 ```
 
@@ -52,7 +52,7 @@ The function `attempt_infection()` needs to do the following:
 3. Schedule the next infection attempt by inserting a plan into the timeline that will run `attempt_infection()` again.
 
 ```rust
-{{#include ../../models/disease_model/src/transmission_manager.rs:12:41}}
+{{#rustdoc_include ../../models/disease_model/src/transmission_manager.rs:12:41}}
 ```
 
 Read through this implementation and make sure you understand how it accomplishes the three tasks above. A few observations:

--- a/docs/book/src/get-started.md
+++ b/docs/book/src/get-started.md
@@ -19,7 +19,7 @@ curl -s https://raw.githubusercontent.com/CDCgov/ixa/main/scripts/setup_new_ixa_
 Open `src/main.rs` in your favorite editor or IDE to verify the model looks like the following:
 
 ```rust
-{{#include ../models/basic/main.rs}}
+{{#rustdoc_include ../models/basic/main.rs}}
 ```
 
 To run the model:


### PR DESCRIPTION
Fixes #315  

See https://rust-lang.github.io/mdBook/format/mdbook.html#including-a-file-but-initially-hiding-all-except-specified-lines