### PR TITLE
chore: Modified workspace members to opt in to workspace lint exceptions.  Fixes #339.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -66,6 +66,7 @@ pedantic = { level = "warn", priority = -1 }
 module-name-repetitions = "allow"
 implicit_hasher = "allow"
 missing_panics_doc = "allow"
+missing_errors_doc = "allow"
 uninlined_format_args = "allow"
 
 [lib]

--- a/examples/basic-infection/Cargo.toml
+++ b/examples/basic-infection/Cargo.toml
@@ -15,6 +15,9 @@ rand = "^0.8.5"
 rand_distr = "^0.4.3"
 paste = "^1.0.15"
 
+[lints]
+workspace = true
+
 [[bin]]
 name = "basic_infection"
 path = "main.rs"

--- a/examples/births-deaths/Cargo.toml
+++ b/examples/births-deaths/Cargo.toml
@@ -16,6 +16,9 @@ rand = "^0.8.5"
 rand_distr = "^0.4.3"
 paste = "^1.0.15"
 
+[lints]
+workspace = true
+
 [[bin]]
 name = "births_deaths"
 path = "main.rs"

--- a/ixa-derive/Cargo.toml
+++ b/ixa-derive/Cargo.toml
@@ -11,5 +11,8 @@ homepage = "https://github.com/CDCgov/ixa"
 quote = "^1.0.38"
 syn = "^2.0.95"
 
+[lints]
+workspace = true
+
 [lib]
 proc-macro = true

--- a/ixa-integration-tests/Cargo.toml
+++ b/ixa-integration-tests/Cargo.toml
@@ -14,6 +14,8 @@ clap = { version = "^4.5.26", features = ["derive"] }
 [dev-dependencies]
 assert_cmd = "^2.0.16"
 
+[lints]
+workspace = true
 
 [[bin]]
 name = "runner_test_custom_args"


### PR DESCRIPTION
Modified workspace members to opt in to workspace lint exceptions. 

Added `missing_errors_doc = "allow"` for the same reasons as `missing_panics_doc`.


Note that while `examples/births-deaths` and `examples/basic-infection` are not explicitly members of the workspace, for some reason adding the `[lints]` section to their `Cargo.toml` is needed. 