### PR TITLE
chore: Fix benchmark ci

### DIFF
--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -10,7 +10,6 @@ env:
 
 jobs:
   build:
-
     runs-on: ubuntu-latest
 
     steps:
@@ -18,7 +17,7 @@ jobs:
       - name: Build
         run: cargo build --verbose
       - name: Build benchmarks
-        run: cargo bench --no-run
+        run: cargo bench -p ixa-bench --no-run
       - name: Run tests
         run: cargo test --workspace --verbose
       - name: Run examples

--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -1,5 +1,5 @@
 name: Benchmark Pull Requests
-on: [ pull_request ]
+on: [pull_request]
 jobs:
   runBenchmark:
     name: run benchmark
@@ -8,5 +8,6 @@ jobs:
       - uses: actions/checkout@v4
       - uses: boa-dev/criterion-compare-action@v3
         with:
+          package: ixa-bench
           # Needed. The name of the branch to compare with, uses the branch which is being pulled against
           branchName: ${{ github.base_ref }}

--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -9,5 +9,6 @@ jobs:
       - uses: boa-dev/criterion-compare-action@v3
         with:
           package: ixa-bench
-          # Needed. The name of the branch to compare with, uses the branch which is being pulled against
-          branchName: ${{ github.base_ref }}
+          # DO NOT MERGE THIS: Work-around for testing in CI
+          branchName: k88-fix-bench-ci-comparison
+          # branchName: ${{ github.base_ref }}

--- a/ixa-bench/Cargo.toml
+++ b/ixa-bench/Cargo.toml
@@ -19,7 +19,7 @@ ixa_example_basic_infection = { path = "../examples/basic-infection" }
 ixa_example_births_deaths = { path = "../examples/births-deaths" }
 
 [lib]
-# nothing here
+bench = false
 
 [lints]
 workspace = true

--- a/ixa-bench/README.md
+++ b/ixa-bench/README.md
@@ -72,19 +72,19 @@ cargo install cargo-criterion
 To run all benchmarks:
 
 ```bash
-cargo bench
+cargo bench -p ixa-bench
 ```
 
 To run a specific benchmark called `example_births_deaths`:
 
 ```bash
-cargo bench --bench example_births_deaths
+cargo bench -p ixa-bench --bench example_births_deaths
 ```
 
 To run a specific named benchmark group named `example_benches`:
 
 ```bash
-cargo bench -- example_benches
+cargo bench -p ixa-bench -- example_benches
 ```
 
 ### Using `cargo criterion`


### PR DESCRIPTION
This PR addresses an issue where `cargo bench` doesn't run the benchmarks in`ixa-bench` on main right now, so the task is failing