### PR TITLE
feat: Settings module

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -66,6 +66,7 @@ pedantic = { level = "warn", priority = -1 }
 module-name-repetitions = "allow"
 implicit_hasher = "allow"
 missing_panics_doc = "allow"
+missing_errors_doc = "allow"
 uninlined_format_args = "allow"
 
 [lib]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,7 @@ members = [
   "ixa-bench",
   "ixa-derive",
   "ixa-integration-tests",
+  "ixa-fips"
 ]
 
 [workspace.package]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ license.workspace = true
 edition.workspace = true
 
 [dependencies]
+approx = "^0.5.1"
 rand = "^0.8.5"
 csv = "^1.3.1"
 serde = { version = "^1.0.217", features = ["derive"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,6 +48,7 @@ uuid = "^1.12.1"
 tower-http = { version = "^0.6.2", features = ["full"] }
 mime = "^0.3.17"
 rustc-hash = "^2.1.1"
+fips = { path = "../fips" }
 
 [dev-dependencies]
 rand_distr = "^0.4.3"

--- a/examples/basic-infection/Cargo.toml
+++ b/examples/basic-infection/Cargo.toml
@@ -15,6 +15,9 @@ rand = "^0.8.5"
 rand_distr = "^0.4.3"
 paste = "^1.0.15"
 
+[lints]
+workspace = true
+
 [[bin]]
 name = "basic_infection"
 path = "main.rs"

--- a/examples/births-deaths/Cargo.toml
+++ b/examples/births-deaths/Cargo.toml
@@ -16,6 +16,9 @@ rand = "^0.8.5"
 rand_distr = "^0.4.3"
 paste = "^1.0.15"
 
+[lints]
+workspace = true
+
 [[bin]]
 name = "births_deaths"
 path = "main.rs"

--- a/ixa-derive/Cargo.toml
+++ b/ixa-derive/Cargo.toml
@@ -11,5 +11,8 @@ homepage = "https://github.com/CDCgov/ixa"
 quote = "^1.0.38"
 syn = "^2.0.95"
 
+[lints]
+workspace = true
+
 [lib]
 proc-macro = true

--- a/ixa-fips/Cargo.toml
+++ b/ixa-fips/Cargo.toml
@@ -1,0 +1,23 @@
+[package]
+name = "ixa-fips"
+description = "A library for efficiently working with FIPS region codes"
+version = "0.1.0"
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+
+[features]
+default = ["aspr_archive"]
+
+## Support for working with the ASPR Synthetic Population dataset # Parsing ASPR codes
+aspr_archive = ["zip", "once_cell", "ouroboros"] # Reading ASPR Synthetic Population files from ZIP archives
+aspr_tests = [] # Runs tests that assume the existence of ASPR Synthetic Population files from ZIP archives
+
+[dependencies]
+## Dependencies for "aspr_archive"
+zip = { version = "2.6.1", optional = true }
+once_cell = { version = "1", optional = true }
+ouroboros = { version = "0.18.5", optional = true }
+
+[lints]
+workspace = true

--- a/ixa-fips/README.md
+++ b/ixa-fips/README.md
@@ -1,0 +1,94 @@
+# fips — High-performance FIPS geographic codes & ASPR dataset utilities
+
+***Represent, parse, and manipulate hierarchical FIPS region codes in just 64 bits ― with first-class support for the
+ASPR synthetic-population files.***
+
+## Why this crate?
+
+* **Compact & cache-friendly.** A complete state → county → census-tract hierarchy (plus category, id, and extra data)
+  is packed into a single `u64`, minimizing memory use and hash-map overhead.
+* **Zero-copy parsing.** Fast lexical routines turn text into `FIPSCode` values without intermediate heap allocations.
+* **Batteries included for the ASPR dataset.** Transparent iterators load ASPR CSVs whether they live in a directory
+  tree *or* a ZIP archive, so large synthetic populations stream in record-by-record.
+* **Ergonomic, strongly-typed API.** Rich enums (`USState`, `SettingCategory`, …) prevent illegal states at compile time
+  and make downstream code self-documenting.
+
+## Core primitives
+
+| Type / Module   | Purpose                                                                                                     |
+|-----------------|-------------------------------------------------------------------------------------------------------------|
+| `FIPSCode`      | 64-bit value encoding state + county + tract + category + id *(10 spare bits for you)*                      |
+| `parser`        | Zero-allocation conversions <br/>`&str` ⇆ `FIPSCode` / fragments                                            |
+| `USState`       | Exhaustive enum of valid state codes (fits in the 6 bits allocated by `FIPSCode`)                           |
+| `aspr`          | Helpers for the **ASPR synthetic-population** files <br/>`ASPRPersonRecord`, parsers                        |
+| `aspr::archive` | (With feature `aspr_archive`) <br/>Reads ASPR CSVs inside a directory *or* a ZIP without changing your code |
+
+## Quick tour
+
+### 1. Building a code "by hand"
+
+```rust
+use fips::{FIPSCode, USState};
+
+let code  = FIPSCode::with_tract(
+USState::TX,
+201,        // county
+1234,                // census tract
+);
+
+// Pattern-match the components later:
+assert_eq!(code.state(), USState::TX);
+```
+
+### **2. Parsing from text**
+
+Example parsing a complete FIPS code (state + county + tract):
+
+```rust
+// Example: "01001020100" = Alabama (01), Autauga County (001), Tract 020100
+
+let input = "01001020100";
+
+// First parse the state
+let (rest, state) = parse_state_code(input).unwrap();
+assert_eq!(rest, "001020100");
+
+// Then parse the county
+let (rest, county) = parse_county_code(rest).unwrap();
+assert_eq!(rest, "020100");
+
+// Finally parse the tract
+let (rest, tract) = parse_tract_code(rest).unwrap();
+assert_eq!(rest, "");
+
+// Verify the parsed values (assuming USState enum implementation)
+assert_eq!(state, USState::AL);
+assert_eq!(county, 1);
+assert_eq!(tract, 20100);
+```
+
+(The grammar understands plain hierarchical strings as well as extended from the ASPR synthetic population dataset.)
+
+### 3. Streaming a synthetic population
+
+```rust
+use fips::aspr::archive::{ASPRRecordIterator, set_aspr_data_path};
+use fips::USState;
+
+set_aspr_data_path(PathBuf::from("../CDC/data/ASPR_Synthetic_Population.zip"));
+
+for person in ASPRRecordIterator::state_population(USState::AK) {
+if let Ok(record) = person {
+// record.age, record.home_id, record.school_id, record.work_id …
+println ! ("{}", record);
+}
+}
+```
+
+The iterator automatically detects whether the `ASPR_DATA_PATH` you configured is a directory tree or a zipped archive.
+
+## Feature flags
+
+| **Feature**    | **Default?** | **Adds…**                                            |
+|----------------|--------------|------------------------------------------------------|
+| `aspr_archive` | Yes          | `aspr::archive` — seamless ZIP/dir record iterators. |

--- a/ixa-fips/README.md
+++ b/ixa-fips/README.md
@@ -28,12 +28,12 @@ ASPR synthetic-population files.***
 ### 1. Building a code "by hand"
 
 ```rust
-use fips::{FIPSCode, USState};
+use ixa_fips::{FIPSCode, USState};
 
 let code  = FIPSCode::with_tract(
-USState::TX,
-201,        // county
-1234,                // census tract
+    USState::TX,
+    201,  // county
+    1234, // census tract
 );
 
 // Pattern-match the components later:
@@ -46,7 +46,6 @@ Example parsing a complete FIPS code (state + county + tract):
 
 ```rust
 // Example: "01001020100" = Alabama (01), Autauga County (001), Tract 020100
-
 let input = "01001020100";
 
 // First parse the state
@@ -72,16 +71,16 @@ assert_eq!(tract, 20100);
 ### 3. Streaming a synthetic population
 
 ```rust
-use fips::aspr::archive::{ASPRRecordIterator, set_aspr_data_path};
-use fips::USState;
+use ixa_fips::aspr::archive::{ASPRRecordIterator, set_aspr_data_path};
+use ixa_fips::USState;
 
 set_aspr_data_path(PathBuf::from("../CDC/data/ASPR_Synthetic_Population.zip"));
 
 for person in ASPRRecordIterator::state_population(USState::AK) {
-if let Ok(record) = person {
-// record.age, record.home_id, record.school_id, record.work_id …
-println ! ("{}", record);
-}
+    if let Ok(record) = person {
+        // record.age, record.home_id, record.school_id, record.work_id …
+        println ! ("{}", record);
+    }
 }
 ```
 

--- a/ixa-fips/src/aspr/archive.rs
+++ b/ixa-fips/src/aspr/archive.rs
@@ -1,0 +1,470 @@
+/*!
+This module is enabled with the `aspr_archive` feature and provides facilities to read ASPR synthetic population data.
+
+Set and get the ASPR data path with the `set_aspr_data_path` and `get_aspr_data_path` functions:
+
+```rust
+# use fips::aspr::archive::{get_aspr_data_path, set_aspr_data_path};
+# use std::path::PathBuf;
+let current_path = get_aspr_data_path();
+println!("The current ASPR data path: {:?}", current_path);
+
+set_aspr_data_path(PathBuf::from("../CDC/data/ASPR_Synthetic_Population.zip"));
+let new_path = get_aspr_data_path();
+println!("The new ASPR data path: {:?}", new_path);
+```
+
+You can set the ASPR data path to a zip archive or to a directory. You can refer to subdirectories of the data path
+with the `ALL_STATES_DIR`, `CBSA_ALL_DIR`, `CBSA_ONLY_RESIDENTS_DIR`, `NON_CBSA_RESIDENTS_DIR`, and `MULTI_STATE_DIR`
+constants for convenience. (These are `&str`s.)
+
+You can iterate over the records in a CSV file under the ASPR data path with the `ASPRRecordIterator` struct. This
+struct transparently handles the case that the ASPR data path is a zip archive or a directory for you. Just provide the
+path to the CSV file relative to the ASPR data path:
+
+```rust
+# use fips::aspr::archive::{CBSA_ALL_DIR, ASPRRecordIterator};
+# use std::path::PathBuf;
+let subdirectory = PathBuf::from(CBSA_ALL_DIR).join("AK/Ketchikan AK.csv");
+let records = ASPRRecordIterator::from_path(subdirectory);
+// Do something with the records...
+```
+
+The `ASPRRecordIterator::state_population()` function is a convenience function that returns an iterator over the
+records in `${ASPR_DATA_PATH}/${ALL_STATES_DIR}/${state}.csv`.
+
+```rust
+# use fips::aspr::archive::{ASPRRecordIterator};
+# use fips::USState;
+let records = ASPRRecordIterator::state_population(USState::AK);
+// Do something with the records...
+```
+
+You can get a list of CSV files in a given subdirectory of the ASPR data path with the `iter_csv_files` function. This
+is useful for chaining record iterators using the `from_file_iterator` constructor method:
+
+```rust
+# use fips::aspr::archive::{iter_csv_files, ALL_STATES_DIR, ASPRRecordIterator};
+let records = ASPRRecordIterator::from_file_iterator(iter_csv_files(ALL_STATES_DIR).unwrap());
+// Do something with the records...
+```
+
+*/
+
+use crate::{
+    aspr::{
+        errors::ASPRError,
+        parser::{parse_fips_home_id, parse_fips_school_id, parse_fips_workplace_id},
+        ASPRPersonRecord,
+    },
+    states::USState,
+};
+use once_cell::sync::Lazy;
+use ouroboros::self_referencing;
+use std::{
+    fs::File,
+    io::Lines,
+    io::{BufRead, BufReader},
+    path::PathBuf,
+    sync::RwLock,
+};
+use zip::{read::ZipFile, ZipArchive};
+
+// Directory structure of the ASPR data
+pub const ALL_STATES_DIR: &str = "all_states";
+pub const CBSA_ALL_DIR: &str = "cbsa_all_work_school_household";
+pub const CBSA_ONLY_RESIDENTS_DIR: &str = "cbsa_only_residents";
+// Either of the next two can be affixed to either of the two above directories
+pub const NON_CBSA_RESIDENTS_DIR: &str = "non_CBSA_residents";
+pub const MULTI_STATE_DIR: &str = "Multi-state";
+
+// Path to the ASPR data directory
+const DEFAULT_ASPR_DATA_PATH: &str = "../CDC/data/ASPR_Synthetic_Population";
+// ToDo: Get the ASPR data path from an environment variable.
+static ASPR_DATA_PATH: Lazy<RwLock<PathBuf>> =
+    Lazy::new(|| RwLock::new(PathBuf::from(DEFAULT_ASPR_DATA_PATH)));
+
+/// Setter for the ASPR data directory path.
+pub fn set_aspr_data_path(path: PathBuf) {
+    *ASPR_DATA_PATH.write().unwrap() = path;
+}
+
+/// Getter for the ASPR data directory path.
+pub fn get_aspr_data_path() -> PathBuf {
+    ASPR_DATA_PATH.read().unwrap().clone()
+}
+
+// region ZipLineIterator
+
+/// Iterator over lines in a particular ASPR data file within a zip archive.
+#[self_referencing]
+struct ZipLineIterator {
+    _archive: ZipArchive<BufReader<File>>,
+
+    // This option is always `Some` after successful construction.
+    #[borrows(mut _archive)]
+    #[covariant]
+    line_iter: Option<Lines<BufReader<ZipFile<'this, BufReader<File>>>>>,
+}
+
+impl ZipLineIterator {
+    /// Constructs a ZipLineIterator over the lines of the file `path` zipped inside the archive at `archive_path`.
+    pub fn from_path(archive_path: PathBuf, path: PathBuf) -> Result<Self, ASPRError> {
+        // Open the file with a buffer. These values are consumed.
+        let file = File::open(archive_path).map_err(ASPRError::Io)?;
+        let reader = BufReader::new(file);
+        // Capturing an error during construction is a little awkward.
+        let mut maybe_error: Option<ASPRError> = None;
+
+        let zip_line_iter = ZipLineIteratorBuilder {
+            _archive: ZipArchive::new(reader).map_err(ASPRError::ZipError)?,
+
+            line_iter_builder: |archive: &mut ZipArchive<BufReader<File>>| match archive
+                .by_name(path.to_str().unwrap())
+            {
+                Ok(zipped_file) => {
+                    let buf_zipped_file = BufReader::new(zipped_file);
+                    Some(buf_zipped_file.lines())
+                }
+                Err(e) => {
+                    maybe_error = Some(ASPRError::ZipError(e));
+                    None
+                }
+            },
+        }
+        .build();
+
+        if let Some(e) = maybe_error {
+            Err(e)
+        } else {
+            Ok(zip_line_iter)
+        }
+    }
+}
+
+impl Iterator for ZipLineIterator {
+    type Item = Result<String, ASPRError>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.with_line_iter_mut(|line_iter| {
+            line_iter
+                .as_mut()
+                .unwrap() // always safe
+                .next()
+                .map(|r| r.map_err(ASPRError::Io))
+        })
+    }
+}
+// endregion ZipLineIterator
+
+/// Interface abstracting over the different ways to iterate over lines in an ASPR data file.
+enum LineIterator {
+    File(Lines<BufReader<File>>),
+    Zip(ZipLineIterator),
+}
+
+impl LineIterator {
+    pub fn from_path(file_path: PathBuf) -> Result<Self, ASPRError> {
+        let path = get_aspr_data_path();
+
+        // The dance to check if the path is a zip archive is ridiculous.
+        if path
+            .extension()
+            .and_then(|ext| ext.to_str())
+            .map(|s| s.eq_ignore_ascii_case("zip"))
+            .unwrap_or(false)
+        {
+            // The path is a zip archive.
+            Ok(LineIterator::Zip(ZipLineIterator::from_path(
+                path, file_path,
+            )?))
+        } else {
+            // The path is a directory.
+            let file = File::open(path.join(file_path)).map_err(ASPRError::Io)?;
+            let reader = BufReader::new(file);
+            Ok(LineIterator::File(reader.lines()))
+        }
+    }
+}
+
+impl Iterator for LineIterator {
+    type Item = Result<String, ASPRError>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        match self {
+            LineIterator::File(iter) => iter.next().map(|r| r.map_err(ASPRError::Io)),
+
+            LineIterator::Zip(iter) => iter.next(),
+        }
+    }
+}
+
+/// Returns an iterator over all the data files in the given subdirectory of the ASPR data path. The ASPR data path can
+/// be a zip archive or a directory. The paths returned are relative to the ASPR data path.
+pub fn iter_csv_files(
+    subdirectory: &'static str,
+) -> Result<std::vec::IntoIter<PathBuf>, ASPRError> {
+    let mut path = get_aspr_data_path();
+
+    // The dance to check if the path is a zip archive is ridiculous.
+    if path
+        .extension()
+        .and_then(|ext| ext.to_str())
+        .map(|s| s.eq_ignore_ascii_case("zip"))
+        .unwrap_or(false)
+    {
+        // Iterator through files within the zip archive.
+        let file = File::open(path).map_err(ASPRError::Io)?;
+        let reader = BufReader::new(file);
+        let archive = ZipArchive::new(reader).map_err(ASPRError::ZipError)?;
+
+        let file_names: Vec<PathBuf> = archive
+            .file_names()
+            .filter_map(|s| {
+                if s.starts_with(subdirectory) {
+                    Some(PathBuf::from(s))
+                } else {
+                    None
+                }
+            })
+            .collect();
+
+        Ok(file_names.into_iter())
+    } else {
+        // Iterator through files in the directory.
+        path.push(subdirectory);
+        let mut files = vec![];
+        let entries = path.read_dir().map_err(ASPRError::Io)?;
+
+        for entry in entries {
+            // We don't use `filter_map` so we can return an error here.
+            let entry = entry.map_err(ASPRError::Io)?;
+            if entry.path().is_file() {
+                files.push(entry.path());
+            }
+        }
+
+        Ok(files.into_iter())
+    }
+}
+
+/// Iterator over ASPR records in a particular ASPR data file.
+pub struct ASPRRecordIterator {
+    line_iter: LineIterator,
+}
+
+impl ASPRRecordIterator {
+    /// Returns an iterator over the records in `${ASPR_DATA_PATH}/${ALL_STATES_DIR}/${state}.csv`
+    pub fn state_population(state: USState) -> Result<Self, ASPRError> {
+        let file_name = format!("{}.csv", state.to_string().to_lowercase());
+        let mut path = PathBuf::from(ALL_STATES_DIR);
+        path.push(file_name);
+
+        Self::from_path(path)
+    }
+
+    /// Returns an iterator over the records in `file_path`. This function is intended to be used with the
+    /// `iter_csv_files` function.
+    pub fn from_path(file_path: PathBuf) -> Result<Self, ASPRError> {
+        // let file          = File::open(path.clone()).map_err(ASPRError::Io)?;
+        let mut line_iter = LineIterator::from_path(file_path.clone())?;
+
+        // Skip the header row
+        if line_iter.next().is_none() {
+            // If there is no header row, something is wrong, so return an error.
+            return Err(ASPRError::EmptyFile(file_path));
+        }
+
+        Ok(Self { line_iter })
+    }
+
+    /// Returns an iterator over all the rows of all the files in the iterator. This function is intended to be used with
+    /// the `iter_csv_files` function:
+    ///
+    /// ```rust
+    /// # use fips::aspr::archive::{iter_csv_files, ALL_STATES_DIR, ASPRRecordIterator};
+    /// let records = ASPRRecordIterator::from_file_iterator(iter_csv_files(ALL_STATES_DIR).unwrap());
+    /// ```
+    pub fn from_file_iterator(
+        files: impl Iterator<Item = PathBuf>,
+    ) -> impl Iterator<Item = ASPRPersonRecord> {
+        // Try to open each file, drop it if Err(_)
+        files
+            .filter_map(|path| ASPRRecordIterator::from_path(path).ok())
+            // Each successful iterator yields records; flatten them all.
+            .flatten()
+    }
+}
+
+impl Iterator for ASPRRecordIterator {
+    type Item = ASPRPersonRecord;
+
+    /// Returns the next record in the ASPR data file. This function returns `None` on malformed data. We assume
+    /// that the prepared data is well-formed.
+    fn next(&mut self) -> Option<Self::Item> {
+        let line = (self.line_iter.next()?).ok()?;
+        let mut part_iter = line.split(',');
+
+        let age = part_iter.next()?.parse::<u8>().unwrap();
+
+        let home_id_str = part_iter.next()?.trim();
+        let home_id = parse_fips_home_id(home_id_str).ok().map(|(_, id)| id);
+
+        let school_id_str = part_iter.next()?.trim();
+        let school_id = parse_fips_school_id(school_id_str).ok().map(|(_, id)| id);
+
+        let work_id_str = part_iter.next()?.trim();
+        let work_id = parse_fips_workplace_id(work_id_str).ok().map(|(_, id)| id);
+
+        Some(ASPRPersonRecord {
+            age,
+            home_id,
+            school_id,
+            work_id,
+        })
+    }
+}
+
+#[cfg(all(feature = "aspr_tests", test))]
+mod tests {
+    //! These tests assume the existence of data in the default ASPR data path AND the existence of the zip archive
+    //! in the default ASPR data path.
+
+    use super::*;
+
+    // Enforce serial execution of tests. Since the "zip" tests change the ASPR data path, we also need to set the
+    // ASPR data path to the default value before running the tests.
+    static TEST_MUTEX: Lazy<std::sync::Mutex<()>> = Lazy::new(|| std::sync::Mutex::new(()));
+
+    #[test]
+    fn test_record_iterator_state_population() {
+        let _guard = TEST_MUTEX.lock();
+        set_aspr_data_path(PathBuf::from(DEFAULT_ASPR_DATA_PATH));
+
+        let records = ASPRRecordIterator::state_population(USState::WY).unwrap();
+        // We count the lines in the file excluding the header:
+        //     583,201 - 1 = 583,200
+        assert_eq!(records.count(), 583200);
+    }
+
+    #[test]
+    fn test_record_iterator_from_path() {
+        let _guard = TEST_MUTEX.lock();
+        set_aspr_data_path(PathBuf::from(DEFAULT_ASPR_DATA_PATH));
+
+        let path = PathBuf::from(CBSA_ALL_DIR).join("AK/Ketchikan AK.csv");
+        let records = match ASPRRecordIterator::from_path(path) {
+            Ok(records) => records,
+            Err(e) => {
+                // println!("{:?}", e);
+                panic!("{:?}", e);
+            }
+        };
+        // We count the lines in the file excluding the header:
+        //     14,133 - 1 = 14,132
+        assert_eq!(records.count(), 14132);
+    }
+
+    #[test]
+    fn test_record_iterator_from_files() {
+        let _guard = TEST_MUTEX.lock();
+        set_aspr_data_path(PathBuf::from(DEFAULT_ASPR_DATA_PATH));
+
+        let all_path = PathBuf::from(CBSA_ALL_DIR);
+        let only_residents_path = PathBuf::from(CBSA_ONLY_RESIDENTS_DIR);
+        let paths = vec![
+            all_path.join("AK/Ketchikan AK.csv"),
+            all_path.join("TX/Vernon TX.csv"),
+            only_residents_path.join("AK/Ketchikan AK.csv"),
+            only_residents_path.join("TX/Vernon TX.csv"),
+        ]
+        .into_iter();
+
+        let records = ASPRRecordIterator::from_file_iterator(paths);
+
+        // We sum the count of lines in each file excluding the header:
+        //     14,133 + 16,606 + 13,746 + 12,973 - 4 = 57,454
+        assert_eq!(records.count(), 57454);
+    }
+
+    #[test]
+    fn test_state_row_iter() {
+        let _guard = TEST_MUTEX.lock();
+        set_aspr_data_path(PathBuf::from(DEFAULT_ASPR_DATA_PATH));
+
+        let state = USState::AL;
+        let state_records = ASPRRecordIterator::state_population(state).unwrap();
+
+        for (idx, record) in state_records.enumerate() {
+            if idx == 10 {
+                break;
+            }
+            println!("{}", record);
+        }
+    }
+
+    #[test]
+    fn test_zip_record_iterator_state_population() {
+        let _guard = TEST_MUTEX.lock();
+
+        set_aspr_data_path(get_aspr_data_path().with_extension("zip"));
+
+        let records = ASPRRecordIterator::state_population(USState::WY).unwrap();
+        // We count the lines in the file excluding the header:
+        //     583,201 - 1 = 583,200
+        assert_eq!(records.count(), 583200);
+    }
+
+    #[test]
+    fn test_zip_record_iterator_from_path() {
+        let _guard = TEST_MUTEX.lock();
+
+        set_aspr_data_path(get_aspr_data_path().with_extension("zip"));
+
+        let path = PathBuf::from(CBSA_ALL_DIR).join("AK/Ketchikan AK.csv");
+        let records = ASPRRecordIterator::from_path(path).unwrap();
+        // We count the lines in the file excluding the header:
+        //     14,133 - 1 = 14,132
+        assert_eq!(records.count(), 14132);
+    }
+
+    #[test]
+    fn test_zip_record_iterator_from_files() {
+        let _guard = TEST_MUTEX.lock();
+
+        set_aspr_data_path(get_aspr_data_path().with_extension("zip"));
+
+        let all_path = PathBuf::from(CBSA_ALL_DIR);
+        let only_residents_path = PathBuf::from(CBSA_ONLY_RESIDENTS_DIR);
+        let paths = vec![
+            all_path.join("AK/Ketchikan AK.csv"),
+            all_path.join("TX/Vernon TX.csv"),
+            only_residents_path.join("AK/Ketchikan AK.csv"),
+            only_residents_path.join("TX/Vernon TX.csv"),
+        ]
+        .into_iter();
+
+        let records = ASPRRecordIterator::from_file_iterator(paths);
+
+        // We sum the count of lines in each file excluding the header:
+        //     14,133 + 16,606 + 13,746 + 12,973 - 4 = 57,454
+        assert_eq!(records.count(), 57454);
+    }
+
+    #[test]
+    fn test_zip_state_row_iter() {
+        let _guard = TEST_MUTEX.lock();
+
+        set_aspr_data_path(get_aspr_data_path().with_extension("zip"));
+
+        let state = USState::AL;
+        let state_records = ASPRRecordIterator::state_population(state).unwrap();
+
+        for (idx, record) in state_records.enumerate() {
+            if idx == 10 {
+                break;
+            }
+            println!("{}", record);
+        }
+    }
+}

--- a/ixa-fips/src/aspr/archive.rs
+++ b/ixa-fips/src/aspr/archive.rs
@@ -4,7 +4,7 @@ This module is enabled with the `aspr_archive` feature and provides facilities t
 Set and get the ASPR data path with the `set_aspr_data_path` and `get_aspr_data_path` functions:
 
 ```rust
-# use fips::aspr::archive::{get_aspr_data_path, set_aspr_data_path};
+# use ixa_fips::aspr::archive::{get_aspr_data_path, set_aspr_data_path};
 # use std::path::PathBuf;
 let current_path = get_aspr_data_path();
 println!("The current ASPR data path: {:?}", current_path);
@@ -22,8 +22,8 @@ You can iterate over the records in a CSV file under the ASPR data path with the
 struct transparently handles the case that the ASPR data path is a zip archive or a directory for you. Just provide the
 path to the CSV file relative to the ASPR data path:
 
-```rust
-# use fips::aspr::archive::{CBSA_ALL_DIR, ASPRRecordIterator};
+```ignore
+# use ixa_fips::aspr::archive::{CBSA_ALL_DIR, ASPRRecordIterator};
 # use std::path::PathBuf;
 let subdirectory = PathBuf::from(CBSA_ALL_DIR).join("AK/Ketchikan AK.csv");
 let records = ASPRRecordIterator::from_path(subdirectory);
@@ -33,9 +33,9 @@ let records = ASPRRecordIterator::from_path(subdirectory);
 The `ASPRRecordIterator::state_population()` function is a convenience function that returns an iterator over the
 records in `${ASPR_DATA_PATH}/${ALL_STATES_DIR}/${state}.csv`.
 
-```rust
-# use fips::aspr::archive::{ASPRRecordIterator};
-# use fips::USState;
+```ignore
+# use ixa_fips::aspr::archive::{ASPRRecordIterator};
+# use ixa_fips::USState;
 let records = ASPRRecordIterator::state_population(USState::AK);
 // Do something with the records...
 ```
@@ -43,8 +43,8 @@ let records = ASPRRecordIterator::state_population(USState::AK);
 You can get a list of CSV files in a given subdirectory of the ASPR data path with the `iter_csv_files` function. This
 is useful for chaining record iterators using the `from_file_iterator` constructor method:
 
-```rust
-# use fips::aspr::archive::{iter_csv_files, ALL_STATES_DIR, ASPRRecordIterator};
+```ignore
+# use ixa_fips::aspr::archive::{iter_csv_files, ALL_STATES_DIR, ASPRRecordIterator};
 let records = ASPRRecordIterator::from_file_iterator(iter_csv_files(ALL_STATES_DIR).unwrap());
 // Do something with the records...
 ```
@@ -281,8 +281,8 @@ impl ASPRRecordIterator {
     /// Returns an iterator over all the rows of all the files in the iterator. This function is intended to be used with
     /// the `iter_csv_files` function:
     ///
-    /// ```rust
-    /// # use fips::aspr::archive::{iter_csv_files, ALL_STATES_DIR, ASPRRecordIterator};
+    /// ```ignore
+    /// # use ixa_fips::aspr::archive::{iter_csv_files, ALL_STATES_DIR, ASPRRecordIterator};
     /// let records = ASPRRecordIterator::from_file_iterator(iter_csv_files(ALL_STATES_DIR).unwrap());
     /// ```
     pub fn from_file_iterator(

--- a/ixa-fips/src/aspr/errors.rs
+++ b/ixa-fips/src/aspr/errors.rs
@@ -1,0 +1,47 @@
+use crate::parser::FIPSParserError;
+use std::{
+    error::Error,
+    fmt::{Debug, Display},
+    io::Error as IoError,
+    path::PathBuf,
+};
+#[cfg(feature = "aspr_archive")]
+use zip::result::ZipError;
+
+pub enum ASPRError {
+    Io(IoError),
+    Parse(FIPSParserError),
+    EmptyFile(PathBuf),
+    #[cfg(feature = "aspr_archive")]
+    ZipError(ZipError),
+}
+
+impl Display for ASPRError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            ASPRError::Io(e) => write!(f, "ASPR IO error: {}", e),
+            ASPRError::Parse(e) => write!(f, "ASPR Parse error: {}", e),
+            ASPRError::EmptyFile(path) => write!(f, "ASPR data file is empty: {}", path.display()),
+            #[cfg(feature = "aspr_archive")]
+            ASPRError::ZipError(e) => write!(f, "ASPR Zip error: {}", e),
+        }
+    }
+}
+
+impl Debug for ASPRError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        Display::fmt(self, f)
+    }
+}
+
+impl Error for ASPRError {
+    fn source(&self) -> Option<&(dyn Error + 'static)> {
+        match self {
+            ASPRError::Io(e) => Some(e),
+            ASPRError::Parse(e) => Some(e),
+            ASPRError::EmptyFile(_) => None,
+            #[cfg(feature = "aspr_archive")]
+            ASPRError::ZipError(e) => Some(e),
+        }
+    }
+}

--- a/ixa-fips/src/aspr/mod.rs
+++ b/ixa-fips/src/aspr/mod.rs
@@ -1,0 +1,181 @@
+/*!
+
+This module provides routines to make it easier to work with the ASPR synthetic population dataset. It provides basic
+parsing functionality for parsing the codes found in the dataset.  The `archive` submodule, enabled with the
+"aspr_archive" feature, additionally allows for reading ASPR data from CSV files in the dataset, including files within
+zipped archives.
+
+This dataset encodes `homeId`, `schoolId`, and `workplaceId` using a FIPS geographic region code prefix. In particular,
+each row is a single entry for each person with:
+
+1. **Age** as an integer by single year
+2. **Home ID** as a 15-character string:
+    - 11-digit tract + 4-digit within-tract sequential id
+3. **School ID** as a 14-character string:
+    - Public: 11-digit tract + 3-digit within-tract sequential id
+    - Private: 5-digit county + “xprvx” + 4-digit within-county sequential id
+4. **Work ID** as a 16-character string:
+    - 11-digit tract + 5-digit within-tract sequential id
+
+*/
+
+use crate::fips_code::FIPSCode;
+use std::fmt::{Display, Write};
+
+// Re-exported publicly in `parser.rs`.
+#[cfg(feature = "aspr_archive")]
+pub mod archive;
+pub mod errors;
+pub mod parser;
+
+/// A record representing a person in the ASPR synthetic population dataset
+#[derive(Copy, Clone, Eq, PartialEq, Hash, Default, Debug)]
+pub struct ASPRPersonRecord {
+    pub age: u8,
+    pub home_id: Option<FIPSCode>,
+    pub school_id: Option<FIPSCode>,
+    pub work_id: Option<FIPSCode>,
+}
+
+impl Display for ASPRPersonRecord {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "Age: {}", self.age)?;
+
+        if let Some(home) = &self.home_id {
+            write!(f, ", Home: ({})", home)?;
+        }
+        if let Some(school) = &self.school_id {
+            write!(f, ", School: ({})", school)?;
+        }
+        if let Some(work) = &self.work_id {
+            write!(f, ", Work: ({})", work)?;
+        }
+
+        Ok(())
+    }
+}
+
+/// A `SettingCategory` is not a FIPS code but is implicit in the ASPR synthetic population dataset
+#[derive(Copy, Clone, Eq, PartialEq, Hash, Default, Debug)]
+#[repr(u8)]
+pub enum SettingCategory {
+    // We expect applications that do not use `SettingCategory` to have this field zeroed out.
+    #[default]
+    Unspecified = 0,
+    Home,
+    Workplace,
+    PublicSchool,
+    PrivateSchool,
+    CensusTract,
+}
+
+impl SettingCategory {
+    /// Decode a numeric value to a `SettingCategory`
+    #[inline(always)]
+    pub fn decode(value: u8) -> Option<Self> {
+        // ToDo: This isn't great, as we need to keep this limit updated with the number of variants in `SettingCategory`.
+        if value <= 5 {
+            Some(unsafe { std::mem::transmute(value) })
+        } else {
+            None
+        }
+    }
+
+    /// Encode a `SettingCategory` as a `u8`
+    #[inline(always)]
+    pub fn encode(self) -> u8 {
+        self as u8
+    }
+}
+
+impl Display for SettingCategory {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            SettingCategory::Unspecified => write!(f, "Unspecified"),
+            SettingCategory::Home => write!(f, "Home"),
+            SettingCategory::Workplace => write!(f, "Workplace"),
+            SettingCategory::PublicSchool => write!(f, "Public School"),
+            SettingCategory::PrivateSchool => write!(f, "Private School"),
+            SettingCategory::CensusTract => write!(f, "Census Tract"),
+        }
+    }
+}
+
+/// This formats the FIPS code as a string according to the ASPR format, which augments FIPS region codes with setting
+/// IDs. The category code and "data" field are not represented in this format. However, this function should round-trip
+/// for IDs from the ASPR synthetic population dataset.
+fn format_as_fips_code<W: Write>(fips_code: FIPSCode, f: &mut W) -> std::fmt::Result {
+    write!(f, "{:02}", fips_code.state_code())?;
+    write!(f, "{:03}", fips_code.county_code())?;
+
+    match fips_code.category() {
+        SettingCategory::Home => {
+            // 11-digit tract + 4-digit within-tract sequential id
+            write!(f, "{:06}", fips_code.census_tract_code())?;
+            write!(f, "{:04}", fips_code.id())
+        }
+
+        SettingCategory::Workplace => {
+            // 11-digit tract + 5-digit within-tract sequential id
+            write!(f, "{:06}", fips_code.census_tract_code())?;
+            write!(f, "{:05}", fips_code.id())
+        }
+
+        SettingCategory::PublicSchool => {
+            // 11-digit tract + 3-digit within-tract sequential id
+            write!(f, "{:06}", fips_code.census_tract_code())?;
+            write!(f, "{:03}", fips_code.id())
+        }
+
+        SettingCategory::PrivateSchool => {
+            // 5-digit county + “xprvx” + 4-digit within-county sequential id
+            write!(f, "xprvx")?;
+            write!(f, "{:04}", fips_code.id())
+        }
+
+        // ToDo: Give a reasonable representation for these categories.
+        SettingCategory::Unspecified | SettingCategory::CensusTract => Err(std::fmt::Error),
+    }
+    // The category code and "data" field are not represented in this format.
+    // write!(f, "{:01}", fips_code.category_code())?;
+    // write!(f, "{:03}", fips_code.data())?;
+}
+
+fn format_as_fips_code_string(fips_code: FIPSCode) -> String {
+    let mut buf = String::new();
+    format_as_fips_code(fips_code, &mut buf).unwrap();
+    buf
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::aspr::parser::{parse_fips_home_id, parse_fips_school_id, parse_fips_workplace_id};
+
+    #[test]
+    fn text_round_trip_formatting() {
+        let home_id = "110010109000024";
+        let workplace_id = "1100100620201546";
+        let public_school_id = "11001009810157";
+        let private_school_id = "24031xprvx0085";
+
+        let (_, parsed_home_id) = parse_fips_home_id(home_id).unwrap();
+        let (_, parsed_workplace_id) = parse_fips_workplace_id(workplace_id).unwrap();
+        let (_, parsed_public_school_id) = parse_fips_school_id(public_school_id).unwrap();
+        let (_, parsed_private_school_id) = parse_fips_school_id(private_school_id).unwrap();
+
+        assert_eq!(home_id, format_as_fips_code_string(parsed_home_id));
+        assert_eq!(
+            workplace_id,
+            format_as_fips_code_string(parsed_workplace_id)
+        );
+        assert_eq!(
+            public_school_id,
+            format_as_fips_code_string(parsed_public_school_id)
+        );
+        assert_eq!(
+            private_school_id,
+            format_as_fips_code_string(parsed_private_school_id)
+        );
+    }
+}

--- a/ixa-fips/src/aspr/parser.rs
+++ b/ixa-fips/src/aspr/parser.rs
@@ -1,0 +1,381 @@
+//! These high-level functions parse the concatenated FIPS code and ids.
+
+use crate::{
+    aspr::SettingCategory,
+    fips_code::FIPSCode,
+    parser::{parse_decimal_digits_to_bits, parse_state_code, FIPSParseResult, FIPSParserError},
+    states::USState,
+    CountyCode, IdCode, TractCode,
+};
+
+/// Parses the input as a FIPS code for a home id. Returns `(FIPSCode, rest)`,
+/// where `rest` is the remaining input after the FIPS code.
+pub fn parse_fips_home_id(input: &str) -> FIPSParseResult<FIPSCode> {
+    let (rest, state): (&str, USState) = parse_state_code(input)?;
+    let (rest, county): (&str, CountyCode) = parse_county_code(rest)?;
+    let (rest, tract): (&str, TractCode) = parse_tract_code(rest)?;
+    let (rest, home_id): (&str, IdCode) = parse_home_id(rest)?;
+
+    let fips_code = FIPSCode::new(state, county, tract, SettingCategory::Home, home_id, 0);
+    Ok((rest, fips_code))
+}
+
+/// Parses the input as a FIPS code for a school id. Returns `(FIPSCode, rest)`,
+/// where `rest` is the remaining input after the FIPS code.
+pub fn parse_fips_school_id(input: &str) -> FIPSParseResult<FIPSCode> {
+    let (rest, state): (&str, USState) = parse_state_code(input)?;
+    let (rest, county): (&str, CountyCode) = parse_county_code(rest)?;
+
+    if rest.starts_with("x") {
+        // Private school id
+        let (rest, school_id): (&str, IdCode) = parse_private_school_id(rest)?;
+        let fips_code = FIPSCode::new(
+            state,
+            county,
+            0,
+            SettingCategory::PrivateSchool,
+            school_id,
+            0,
+        );
+        Ok((rest, fips_code))
+    } else {
+        // Public school
+        // Public schools also have a tract code.
+        let (rest, tract): (&str, TractCode) = parse_tract_code(rest)?;
+        let (rest, school_id): (&str, IdCode) = parse_public_school_id(rest)?;
+        let fips_code = FIPSCode::new(
+            state,
+            county,
+            tract,
+            SettingCategory::PublicSchool,
+            school_id,
+            0,
+        );
+        Ok((rest, fips_code))
+    }
+}
+
+/// Parses the input as a FIPS code for a workplace id. Returns `(FIPSCode, rest)`,
+/// where `rest` is the remaining input after the FIPS code.
+pub fn parse_fips_workplace_id(input: &str) -> FIPSParseResult<FIPSCode> {
+    let (rest, state): (&str, USState) = parse_state_code(input)?;
+    let (rest, county): (&str, CountyCode) = parse_county_code(rest)?;
+    let (rest, tract): (&str, TractCode) = parse_tract_code(rest)?;
+    let (rest, workplace_id): (&str, IdCode) = parse_workplace_id(rest)?;
+
+    let fips_code = FIPSCode::new(
+        state,
+        county,
+        tract,
+        SettingCategory::Workplace,
+        workplace_id,
+        0,
+    );
+    Ok((rest, fips_code))
+}
+
+/// Parses the first three digits of `input` as a county
+/// code. Enforces the requirement that the value is representable using 10
+/// bits (which is tautologically always true).
+pub fn parse_county_code(input: &str) -> FIPSParseResult<CountyCode> {
+    parse_decimal_digits_to_bits(3, 10, input).map(|(rest, value)| (rest, value as CountyCode))
+}
+
+/// Parses the first six digits of `input` as a tract
+/// code. Enforces the requirement that the value is representable using 20
+/// bits (which is tautologically always true).
+pub fn parse_tract_code(input: &str) -> FIPSParseResult<TractCode> {
+    parse_decimal_digits_to_bits(6, 20, input).map(|(rest, value)| (rest, value as TractCode))
+}
+
+/// Parses the first four digits of `input` as a (monotonically increasing) id
+/// number. Enforces the requirement that the value is representable using 14
+/// bits (which is tautologically always true).
+pub fn parse_home_id(input: &str) -> FIPSParseResult<IdCode> {
+    parse_decimal_digits_to_bits(4, 14, input).map(|(rest, value)| (rest, value as IdCode))
+}
+
+/// Parses the first four digits of `input` as a (monotonically increasing)
+/// id number after stripping `"xprvx"`, if it exists. Enforces the
+/// requirement that the value is representable using 11 bits.
+pub fn parse_private_school_id(input: &str) -> FIPSParseResult<IdCode> {
+    let input = input.strip_prefix("xprvx").unwrap_or(input);
+    parse_decimal_digits_to_bits(4, 11, input).map(|(rest, value)| (rest, value as IdCode))
+}
+
+/// Parses the first three digits of `input` as a (monotonically increasing)
+/// id number. Enforces the requirement that the value is representable using
+/// 10 bits (a tautology in this case).
+pub fn parse_public_school_id(input: &str) -> FIPSParseResult<IdCode> {
+    parse_decimal_digits_to_bits(3, 10, input).map(|(rest, value)| (rest, value as IdCode))
+}
+
+/// Parses the first five digits of `input` as a (monotonically increasing)
+/// id number. Enforces the requirement that the value is representable using
+/// 14 bits.
+pub fn parse_workplace_id(input: &str) -> FIPSParseResult<IdCode> {
+    parse_decimal_digits_to_bits(5, 14, input).map(|(rest, value)| (rest, value as IdCode))
+}
+
+/// Parses the next sequence of decimal digits in `input` without respect to
+/// its length of how many bits are required to represent it (thought it must
+/// implicitly be at most 64).
+pub fn parse_integer(input: &str) -> FIPSParseResult<u64> {
+    // Find the first non-digit character
+    let digit_end = input
+        .find(|c: char| !c.is_ascii_digit())
+        .unwrap_or(input.len());
+
+    // If there are no digits at the start, return None
+    if digit_end == 0 {
+        return Err((
+            input,
+            FIPSParserError::InvalidLength {
+                expected: 1,
+                found: 0,
+            },
+        ));
+    }
+
+    // Parse the digit substring
+    let value = match input[..digit_end].parse::<u64>() {
+        Ok(v) => v,
+        Err(parse_int_error) => match parse_int_error.kind() {
+            std::num::IntErrorKind::Empty => {
+                return Err((
+                    input,
+                    FIPSParserError::InvalidLength {
+                        expected: 1,
+                        found: 0,
+                    },
+                ));
+            }
+
+            std::num::IntErrorKind::InvalidDigit => {
+                return Err((
+                    input,
+                    FIPSParserError::InvalidDigit {
+                        found: input.chars().next().unwrap(),
+                    },
+                ));
+            }
+
+            _ => {
+                return Err((
+                    input,
+                    FIPSParserError::ValueExceedsCapacity {
+                        value: u64::MAX,
+                        capacity: u64::MAX,
+                    },
+                ));
+            }
+        },
+    };
+
+    Ok((&input[digit_end..], value))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::StateCode;
+
+    #[test]
+    fn test_parse_home_id() {
+        // Basic successful parsing
+        assert_eq!(parse_home_id("1234rest"), Ok(("rest", 1234)));
+        assert_eq!(parse_home_id("0001xyz"), Ok(("xyz", 1)));
+        assert_eq!(parse_home_id("9999"), Ok(("", 9999)));
+
+        // Maximum allowed value (14 bits max = 16383)
+        assert_eq!(parse_home_id("16383abc"), Ok(("3abc", 1638)));
+
+        // Edge cases
+        assert_eq!(parse_home_id("0000test"), Ok(("test", 0)));
+
+        // Error cases
+        assert!(parse_home_id("").is_err()); // Empty string
+        assert!(parse_home_id("abc").is_err()); // No digits
+        assert!(parse_home_id("12").is_err()); // Too few digits
+        assert!(parse_home_id("123").is_err()); // Too few digits
+    }
+
+    #[test]
+    fn test_parse_private_school_id() {
+        // Basic successful parsing
+        assert_eq!(parse_private_school_id("1234rest"), Ok(("rest", 1234)));
+        assert_eq!(parse_private_school_id("0001xyz"), Ok(("xyz", 1)));
+
+        // With 'xprvx' prefix
+        assert_eq!(parse_private_school_id("xprvx1234rest"), Ok(("rest", 1234)));
+        assert_eq!(parse_private_school_id("xprvx0001xyz"), Ok(("xyz", 1)));
+
+        // Maximum allowed value (11 bits max = 2047)
+        assert_eq!(parse_private_school_id("2047"), Ok(("", 2047)));
+        assert_eq!(parse_private_school_id("xprvx2047"), Ok(("", 2047)));
+
+        // Edge cases
+        assert_eq!(parse_private_school_id("0000test"), Ok(("test", 0)));
+        assert_eq!(parse_private_school_id("xprvx0000test"), Ok(("test", 0)));
+
+        // Error cases
+        assert!(parse_private_school_id("").is_err()); // Empty string
+        assert!(parse_private_school_id("xprvx").is_err()); // Empty after prefix
+        assert!(parse_private_school_id("xprvxabc").is_err()); // No digits after prefix
+        assert!(parse_private_school_id("2048").is_err()); // Exceeds 11 bits
+        assert!(parse_private_school_id("xprvx2048").is_err()); // Exceeds 11 bits
+    }
+
+    #[test]
+    fn test_parse_public_school_id() {
+        // Basic successful parsing
+        assert_eq!(parse_public_school_id("123rest"), Ok(("rest", 123)));
+        assert_eq!(parse_public_school_id("001xyz"), Ok(("xyz", 1)));
+        assert_eq!(parse_public_school_id("999"), Ok(("", 999)));
+
+        // Maximum allowed value (10 bits max = 1023)
+        assert_eq!(parse_public_school_id("1023abc"), Ok(("3abc", 102)));
+
+        // Edge cases
+        assert_eq!(parse_public_school_id("000test"), Ok(("test", 0)));
+
+        // Error cases
+        assert!(parse_public_school_id("").is_err()); // Empty string
+        assert!(parse_public_school_id("abc").is_err()); // No digits
+        assert!(parse_public_school_id("12").is_err()); // Too few digits
+    }
+
+    #[test]
+    fn test_parse_workplace_id() {
+        // Basic successful parsing
+        assert_eq!(parse_workplace_id("12345rest"), Ok(("rest", 12345)));
+        assert_eq!(parse_workplace_id("00001xyz"), Ok(("xyz", 1)));
+        assert_eq!(parse_workplace_id("10383"), Ok(("", 10383)));
+
+        // Maximum allowed value (14 bits max = 16383)
+        assert_eq!(parse_workplace_id("16383abc"), Ok(("abc", 16383)));
+
+        // Edge cases
+        assert_eq!(parse_workplace_id("00000test"), Ok(("test", 0)));
+
+        // Error cases
+        assert!(parse_workplace_id("").is_err()); // Empty string
+        assert!(parse_workplace_id("abc").is_err()); // No digits
+        assert!(parse_workplace_id("1234").is_err()); // Too few digits
+        assert!(parse_workplace_id("16384").is_err()); // Exceeds 14 bits
+    }
+
+    #[test]
+    fn test_fips_home_id() {
+        let home_id = "110010109000024";
+        let state_code: StateCode = 11;
+        let county_code: CountyCode = 1;
+        let tract_code: TractCode = 10900;
+        let home_id_code = 24;
+
+        let (_, parsed_home_id) = parse_fips_home_id(home_id).unwrap();
+
+        assert_eq!(parsed_home_id.state_code(), state_code);
+        assert_eq!(parsed_home_id.county_code(), county_code);
+        assert_eq!(parsed_home_id.census_tract_code(), tract_code);
+        assert_eq!(parsed_home_id.id(), home_id_code);
+    }
+
+    #[test]
+    fn test_fips_work_id() {
+        let workplace_id = "1100100620201546";
+        let state_code: StateCode = 11;
+        let county_code: CountyCode = 1;
+        let tract_code: TractCode = 6202;
+        let workplace_id_code = 1546;
+
+        let (_, parsed_workplace_id) = parse_fips_workplace_id(workplace_id).unwrap();
+
+        assert_eq!(parsed_workplace_id.state_code(), state_code);
+        assert_eq!(parsed_workplace_id.county_code(), county_code);
+        assert_eq!(parsed_workplace_id.census_tract_code(), tract_code);
+        assert_eq!(parsed_workplace_id.id(), workplace_id_code);
+    }
+
+    #[test]
+    fn test_fips_public_school_id() {
+        let public_school_id = "11001009810157";
+        let state_code: StateCode = 11;
+        let county_code: CountyCode = 1;
+        let tract_code: TractCode = 9810;
+        let public_school_id_code = 157;
+
+        let (_, parsed_public_school_id) = parse_fips_school_id(public_school_id).unwrap();
+
+        assert_eq!(parsed_public_school_id.state_code(), state_code);
+        assert_eq!(parsed_public_school_id.county_code(), county_code);
+        assert_eq!(parsed_public_school_id.census_tract_code(), tract_code);
+        assert_eq!(parsed_public_school_id.id(), public_school_id_code);
+    }
+
+    #[test]
+    fn test_fips_private_school_id() {
+        let private_school_id = "24031xprvx0150";
+        let state_code: StateCode = 24;
+        let county_code: CountyCode = 31;
+        let tract_code: TractCode = 0;
+        let private_school_id_code = 150;
+
+        let (_, parsed_private_school_id) = parse_fips_school_id(private_school_id).unwrap();
+
+        assert_eq!(parsed_private_school_id.state_code(), state_code);
+        assert_eq!(parsed_private_school_id.county_code(), county_code);
+        assert_eq!(parsed_private_school_id.census_tract_code(), tract_code);
+        assert_eq!(parsed_private_school_id.id(), private_school_id_code);
+    }
+
+    #[test]
+    fn test_parse_integer() {
+        // Basic successful parsing
+        assert_eq!(parse_integer("123rest"), Ok(("rest", 123)));
+        assert_eq!(parse_integer("0xyz"), Ok(("xyz", 0)));
+        assert_eq!(parse_integer("9876543210"), Ok(("", 9876543210)));
+
+        // Single digit
+        assert_eq!(parse_integer("5abc"), Ok(("abc", 5)));
+
+        // Long number
+        assert_eq!(
+            parse_integer("18446744073709551615end"),
+            Ok(("end", 18446744073709551615))
+        ); // u64 max
+
+        // Error cases
+        assert!(parse_integer("").is_err()); // Empty string
+        assert!(parse_integer("abc").is_err()); // No digits
+    }
+
+    // Additional combined tests
+    #[test]
+    fn test_combined_scenarios() {
+        // Test with leading zeros
+        assert_eq!(parse_home_id("0123"), Ok(("", 123)));
+        assert_eq!(parse_private_school_id("xprvx0042"), Ok(("", 42)));
+
+        // Test with excess digits
+        assert_eq!(parse_public_school_id("12345"), Ok(("45", 123)));
+
+        // Test with value equal to max
+        assert_eq!(parse_workplace_id("16383@#$%"), Ok(("@#$%", 16383)));
+
+        // Test with value exceeding max
+        assert_eq!(
+            parse_workplace_id("19876@#$%"),
+            Err((
+                "19876@#$%",
+                FIPSParserError::ValueExceedsCapacity {
+                    value: 19876,
+                    capacity: 16383
+                }
+            ))
+        );
+
+        // Test with special characters after digits
+        assert_eq!(parse_workplace_id("16380@#$%"), Ok(("@#$%", 16380)));
+    }
+}

--- a/ixa-fips/src/fips_code.rs
+++ b/ixa-fips/src/fips_code.rs
@@ -1,0 +1,502 @@
+/*!
+Defines the `FIPSCode` types to represent FIPS geographic region codes (and “code fragments”) very efficiently.
+
+# Terminology and Textual Representation
+
+We use the phrase *census tract* (block, place, etc.) to refer to the full 11-digit encode, while the phrase *census
+tract code* (resp. block code, place code, etc.) refers to the 6 digits for the tract designation itself. The digits of
+more specific structures are generally the rightmost decimal digits of the encoding. Thus the census tract code is the
+rightmost 6 digits of the GeoId.
+
+# FIPS Code Structure
+
+Source: <https://www.census.gov/programs-surveys/geography/guidance/geo-identifiers.html>
+
+| **Area Type**                              | **GEOID Structure**            | **Number of Digits** | **Example Geographic Area**                             | **Example GEOID** |
+| ------------------------------------------ | ------------------------------ | -------------------- | ------------------------------------------------------- | ----------------- |
+| State                                      | STATE                          | 2                    | Texas                                                   | 48                |
+| County                                     | STATE+COUNTY                   | 2+3=5                | Harris County, TX                                       | 48201             |
+| County Subdivision                         | STATE+COUNTY+COUSUB            | 2+3+5=10             | Pasadena CCD, Harris County, TX                         | 4820192975        |
+| Census Tract                               | STATE+COUNTY+TRACT             | 2+3+6=11             | Census Tract 2231 in Harris County, TX                  | 48201223100       |
+| Block Group                                | STATE+COUNTY+TRACT+BLOCK GROUP | 2+3+6+1=12           | Block Group 1 in Census Tract 2231 in Harris County, TX | 482012231001      |
+| Block*                                     | STATE+COUNTY+TRACT+BLOCK       | 2+3+6+4=15           | Block 1050 in Census Tract 2231 in Harris County, TX    | 482012231001050   |
+| Places                                     | STATE+PLACE                    | 2+5=7                | Houston, TX                                             | 4835000           |
+| Congressional District (113th Congress)    | STATE+CD                       | 2+2=4                | Connecticut District 2                                  | 902               |
+| State Legislative District (Upper Chamber) | STATE+SLDU                     | 2+3=5                | Connecticut State Senate District 33                    | 9033              |
+| State Legislative District (Lower Chamber) | STATE+SLDL                     | 2+3=5                | Connecticut State House District 147                    | 9147              |
+| ZCTA **                                    | ZCTA                           | 5                    | Suitland, MD ZCTA                                       | 20746             |
+
+\* The block group code is not included in the census block GEOID code
+because the first digit of a census block code represents the block group
+code. Note – some blocks also contain a one character suffix (A, B, C, ect.)
+
+\** ZIP Code Tabulation Areas (ZCTAs) are generalized areal representations
+of United States Postal Service (USPS) ZIP Code service areas.
+
+
+# Encoding Scheme
+
+The rows in the table above up to and including Block (that is, all but the last
+five rows) form a linear order with respect to prefix inclusion ("is prefix of").
+This encoding scheme is for these codes. The last four rows are treated separately.
+
+In the following table, we describe the data "fragments" and their storage requirements.
+
+|                                   | **Decimal Digits** | **Actual Max Value** | **Bits** | **Capacity (2^bits - 1)**                                    |
+| --------------------------------- | ------------------ | -------------------- | -------- | ------------------------------------------------------------ |
+| **Sate**                          | 2                  | 56                   | 6        | 63                                                           |
+| **County**                        | 3                  | 840                  | 10       | 1023                                                         |
+| **Tract**                         | 6                  | 990101               | 20       | 1048575                                                      |
+| **Subtotal**                      |                    |                      | **36**   | **Bits needed for tract code**                               |
+|                                   |                    |                      |          |                                                              |
+| **Monotonically Increasing Id's** |                    |                      |          |                                                              |
+| **homeId**                        | 4                  | 9999                 | 14       | 16383                                                        |
+| **publicschoolId**                | 3                  | 999                  | 10       | 1023                                                         |
+| **privateschoolId**               | 4                  | 1722                 | 11       | 2047                                                         |
+| **workplaceId**                   | 5                  | 14938                | 14       | 16383                                                        |
+| **Max:**                          |                    |                      | **14**   |                                                              |
+| **Total:**                        |                    |                      | **50**   |                                                              |
+
+To the 50 bits apparently required to store this data we add an additional 4 bits for a category tag to distinguish
+between home, public school, private school, and workplace, a field useful for representing ASPR synthetic population
+data. Only 2 bits are required to distinguish these 4 categories, so the additional 2 bits are left unused / for future
+use.
+
+We encode this data into a `u64` as follows:
+
+ | **Data**               |       **State** | **County** | **Tract** |    **Category Tag** | **Monotonically increasing ID number** | **Reserved / Unused** |
+ | :--------------------- | --------------: | ---------: | --------: | ------------------: | -------------------------------------: | --------------------: |
+ | **Bits**               |           63…58 |      57…48 |     47…28 |               27…24 |                                  23…10 |                   9…0 |
+ | **Ex. Value**          | `AK`, `AZ`, ... |        258 |    223100 | `Home`, `Work`, ... |                                  12345 |                     0 |
+ | **Bit Count**          |               6 |         10 |        20 |                   4 |                                     14 |                    10 |
+ | **Capacity**           |              64 |       1024 |   1048576 |                  16 |                                  16384 |                  1024 |
+ | **Decimal Digits**     |               2 |          3 |         6 |                   - |                                 3 to 5 |                     - |
+ | **Max Observed Value** |              56 |        840 |    990101 |                   4 |                                  14938 |                     - |
+
+Observe that:
+
+ - We give the "category tag" 4 bits to allow up to 16 distinct categories. In some applications this field might be unused.
+ - The least significant 10 bits is completely unused by this encoding. It may be used for application specific storage.
+ - The field for ID number only requires 10 bits for `publicschoolId`, for example. That is, the storage it requires
+   depends on the category tag.
+ - The category tag is encoded after the tract code but before the ID field so that numerical ordering coincides with
+   the hierarchical ordering.
+ - Likewise, the unused 10 bits are the least significant bits so that numerical ordering coincides with the
+   hierarchical ordering modulo those bits.
+
+# Nonhierarchical FIPS Codes
+
+The encoding of the previous section excludes the nonhierarchical codes of the last five rows from the first table
+above:
+
+ - Places
+ - Congressional District (113th Congress)
+ - State Legislative District (Upper Chamber)
+ - State Legislative District (Lower Chamber)
+ - ZCTA
+
+We could easily accommodate these codes as well, in a variety of ways, e.g.:
+ - assign each of these a category tag and store their corresponding code fragments in the ID field
+ - use the 14 buts of the ID field and the unused 10 least significant bits, allowing the category tag to remain
+   orthogonal
+
+We leave them unspecified until we have a use case for them.
+
+*/
+
+use crate::{
+    aspr::SettingCategory, states::USState, CountyCode, DataCode, IdCode, TractCode,
+    CATEGORY_OFFSET, COUNTY_OFFSET, FOURTEEN_BIT_MASK, FOUR_BIT_MASK, ID_OFFSET, SIX_BIT_MASK,
+    STATE_OFFSET, TEN_BIT_MASK, TRACT_OFFSET, TWENTY_BIT_MASK,
+};
+use std::fmt::Debug;
+use std::{
+    cmp::Ordering,
+    fmt::{Display, Formatter},
+    num::NonZero,
+};
+
+/// Encodes a hierarchical FIPS geographic region code in 64 bits. Excludes the nonhierarchical codes places,
+/// congressional or state legislative districts, and ZIP code tabulation areas. (See the
+/// [module level documentation](`crate::fips_code`).)
+#[derive(Copy, Clone, Ord, PartialOrd, Eq, PartialEq, Hash)]
+pub struct FIPSCode(NonZero<u64>);
+
+impl FIPSCode {
+    // region Constructors
+    pub fn with_state(state: USState) -> Self {
+        Self::new(state, 0, 0, SettingCategory::default(), 0, 0)
+    }
+    pub fn with_county(state: USState, county: CountyCode) -> Self {
+        Self::new(state, county, 0, SettingCategory::default(), 0, 0)
+    }
+    pub fn with_tract(state: USState, county: CountyCode, tract: TractCode) -> Self {
+        Self::new(state, county, tract, SettingCategory::default(), 0, 0)
+    }
+    pub fn with_category(
+        state: USState,
+        county: CountyCode,
+        tract: TractCode,
+        category: SettingCategory,
+    ) -> Self {
+        Self::new(state, county, tract, category, 0, 0)
+    }
+
+    pub fn new(
+        state: USState,
+        county: CountyCode,
+        tract: TractCode,
+        category: SettingCategory,
+        id: IdCode,
+        data: DataCode,
+    ) -> Self {
+        let encoded: u64 = Self::encode_state(state.encode())
+            | Self::encode_county(county)
+            | Self::encode_tract(tract)
+            | Self::encode_category(category.encode())
+            | Self::encode_id(id)
+            | Self::encode_data(data);
+        // At the very least, `USState.encode()` will return a non-zero value, so this unwrapping is safe.
+        let encoded = NonZero::new(encoded).unwrap();
+        Self(encoded)
+    }
+    // endregion Constructors
+
+    // region Accessors
+
+    /// Returns the FIPS STATE as a `USState` enum variant.
+    #[inline(always)]
+    pub fn state(&self) -> USState {
+        // We are guaranteed to have a valid state code if this `FIPSCode` was constructed safely
+        unsafe { USState::decode(self.state_code()).unwrap_unchecked() }
+    }
+
+    /// Returns the FIPS STATE code as a `u8`
+    #[inline(always)]
+    pub fn state_code(&self) -> u8 {
+        // The state code occupies the 6 most significant bits, bits 58..63
+        (self.0.get() >> STATE_OFFSET) as u8
+    }
+
+    /// Returns the numeric FIPS COUNTY code
+    #[inline(always)]
+    pub fn county_code(&self) -> u16 {
+        // The county code occupies the 10 bits from bits 48..57
+        ((self.0.get() >> COUNTY_OFFSET) as u16) & TEN_BIT_MASK
+    }
+
+    /// Returns the numeric FIPS CENSUS TRACT code
+    #[inline(always)]
+    pub fn census_tract_code(&self) -> u32 {
+        // The census tract code occupies the 20 bits from bits 28..47
+        ((self.0.get() >> TRACT_OFFSET) as u32) & TWENTY_BIT_MASK
+    }
+
+    /// Returns the setting category code as a `u18`
+    #[inline(always)]
+    pub fn category_code(&self) -> u8 {
+        // The category code occupies the 4 bits from bits 24..27
+        ((self.0.get() >> CATEGORY_OFFSET) as u8) & FOUR_BIT_MASK
+    }
+
+    /// Returns the setting category as a `SettingCategory`
+    #[inline(always)]
+    pub fn category(&self) -> SettingCategory {
+        // We are guaranteed to have a valid SettingCategory if this `FIPSCode` was constructed safely
+        unsafe { SettingCategory::decode(self.category_code()).unwrap_unchecked() }
+    }
+
+    /// Returns the monotonically increasing ID number as a `u16`
+    #[inline(always)]
+    pub fn id(&self) -> u16 {
+        // The ID number occupies the 14 bits from bits 10..23
+        ((self.0.get() >> ID_OFFSET) as u16) & FOURTEEN_BIT_MASK
+    }
+
+    /// Returns the unused data region occupying the 10 LSB
+    #[inline(always)]
+    pub fn data(&self) -> u16 {
+        self.0.get() as u16 & TEN_BIT_MASK
+    }
+    // endregion Accessors
+
+    // region Setters
+
+    /// Creates a copy of `self` with the FIPS STATE set to `state`.
+    pub fn set_state(&self, state: USState) -> Self {
+        let mut expanded = ExpandedFIPSCode::from_fips_code(*self);
+        expanded.state = state;
+        expanded.to_fips_code()
+    }
+
+    /// Creates a copy of `self` with the FIPS COUNTY set to `county`.
+    pub fn set_county(&self, county: CountyCode) -> Self {
+        let mut expanded = ExpandedFIPSCode::from_fips_code(*self);
+        expanded.county = county;
+        expanded.to_fips_code()
+    }
+
+    /// Creates a copy of `self` with the FIPS CENSUS TRACT set to `tract`.
+    pub fn set_tract(&self, tract: TractCode) -> Self {
+        let mut expanded = ExpandedFIPSCode::from_fips_code(*self);
+        expanded.tract = tract;
+        expanded.to_fips_code()
+    }
+
+    /// Creates a copy of `self` with the setting category set to `category`.
+    pub fn set_category(&self, category: SettingCategory) -> Self {
+        let mut expanded = ExpandedFIPSCode::from_fips_code(*self);
+        expanded.category = category;
+        expanded.to_fips_code()
+    }
+
+    /// Creates a copy of `self` with the ID number set to `id`.
+    pub fn set_id(&self, id: IdCode) -> Self {
+        let mut expanded = ExpandedFIPSCode::from_fips_code(*self);
+        expanded.id = id;
+        expanded.to_fips_code()
+    }
+
+    /// Creates a copy of `self` with the unused data region set to `data`.
+    pub fn set_data(&self, data: DataCode) -> Self {
+        let mut expanded = ExpandedFIPSCode::from_fips_code(*self);
+        expanded.data = data;
+        expanded.to_fips_code()
+    }
+
+    // endregion Setters
+
+    /// Sets the unused data region occupying the 10 LSB in place.
+    #[inline(always)]
+    pub fn set_data_in_place(&mut self, data: u16) {
+        assert!(
+            data <= TEN_BIT_MASK,
+            "Data must be representable in 10 bits."
+        );
+        let inverse_mask = !(TEN_BIT_MASK as u64);
+        self.0 = unsafe {
+            NonZero::new((self.0.get() & inverse_mask) | ((data & TEN_BIT_MASK) as u64))
+                .unwrap_unchecked()
+        };
+    }
+
+    /// Compares the given values without respect to the data region (the Least Significant Bits). Use the usual equality
+    /// operators for comparing `FIPSCode`s including the data region.
+    #[inline(always)]
+    pub fn compare_non_data(&self, other: Self) -> Ordering {
+        let inverse_mask = !(TEN_BIT_MASK as u64);
+        let this = self.0.get() & inverse_mask;
+        let other = other.0.get() & inverse_mask;
+
+        this.cmp(&other)
+    }
+
+    // region Encoding
+    // It is convenient to factor out the encode operations into their own functions.
+    // These functions take numeric values and return encoded `u64` values. To encode
+    // enum variants, call the `encode` function on the enum variant.
+
+    #[inline(always)]
+    fn encode_state(state: u8) -> u64 {
+        // Validate
+        assert!(USState::valid_code(state));
+        // Only 6 bits are available for the state code.
+        assert!(state <= SIX_BIT_MASK);
+        (state as u64) << STATE_OFFSET
+    }
+
+    #[inline(always)]
+    fn encode_county(county: u16) -> u64 {
+        // Validate
+        assert!(county <= TEN_BIT_MASK);
+        (county as u64) << COUNTY_OFFSET
+    }
+
+    #[inline(always)]
+    fn encode_tract(tract: u32) -> u64 {
+        // Validate
+        assert!(tract <= TWENTY_BIT_MASK);
+        (tract as u64) << TRACT_OFFSET
+    }
+
+    #[inline(always)]
+    fn encode_category(setting_category: u8) -> u64 {
+        // Validate
+        assert!(setting_category <= FOUR_BIT_MASK);
+        (setting_category as u64) << CATEGORY_OFFSET
+    }
+
+    #[inline(always)]
+    fn encode_id(id: u16) -> u64 {
+        // Validate
+        assert!(id <= FOURTEEN_BIT_MASK);
+        (id as u64) << ID_OFFSET
+    }
+
+    #[inline(always)]
+    fn encode_data(data: u16) -> u64 {
+        // Validate
+        assert!(data <= TEN_BIT_MASK);
+        data as u64
+    }
+    // endregion Encoding
+}
+
+impl Display for FIPSCode {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", ExpandedFIPSCode::from_fips_code(*self))
+    }
+}
+
+impl Debug for FIPSCode {
+    /// Format the code as a string of hex digits with fields separated by dashes. Note that this is different
+    /// from serializing to the original FIPS code encoding. Use `format_as_fips_code`/`format_as_fips_code`
+    /// for that purpose.
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{:02}", self.state_code())?;
+        write!(f, "-{:03}", self.county_code())?;
+        write!(f, "-{:06}", self.census_tract_code())?;
+        write!(f, "-{:01}", self.category_code())?;
+        write!(f, "-{:05}", self.id())?;
+        write!(f, "-{:03x}", self.data())?;
+        Ok(())
+    }
+}
+
+#[derive(Copy, Clone, Eq, PartialEq, Hash, Debug)]
+pub struct ExpandedFIPSCode {
+    pub state: USState,
+    pub county: CountyCode,
+    pub tract: TractCode,
+    pub category: SettingCategory,
+    pub id: IdCode,
+    pub data: DataCode,
+}
+
+impl ExpandedFIPSCode {
+    pub fn from_fips_code(fips_code: FIPSCode) -> Self {
+        Self {
+            state: fips_code.state(),
+            county: fips_code.county_code(),
+            tract: fips_code.census_tract_code(),
+            category: fips_code.category(),
+            id: fips_code.id(),
+            data: fips_code.data(),
+        }
+    }
+
+    pub fn to_fips_code(&self) -> FIPSCode {
+        FIPSCode::new(
+            self.state,
+            self.county,
+            self.tract,
+            self.category,
+            self.id,
+            self.data,
+        )
+    }
+}
+
+impl Display for ExpandedFIPSCode {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(f, "state: {}", self.state)?;
+
+        if self.county != 0 {
+            write!(f, ", county: {}", self.county)?;
+        }
+        if self.tract != 0 {
+            write!(f, ", tract: {}", self.tract)?;
+        }
+        if self.category != SettingCategory::Unspecified {
+            write!(f, ", setting: {}", self.category)?;
+        }
+        if self.id != 0 {
+            write!(f, ", id: {}", self.id)?;
+        }
+        if self.data != 0 {
+            write!(f, ", data field: {}", self.data)?;
+        }
+
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn fields_round_trip() {
+        let fips_code = FIPSCode::new(
+            USState::TX,
+            123,
+            990101,
+            SettingCategory::Home,
+            14938,
+            0x3ff,
+        );
+        assert_eq!(fips_code.state(), USState::TX);
+        assert_eq!(fips_code.county_code(), 123);
+        assert_eq!(fips_code.census_tract_code(), 990101);
+        assert_eq!(fips_code.category(), SettingCategory::Home);
+        assert_eq!(fips_code.id(), 14938);
+        assert_eq!(fips_code.data(), 0x3ff);
+    }
+
+    #[test]
+    fn nonstate_round_trip() {
+        let fips_code = FIPSCode::with_state(USState::VirginIslandsOfTheUS);
+        assert_eq!(fips_code.state(), USState::VirginIslandsOfTheUS);
+        assert_eq!(fips_code.state_code(), 52);
+
+        let fips_code = FIPSCode::with_state(USState::HawaiianCoast);
+        assert_eq!(fips_code.state(), USState::HawaiianCoast);
+        assert_eq!(fips_code.state_code(), 59);
+    }
+
+    #[test]
+    fn expanded_round_trip() {
+        let fips_code = FIPSCode::new(
+            USState::TX,
+            123,
+            990101,
+            SettingCategory::Home,
+            14938,
+            0x01ff,
+        );
+        let expanded = ExpandedFIPSCode::from_fips_code(fips_code);
+        assert_eq!(expanded.to_fips_code(), fips_code);
+    }
+
+    #[test]
+    fn test_compare_non_data() {
+        let fips_code_a = FIPSCode::new(
+            USState::TX,
+            123,
+            990101,
+            SettingCategory::Home,
+            14938,
+            0x01ff,
+        );
+        let fips_code_b = FIPSCode::new(
+            USState::TX,
+            123,
+            990101,
+            SettingCategory::Home,
+            14938,
+            0x00ff,
+        );
+
+        assert_eq!(fips_code_a.compare_non_data(fips_code_b), Ordering::Equal);
+        assert_eq!(fips_code_a.cmp(&fips_code_b), Ordering::Greater);
+    }
+
+    #[test]
+    fn test_set_id() {
+        // Exercises case that triggered a bug that causes a panic.
+        let fips_code = FIPSCode::with_category(USState::AK, 0, 0, SettingCategory::CensusTract);
+
+        let other_fips_code = fips_code.set_id(0);
+        assert_eq!(fips_code, other_fips_code);
+    }
+}

--- a/ixa-fips/src/lib.rs
+++ b/ixa-fips/src/lib.rs
@@ -1,0 +1,52 @@
+/*!
+
+# FIPS Geographic Region Code Library
+
+FIPS geographic region codes are used to represent hierarchical geographic regions from the state level down to the
+"block" level. They are augmented in some synthetic population datasets with additional ID numbers for households,
+workplaces, and schools. This library provides types to represent FIPS geographic region codes (and "code fragments"),
+efficient representations, and utilities to convert to and from textual representations ([`crate::parser`]).
+
+The [`crate::aspr`] module provides types for representing records from the ASPR synthetic population dataset, and the
+[`crate::aspr::parser`] submodule provides parsers for textual representations of ASPR records.
+
+The `aspr_archive` feature (enabled by default) enables the [`crate::aspr::archive`] module, which provides a reader
+for ASPR synthetic population data files, including files that are within a zip archive.
+
+*/
+
+#![allow(dead_code)]
+
+pub mod aspr;
+pub mod fips_code;
+pub mod parser;
+pub mod states;
+
+pub use fips_code::{ExpandedFIPSCode, FIPSCode};
+pub use states::USState;
+
+// Convenience constants
+const FOUR_BIT_MASK: u8 = 15; // 2^4-1
+const SIX_BIT_MASK: u8 = 63; // 2^6-1
+const TEN_BIT_MASK: u16 = 1023; // 2^10-1
+const FOURTEEN_BIT_MASK: u16 = 16383; // 2^14-1
+const TWENTY_BIT_MASK: u32 = 1048575; // 2^20-1
+
+// Offsets of the bit fields in the encoded FIPS code
+const STATE_OFFSET: usize = 58;
+const COUNTY_OFFSET: usize = 48;
+const TRACT_OFFSET: usize = 28;
+const CATEGORY_OFFSET: usize = 24;
+const ID_OFFSET: usize = 10;
+// const DATA_OFFSET: usize = 0;
+
+/// The numeric type used for the state code fragment; `u8`
+pub type StateCode = u8;
+/// The numeric type used for the county code fragment; `u16`
+pub type CountyCode = u16;
+/// The numeric type used for the tract code fragment; `u32`
+pub type TractCode = u32;
+/// The numeric type used for the id code fragment; `u16`
+pub type IdCode = u16;
+/// The numeric type used for the data code fragment; `u16`
+pub type DataCode = u16;

--- a/ixa-fips/src/parser.rs
+++ b/ixa-fips/src/parser.rs
@@ -1,0 +1,348 @@
+/*!
+
+Simple parsing utilities for parsing text representations of FIPS codes and variations thereupon.
+
+The concatenative structure of hierarchical FIPS geographic region codes, the (decimal) digit count of code fragments, and the bit count (defined by this implementation) allowed for each code fragment, are described in detail in the library level documentation
+
+*/
+
+use std::fmt::{Debug, Display};
+
+use crate::states::USState;
+
+/// The FIPS parser error type.
+/// The assumption is that the parsing context is so small that it isn't necessary to track source location information.
+#[derive(Copy, Clone, PartialEq, Eq)]
+pub enum FIPSParserError {
+    InvalidDigit { found: char },
+    InvalidLength { expected: u32, found: u32 },
+    ValueExceedsCapacity { value: u64, capacity: u64 },
+}
+
+impl Display for FIPSParserError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            FIPSParserError::InvalidDigit { found } => write!(f, "Invalid digit: {}", found),
+            FIPSParserError::InvalidLength { expected, found } => {
+                write!(f, "Expected {} characters, found {}", expected, found)
+            }
+            FIPSParserError::ValueExceedsCapacity { value, capacity } => {
+                write!(f, "Value {} exceeds max capacity {}", value, capacity)
+            }
+        }
+    }
+}
+
+impl Debug for FIPSParserError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        Display::fmt(&self, f)
+    }
+}
+
+impl std::error::Error for FIPSParserError {}
+
+/// Similar to how Nom structures its results. We have:
+///   `I`: The input type, i.e. `&str`
+///   `O`: The output type, i.e. `u32`
+///   `E`: The error type returns a tuple of the original input and the error.
+/// A successful result consists of the remaining unparsed input and the parsed value.
+pub type IResult<I, O, E = (I, FIPSParserError)> = Result<(I, O), E>;
+pub type FIPSParseResult<'a, T> = IResult<&'a str, T>;
+
+/// A function that parses a specified number of decimal digits, enforcing the
+/// constraint that the parsed value of those digits be representable by the
+/// specified number of binary bits. Upon success, returns the remainder of the
+/// input after consuming the parsed digits together with the value of the
+/// parsed digits. If there is an error, the original input is returned along
+/// with the `FIPSParserError` variant describing the error.
+///
+/// This function assumes ASCII decimal digits. (The rest of the string can by any  valid UTF-8.)
+pub(crate) fn parse_decimal_digits_to_bits(
+    digit_count: u32,
+    bit_count: u8,
+    input: &str,
+) -> IResult<&str, u64> {
+    let maximum_allowed_value = (1u64 << bit_count) - 1;
+    let mut input_bytes = input.as_bytes().iter();
+    let mut computed_value: u64 = 0;
+
+    for idx in 0..digit_count {
+        match input_bytes.next() {
+            Some(c) => {
+                if c.is_ascii_digit() {
+                    computed_value = 10 * computed_value + (c - b'0') as u64;
+                } else {
+                    return Err((
+                        input,
+                        FIPSParserError::InvalidDigit {
+                            // The UTF-8 encoded character at `idx` might not be represented as a single byte.
+                            // However, as we assume ASCII decimal digits, we are gauranteed that the first
+                            // `idx-1` bytes represent `idx-1` characters.
+                            found: input.chars().nth(idx as usize).unwrap(),
+                        },
+                    ));
+                }
+            }
+
+            None => {
+                // Ran out of digits before we were done parsing.
+                return Err((
+                    input,
+                    FIPSParserError::InvalidLength {
+                        expected: digit_count,
+                        found: idx,
+                    },
+                ));
+            }
+        } // end match next byte
+    } // end for idx
+
+    // Enforce the bit count constraint.
+    if computed_value > maximum_allowed_value {
+        return Err((
+            input,
+            FIPSParserError::ValueExceedsCapacity {
+                value: computed_value,
+                capacity: maximum_allowed_value,
+            },
+        ));
+    }
+
+    let remaining = &input[digit_count as usize..];
+    Ok((remaining, computed_value))
+}
+
+/// Parses the first two decimal digits of `input` into a `USState` enum variant.
+///
+/// This method is only intended to parse states for which `state.is_state()` is
+/// true. In particular, it enforces the constraint that the decimal value be
+/// representable by 6 binary bits (so values <= 63).
+pub fn parse_state_code(input: &str) -> FIPSParseResult<USState> {
+    parse_decimal_digits_to_bits(2, 6, input).map(|(rest, value)| {
+        // The `parse_decimal_digits_to_bits` function guarantees `value` fits in 6
+        // bits, so this unwrap always succeeds.
+        let state = unsafe { USState::decode(value as u8).unwrap_unchecked() };
+        (rest, state)
+    })
+}
+
+/// Parses the first three digits of `input` as a FIPS county code. Enforces the
+/// requirement that the value fit into 10 bits (a tautology in this case).
+pub fn parse_county_code(input: &str) -> FIPSParseResult<u16> {
+    parse_decimal_digits_to_bits(3, 10, input).map(|(rest, value)| {
+        // The `parse_decimal_digits_to_bits` function guarantees `value` fits in 10 bits.
+        (rest, value as u16)
+    })
+}
+
+/// Parses the first six digits of `input` as a FIPS census tract code. Enforces the
+/// requirement that the value fit into 20 bits (a tautology in this case).
+pub fn parse_tract_code(input: &str) -> FIPSParseResult<u32> {
+    parse_decimal_digits_to_bits(6, 20, input).map(|(rest, value)| {
+        // The `parse_decimal_digits_to_bits` function guarantees `value` fits in 20 bits.
+        (rest, value as u32)
+    })
+}
+
+// #[allow(unused_imports)]
+// pub use crate::aspr::parser::{
+//   parse_home_id,
+//   parse_public_school_id,
+//   parse_private_school_id,
+//   parse_workplace_id,
+//   parse_integer
+// };
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_parse_decimal_digits_to_bits_valid_cases() {
+        // Test with different digit and bit counts
+        assert_eq!(
+            parse_decimal_digits_to_bits(2, 6, "42rest"),
+            Ok(("rest", 42))
+        );
+        assert_eq!(
+            parse_decimal_digits_to_bits(3, 10, "123more"),
+            Ok(("more", 123))
+        );
+        assert_eq!(parse_decimal_digits_to_bits(1, 4, "7end"), Ok(("end", 7)));
+        assert_eq!(
+            parse_decimal_digits_to_bits(6, 20, "123456extra"),
+            Ok(("extra", 123456))
+        );
+
+        // Test maximum values for given bit constraints
+        assert_eq!(
+            parse_decimal_digits_to_bits(2, 6, "63text"),
+            Ok(("text", 63))
+        );
+        assert_eq!(
+            parse_decimal_digits_to_bits(3, 10, "999text"),
+            Ok(("text", 999))
+        );
+        assert_eq!(
+            parse_decimal_digits_to_bits(6, 20, "999999text"),
+            Ok(("text", 999999))
+        );
+    }
+
+    #[test]
+    fn test_parse_decimal_digits_to_bits_invalid_cases() {
+        // Too few digits in input
+        assert!(parse_decimal_digits_to_bits(2, 6, "4").is_err());
+        assert!(parse_decimal_digits_to_bits(3, 10, "12").is_err());
+
+        // Non-digit characters
+        assert!(parse_decimal_digits_to_bits(2, 6, "a4rest").is_err());
+        assert!(parse_decimal_digits_to_bits(3, 10, "1x3more").is_err());
+
+        // Value exceeds bit constraint
+        assert!(parse_decimal_digits_to_bits(2, 6, "64text").is_err()); // 64 doesn't fit in 6 bits
+        assert_eq!(
+            parse_decimal_digits_to_bits(3, 8, "256text"),
+            Err((
+                "256text",
+                FIPSParserError::ValueExceedsCapacity {
+                    value: 256,
+                    capacity: 255
+                }
+            ))
+        ); // 256 doesn't fit in 8 bits
+        assert_eq!(
+            parse_decimal_digits_to_bits(7, 20, "1048576text"),
+            Err((
+                "1048576text",
+                FIPSParserError::ValueExceedsCapacity {
+                    value: 1048576,
+                    capacity: 1048575
+                }
+            ))
+        ); // 2^20 = 1048576
+    }
+
+    #[test]
+    fn test_parse_state_code_valid_cases() {
+        // Test with valid state codes (assuming implementation of USState enum)
+        assert!(parse_state_code("01rest").is_ok()); // Alabama
+        assert!(parse_state_code("06rest").is_ok()); // California
+        assert!(parse_state_code("48rest").is_ok()); // Texas
+        assert!(parse_state_code("36rest").is_ok()); // New York
+
+        // Check that remainder is correctly returned
+        let (remainder, _) = parse_state_code("42Pennsylvania").unwrap();
+        assert_eq!(remainder, "Pennsylvania");
+    }
+
+    #[test]
+    fn test_parse_state_code_invalid_cases() {
+        // Value exceeds 6 bits
+        assert!(parse_state_code("64rest").is_err());
+        assert!(parse_state_code("99rest").is_err());
+
+        // Non-digit characters
+        assert!(parse_state_code("A1rest").is_err());
+
+        // Too few digits
+        assert!(parse_state_code("4").is_err());
+
+        // Empty input
+        assert!(parse_state_code("").is_err());
+    }
+
+    #[test]
+    fn test_parse_county_code_valid_cases() {
+        // Test with valid county codes
+        assert_eq!(parse_county_code("001rest").unwrap().1, 1);
+        assert_eq!(parse_county_code("123rest").unwrap().1, 123);
+        assert_eq!(parse_county_code("999rest").unwrap().1, 999);
+
+        // Check that remainder is correctly returned
+        let (remainder, _) = parse_county_code("001CountyName").unwrap();
+        assert_eq!(remainder, "CountyName");
+    }
+
+    #[test]
+    fn test_parse_county_code_invalid_cases() {
+        // Non-digit characters
+        assert_eq!(
+            parse_county_code("x01rest"),
+            Err(("x01rest", FIPSParserError::InvalidDigit { found: 'x' }))
+        );
+
+        // Too few digits
+        assert_eq!(
+            parse_county_code("12"),
+            Err((
+                "12",
+                FIPSParserError::InvalidLength {
+                    expected: 3,
+                    found: 2
+                }
+            ))
+        );
+
+        // Empty input
+        assert_eq!(
+            parse_county_code(""),
+            Err((
+                "",
+                FIPSParserError::InvalidLength {
+                    expected: 3,
+                    found: 0
+                }
+            ))
+        );
+    }
+
+    #[test]
+    fn test_parse_tract_code_valid_cases() {
+        // Test with valid tract codes
+        assert_eq!(parse_tract_code("000001rest").unwrap().1, 1);
+        assert_eq!(parse_tract_code("123456rest").unwrap().1, 123456);
+        assert_eq!(parse_tract_code("999999rest").unwrap().1, 999999);
+
+        // Check that remainder is correctly returned
+        let (remainder, _) = parse_tract_code("123456TractInfo").unwrap();
+        assert_eq!(remainder, "TractInfo");
+    }
+
+    #[test]
+    fn test_parse_tract_code_invalid_cases() {
+        // Non-digit characters
+        assert!(parse_tract_code("12345xrest").is_err());
+
+        // Too few digits
+        assert!(parse_tract_code("12345").is_err());
+
+        // Empty input
+        assert!(parse_tract_code("").is_err());
+    }
+
+    #[test]
+    fn test_integration_fips_parsing() {
+        // Test parsing a complete FIPS code (state + county + tract)
+        // Example: "01001020100" = Alabama (01), Autauga County (001), Tract 020100
+
+        let input = "01001020100RestOfData";
+
+        // First parse the state
+        let (remainder1, state) = parse_state_code(input).unwrap();
+        assert_eq!(remainder1, "001020100RestOfData");
+
+        // Then parse the county
+        let (remainder2, county) = parse_county_code(remainder1).unwrap();
+        assert_eq!(remainder2, "020100RestOfData");
+
+        // Finally parse the tract
+        let (remainder3, tract) = parse_tract_code(remainder2).unwrap();
+        assert_eq!(remainder3, "RestOfData");
+
+        // Verify the parsed values (assuming USState enum implementation)
+        assert_eq!(state, USState::AL);
+        assert_eq!(county, 1);
+        assert_eq!(tract, 20100);
+    }
+}

--- a/ixa-fips/src/parser.rs
+++ b/ixa-fips/src/parser.rs
@@ -2,7 +2,9 @@
 
 Simple parsing utilities for parsing text representations of FIPS codes and variations thereupon.
 
-The concatenative structure of hierarchical FIPS geographic region codes, the (decimal) digit count of code fragments, and the bit count (defined by this implementation) allowed for each code fragment, are described in detail in the library level documentation
+The concatenative structure of hierarchical FIPS geographic region codes, the (decimal)
+digit count of code fragments, and the bit count (defined by this implementation) allowed
+for each code fragment, are described in detail in the library level documentation
 
 */
 

--- a/ixa-fips/src/states.rs
+++ b/ixa-fips/src/states.rs
@@ -1,0 +1,276 @@
+/*!
+
+An enum for states as represented by FIPS Geographic Region Codes. Note that the `FIPSCode` encoded type only uses six
+bits to encode the state code, which can accommodate codes <= 63. Thus, it is best to only use `FIPSCode` for actual
+proper states.
+
+*/
+
+use crate::StateCode;
+use std::fmt::Display;
+
+#[derive(Copy, Clone, Eq, PartialEq, Hash, Debug)]
+pub enum USState {
+    AL = 1,
+    AK = 2,
+    AmericanSamoa = 3, // (FIPS 5-1 reserved code)
+    AZ = 4,
+    AR = 5,
+    CA = 6,
+    CanalZone = 7, // (FIPS 5-1 reserved code)
+    CO = 8,
+    CT = 9,
+    DE = 10,
+    DC = 11, // District of Columbia
+    FL = 12,
+    GA = 13,
+    Guam = 14, // (FIPS 5-1 reserved code)
+    HI = 15,
+    ID = 16,
+    IL = 17,
+    IN = 18,
+    IA = 19,
+    KS = 20,
+    KY = 21,
+    LA = 22,
+    ME = 23,
+    MD = 24,
+    MA = 25,
+    MI = 26,
+    MN = 27,
+    MS = 28,
+    MO = 29,
+    MT = 30,
+    NE = 31,
+    NV = 32,
+    NH = 33,
+    NJ = 34,
+    NM = 35,
+    NY = 36,
+    NC = 37,
+    ND = 38,
+    OH = 39,
+    OK = 40,
+    OR = 41,
+    PA = 42,
+    PuertoRico = 43, // (FIPS 5-1 reserved code)
+    RI = 44,
+    SC = 45,
+    SD = 46,
+    TN = 47,
+    TX = 48,
+    UT = 49,
+    VT = 50,
+    VA = 51,
+    VirginIslandsOfTheUS = 52, // (FIPS 5-1 reserved code)
+    WA = 53,
+    WV = 54,
+    WI = 55,
+    WY = 56,
+    AS = 60,
+    FM = 64,
+    GU = 66,
+    JohnstonAtoll = 67,
+    MH = 68,
+    MP = 69,
+    PW = 70,
+    MidwayIslands = 71,
+    PR = 72,
+    UM = 74,
+    NavassaIsland = 76,
+    VI = 78,
+    WakeIsland = 79,
+    BakerIsland = 81,
+    HowlandIsland = 84,
+    JarvisIsland = 86,
+    KingmanReef = 89,
+    PalmyraAtoll = 95,
+
+    // Invalid / unassigned values:
+    //    62, 63, ??
+    //    80, 82, 83, 85, 87, 88, 90, ??
+
+    // EAS Maritime values:
+    //    57, 58, 59, 61,
+    //    65, 73, 75, 77,
+    //    91, 92, 93, 94, 96, 97, 98
+
+    // We don't use the EAS Maritime Areas, but what the heck, we'll include them.
+    PacificCoastFromWashingtonToCalifornia = 57, // EAS Maritime area
+    AlaskanCoast = 58,                           // EAS Maritime area
+    HawaiianCoast = 59,                          // EAS Maritime area
+    AmericanSamoaWaters = 61,                    // EAS Maritime area
+    MarianaIslandsWatersIncludingGuam = 65,      // EAS Maritime area
+    AtlanticCoastFromMaineToVirginia = 73,       // EAS Maritime area
+    AtlanticCoastFromNorthCarolinaToFloridaAndTheCoastsOfPuertoRicoAndVirginIslands = 75, // EAS Maritime area
+    GulfOfMexico = 77,                           // EAS Maritime area
+    LakeSuperior = 91,                           // EAS Maritime area
+    LakeMichigan = 92,                           // EAS Maritime area
+    LakeHuron = 93,                              // EAS Maritime area
+    StClairRiverDetroitRiverAndLakeStClair = 94, // EAS Maritime area
+    LakeErie = 96,                               // EAS Maritime area
+    NiagaraRiverAndLakeOntario = 97,             // EAS Maritime area
+    StLawrenceRiver = 98,                        // EAS Maritime area
+}
+
+impl USState {
+    /// Returns true is `self` is a state or District of Columbia
+    pub fn is_state(&self) -> bool {
+        let v = *self as StateCode;
+        v <= 56u8 && ![3u8, 7, 14, 43, 52].contains(&v)
+    }
+
+    /// Returns true if `self` is a state (not including District of Columbia)
+    pub fn is_proper_state(&self) -> bool {
+        self.is_state() && *self as StateCode != 11
+    }
+
+    /// Returns true if `self` is one of the EAS maritime region codes.
+    pub fn is_eas_maritime(&self) -> bool {
+        [57u8, 58, 59, 61, 65, 73, 75, 77, 91, 92, 93, 94, 96, 97, 98]
+            .contains(&(*self as StateCode))
+    }
+
+    /// Returns the numeric FIPS code for this state.
+    ///
+    /// This representation only requires 6 bits if `self.is_state()`.
+    pub fn encode(&self) -> StateCode {
+        *self as StateCode
+    }
+
+    pub fn decode(value: StateCode) -> Result<USState, ()> {
+        if !Self::valid_code(value) {
+            return Err(());
+        }
+        Ok(unsafe { std::mem::transmute(value) })
+    }
+
+    pub fn valid_code(code: StateCode) -> bool {
+        // The list in this next line contains all values between 1 and 98 that are not assigned to a valid region.
+        // Note that there are codes that are neither states nor EAS maritime region codes nor FIPS 5-1 reserved codes,
+        // like Midway Islands, for example.
+        code != 0 && code <= 98 && ![62u8, 63, 80, 82, 83, 85, 87, 88, 90].contains(&code)
+    }
+
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            USState::AL => "AL",
+            USState::AK => "AK",
+            USState::AZ => "AZ",
+            USState::AR => "AR",
+            USState::CA => "CA",
+            USState::CO => "CO",
+            USState::CT => "CT",
+            USState::DE => "DE",
+            USState::DC => "DC", // District of Columbia
+            USState::FL => "FL",
+            USState::GA => "GA",
+            USState::HI => "HI",
+            USState::ID => "ID",
+            USState::IL => "IL",
+            USState::IN => "IN",
+            USState::IA => "IA",
+            USState::KS => "KS",
+            USState::KY => "KY",
+            USState::LA => "LA",
+            USState::ME => "ME",
+            USState::MD => "MD",
+            USState::MA => "MA",
+            USState::MI => "MI",
+            USState::MN => "MN",
+            USState::MS => "MS",
+            USState::MO => "MO",
+            USState::MT => "MT",
+            USState::NE => "NE",
+            USState::NV => "NV",
+            USState::NH => "NH",
+            USState::NJ => "NJ",
+            USState::NM => "NM",
+            USState::NY => "NY",
+            USState::NC => "NC",
+            USState::ND => "ND",
+            USState::OH => "OH",
+            USState::OK => "OK",
+            USState::OR => "OR",
+            USState::PA => "PA",
+            USState::RI => "RI",
+            USState::SC => "SC",
+            USState::SD => "SD",
+            USState::TN => "TN",
+            USState::TX => "TX",
+            USState::UT => "UT",
+            USState::VT => "VT",
+            USState::VA => "VA",
+            USState::WA => "WA",
+            USState::WV => "WV",
+            USState::WI => "WI",
+            USState::WY => "WY",
+            _ => unimplemented!("Only states are supported."),
+        }
+    }
+}
+
+impl Display for USState {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        write!(f, "{:?}", self)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_display() {
+        assert_eq!(USState::AK.to_string(), "AK");
+        assert_eq!(USState::NavassaIsland.to_string(), "NavassaIsland");
+    }
+
+    #[test]
+    fn test_is_state() {
+        assert!(USState::AK.is_state());
+        assert!(USState::DC.is_state());
+        assert!(!USState::NavassaIsland.is_state());
+        assert!(!USState::LakeHuron.is_state());
+    }
+
+    #[test]
+    fn test_is_proper_state() {
+        assert!(USState::AK.is_proper_state());
+        assert!(!USState::DC.is_proper_state());
+        assert!(!USState::NavassaIsland.is_proper_state());
+        assert!(!USState::LakeHuron.is_proper_state());
+    }
+
+    #[test]
+    fn test_is_eas_maritime() {
+        assert!(!USState::PuertoRico.is_eas_maritime());
+        assert!(!USState::VA.is_eas_maritime());
+        assert!(USState::GulfOfMexico.is_eas_maritime());
+        assert!(!USState::JarvisIsland.is_eas_maritime());
+        assert!(USState::AmericanSamoaWaters.is_eas_maritime());
+    }
+
+    #[test]
+    fn test_decode() {
+        assert_eq!(USState::PuertoRico, USState::decode(43).unwrap());
+        assert_eq!(USState::MidwayIslands, USState::decode(71).unwrap());
+        assert_eq!(USState::MN, USState::decode(27).unwrap());
+        assert_eq!(USState::LakeSuperior, USState::decode(91).unwrap());
+
+        assert!(USState::decode(99).is_err());
+        assert!(USState::decode(62).is_err());
+        assert!(USState::decode(63).is_err());
+        assert!(USState::decode(80).is_err());
+        assert!(USState::decode(90).is_err());
+        assert!(USState::decode(0).is_err());
+    }
+
+    #[test]
+    fn test_encode() {
+        assert_eq!(USState::PuertoRico.encode(), 43u8);
+        assert_eq!(USState::MidwayIslands.encode(), 71u8);
+        assert_eq!(USState::MN.encode(), 27u8);
+        assert_eq!(USState::LakeSuperior.encode(), 91u8);
+    }
+}

--- a/ixa-integration-tests/Cargo.toml
+++ b/ixa-integration-tests/Cargo.toml
@@ -14,6 +14,8 @@ clap = { version = "^4.5.26", features = ["derive"] }
 [dev-dependencies]
 assert_cmd = "^2.0.16"
 
+[lints]
+workspace = true
 
 [[bin]]
 name = "runner_test_custom_args"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -66,6 +66,8 @@ pub use log::{
 
 pub mod external_api;
 mod hashing;
+pub mod numeric;
+pub mod settings;
 pub mod web_api;
 
 // Re-export for macros

--- a/src/numeric.rs
+++ b/src/numeric.rs
@@ -8,6 +8,7 @@ pub const ACC: f64 = 10e-11;
 
 /// Compares if two floats are close via `approx::abs_diff_eq` using a maximum absolute difference
 /// (epsilon) of `acc`.
+#[must_use]
 pub fn almost_eq(a: f64, b: f64, acc: f64) -> bool {
     if a.is_infinite() && b.is_infinite() {
         return a == b;
@@ -17,6 +18,7 @@ pub fn almost_eq(a: f64, b: f64, acc: f64) -> bool {
 
 /// Compares if two floats are close via `approx::relative_eq!` and `ACC` relative precision.
 /// Updates first argument to value of second argument.
+#[must_use]
 pub fn convergence(x: &mut f64, x_new: f64) -> bool {
     let res = approx::relative_eq!(*x, x_new, max_relative = ACC);
     *x = x_new;

--- a/src/numeric.rs
+++ b/src/numeric.rs
@@ -1,0 +1,36 @@
+//! Vendored from statrs@0.18.0 (prec.rs), convenience wrappers around methods from the approx crate.
+//! Provides utility functions for working with floating point precision
+
+use approx::AbsDiffEq;
+
+/// Targeted accuracy instantiated over `f64`
+pub const ACC: f64 = 10e-11;
+
+/// Compares if two floats are close via `approx::abs_diff_eq` using a maximum absolute difference
+/// (epsilon) of `acc`.
+pub fn almost_eq(a: f64, b: f64, acc: f64) -> bool {
+    if a.is_infinite() && b.is_infinite() {
+        return a == b;
+    }
+    a.abs_diff_eq(&b, acc)
+}
+
+/// Compares if two floats are close via `approx::relative_eq!` and `ACC` relative precision.
+/// Updates first argument to value of second argument.
+pub fn convergence(x: &mut f64, x_new: f64) -> bool {
+    let res = approx::relative_eq!(*x, x_new, max_relative = ACC);
+    *x = x_new;
+    res
+}
+
+#[macro_export]
+macro_rules! assert_almost_eq {
+    ($a:expr, $b:expr, $prec:expr $(,)?) => {
+        if !$crate::numeric::almost_eq($a, $b, $prec) {
+            panic!(
+                "assertion failed: `abs(left - right) < {:e}`, (left: `{}`, right: `{}`)",
+                $prec, $a, $b
+            );
+        }
+    };
+}

--- a/src/random.rs
+++ b/src/random.rs
@@ -100,7 +100,7 @@ fn get_rng<R: RngId + 'static>(context: &Context) -> RefMut<R::RngType> {
     })
 }
 
-// This is a trait exension on Context
+// This is a trait extension on Context
 pub trait ContextRandomExt {
     fn init_random(&mut self, base_seed: u64);
 

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -20,18 +20,6 @@ use std::ops::Index;
 
 define_rng!(SettingsRng);
 
-/// In a setting with `n` people (including the source of infection), the rate of the total
-/// infectiousness process is computed as
-///      (intrinsic infectiousness) × (n - 1)ᵅ
-/// where 0 ≤ 𝛼 ≤ 1. This interpolates between having the total hazard _distributed_ equally and
-/// the total hazard applying equally to the nonsources.
-#[derive(Debug, Clone)]
-pub struct Setting {
-    // Since the `Setting`
-    // id: FIPSCode,
-    members: Vec<PersonId>,
-}
-
 pub type SettingId = FIPSCode;
 
 #[derive(Copy, Clone, PartialEq, Debug)]
@@ -50,21 +38,41 @@ impl ItineraryEntry {
 /// A convenience wrapper for a vector of `ItineraryEntry`s that enforces the constraint that there
 /// is at most one instance of any given `SettingCategory` represented in the `Itinerary`.
 // ToDo(ap59): This should be a small_vec or equivalent, as many of these will have a single entry.
+#[derive(Debug, Clone, Default)]
 pub struct Itinerary(Vec<ItineraryEntry>);
 
 impl Itinerary {
+    /// Creates an empty `Itinerary`.
+    #[must_use]
+    pub fn new() -> Itinerary {
+        Itinerary::default()
+    }
+
+    /// Creates an `Itinerary` from a vector of `ItineraryEntry`'s. Returns an `IxaError` if there
+    /// are two `ItineraryEntry`s with the same `SettingId`.
+    pub fn from_vec(entries: Vec<ItineraryEntry>) -> Result<Self, IxaError> {
+        let mut itinerary = Itinerary::default();
+
+        for entry in entries {
+            itinerary.add(entry.setting_id, entry.ratio)?;
+        }
+
+        Ok(itinerary)
+    }
+
+    /// Convenience wrapper over `add_itinerary_entry` that creates the `ItineraryEntry` for you.
     pub fn add(&mut self, setting_id: SettingId, ratio: f64) -> Result<(), IxaError> {
         self.add_itinerary_entry(ItineraryEntry::new(setting_id, ratio))
     }
 
+    /// Adds the `ItineraryEntry` to the `Itinerary`. Returns an `IxaError` if an `ItineraryEntry`
+    /// with the same setting already exists in the `Itinerary`.
     pub fn add_itinerary_entry(&mut self, entry: ItineraryEntry) -> Result<(), IxaError> {
-        // Check if there is already an entry for this category
-        let category = entry.setting_id.category();
-        if self
-            .0
-            .iter()
-            .any(|other| other.setting_id.category() == category)
-        {
+        // Check if there is already an entry for this setting
+        if self.0.iter().any(
+            // ToDo(ap59): Should the "data" field be included in the comparison?
+            |other| other.setting_id.compare_non_data(entry.setting_id).is_eq(),
+        ) {
             return Err(IxaError::IxaError(format!(
                 "Duplicated setting in itinerary when adding setting_id {:?}",
                 entry.setting_id
@@ -75,8 +83,17 @@ impl Itinerary {
         Ok(())
     }
 
+    /// Returns an iterator over the `ItineraryEntry`s in this `Itinerary`.
     pub fn iter(&self) -> std::slice::Iter<ItineraryEntry> {
         self.0.iter()
+    }
+}
+
+impl<'this> IntoIterator for &'this Itinerary {
+    type Item = &'this ItineraryEntry;
+    type IntoIter = std::slice::Iter<'this, ItineraryEntry>;
+    fn into_iter(self) -> Self::IntoIter {
+        self.iter()
     }
 }
 
@@ -89,11 +106,17 @@ impl Index<usize> for Itinerary {
 
 #[derive(Default)]
 pub struct SettingsDataContainer {
-    // Each `SettingCategory` has an alpha of type `f64`
+    /// Each `SettingCategory` has an alpha of type `f64`
+    ///
+    /// In a setting with `n` people (including the source of infection), the rate of the total
+    /// infectiousness process is computed as
+    ///      (intrinsic infectiousness) × (n - 1)ᵅ
+    /// where 0 ≤ 𝛼 ≤ 1. This interpolates between having the total hazard _distributed_ equally and
+    /// the total hazard applying equally to the nonsources.
     alpha_for_setting_category: HashMap<SettingCategory, f64>,
-    // Each `PersonId` has an `Itinerary` of `SettingId`s
+    /// Each `PersonId` has an `Itinerary` of `SettingId`s
     itineraries: HashMap<PersonId, Itinerary>,
-    // Each `SettingId` has a list of members
+    /// Each `SettingId` has a list of members
     members: HashMap<SettingId, Vec<PersonId>>,
 }
 
@@ -103,9 +126,13 @@ impl SettingsDataContainer {
     }
 
     /// Adds an `Itinerary` for the given person, inserting the person as a member of the settings
-    /// in the given `Itinerary`. Returns `true` if the method modified an existing itinerary (i.e.
-    /// an itinerary was already set for this person), `false` otherwise.
-    fn add_itinerary_for_person(&mut self, person_id: PersonId, itinerary: Itinerary) -> bool {
+    /// in the given `Itinerary`. Returns the old `Itinerary` if the method replaced an existing
+    /// itinerary (i.e. an itinerary was already set for this person), `None` otherwise.
+    fn add_itinerary_for_person(
+        &mut self,
+        person_id: PersonId,
+        itinerary: Itinerary,
+    ) -> Option<Itinerary> {
         match self.itineraries.entry(person_id) {
             Entry::Vacant(vacant_entry) => {
                 // An itinerary was not previously set for this person.
@@ -118,13 +145,13 @@ impl SettingsDataContainer {
                         .and_modify(|members| members.push(person_id))
                         .or_insert_with(|| vec![person_id]);
                 }
-                false
+                None
             }
             Entry::Occupied(mut occupied_entry) => {
                 // Replace the old itinerary, taking ownership of it
                 let old_it = occupied_entry.insert(itinerary);
                 // Remove the person from each setting in the old itinerary
-                for entry in old_it.iter() {
+                for entry in &old_it {
                     let setting = entry.setting_id;
                     self.members.entry(setting).and_modify(|members| {
                         if let Some(idx) = members.iter().position(|&pid| pid == person_id) {
@@ -134,14 +161,14 @@ impl SettingsDataContainer {
                 }
                 // Now add the person to each setting in the new itinerary
                 let new_it = occupied_entry.get();
-                for entry in new_it.iter() {
+                for entry in new_it {
                     let setting = entry.setting_id;
                     self.members
                         .entry(setting)
                         .and_modify(|members| members.push(person_id))
                         .or_insert_with(|| vec![person_id]);
                 }
-                true
+                Some(old_it)
             }
         }
     }
@@ -151,7 +178,7 @@ impl SettingsDataContainer {
     ///     - the `ItineraryEntry` (contains `SettingId` and `ratio`)
     ///     - alpha - the alpha value for the `SettingCategory` associated to the `SettingId` in
     ///       the `ItineraryEntry`
-    ///     - member_count: the length of the list of members of the setting
+    ///     - `member_count`: the length of the list of members of the setting
     ///
     /// If there is no itinerary for the person, this method is a no-op.
     fn with_itinerary<F>(&self, person_id: PersonId, mut callback: F)
@@ -160,7 +187,7 @@ impl SettingsDataContainer {
         F: FnMut(ItineraryEntry, f64, usize),
     {
         if let Some(itinerary) = self.itineraries.get(&person_id) {
-            for entry in itinerary.iter() {
+            for entry in itinerary {
                 let alpha = match self
                     .alpha_for_setting_category
                     .get(&entry.setting_id.category())
@@ -189,7 +216,7 @@ impl SettingsDataContainer {
     ) -> Option<Vec<f64>> {
         let mut multiplier_vector = vec![];
         self.with_itinerary(person_id, |entry, alpha, member_count| {
-            // let multiplier = setting_type.calculate_multiplier(members, *setting_props);
+            #[allow(clippy::cast_precision_loss)]
             let multiplier = ((member_count - 1) as f64).powf(alpha);
             multiplier_vector.push(entry.ratio * multiplier);
         });
@@ -237,15 +264,6 @@ impl SettingsDataContainer {
     }
 }
 
-// fn calculate_multiplier(
-//     members: &[PersonId],
-//     setting_properties: SettingProperties,
-// ) -> f64 {
-//     let n_members = members.len();
-//     #[allow(clippy::cast_precision_loss)]
-//     ((n_members - 1) as f64).powf(setting_properties.alpha)
-// }
-
 define_data_plugin!(
     SettingDataPlugin,
     SettingsDataContainer,
@@ -263,15 +281,19 @@ pub trait ContextSettingExt {
     ) -> Option<f64>;
 
     /// Adds an `Itinerary` for the given person, inserting the person as a member of the settings
-    /// in the given `Itinerary`. Returns `true` if the method modified an existing itinerary (i.e.
-    /// an itinerary was already set for this person), `false` otherwise.
-    fn add_itinerary_for_person(&mut self, person_id: PersonId, itinerary: Itinerary) -> bool;
+    /// in the given `Itinerary`. Returns the old `Itinerary` if the method replaced an existing
+    /// itinerary (i.e. an itinerary was already set for this person), `None` otherwise.
+    fn add_itinerary_for_person(
+        &mut self,
+        person_id: PersonId,
+        itinerary: Itinerary,
+    ) -> Option<Itinerary>;
 
     /// For the given person, computes the inner product $<R, M>$ where $R$ is the vector of ratios
     /// for each setting and $M$ is the vector of multipliers for each setting.
     ///
     /// Recall that the "multiplier" for a setting is computed as
-    ///     $((n_members - 1) as f64).powf(alpha).$
+    ///     `((n_members - 1) as f64).powf(alpha)`.
     fn calculate_total_infectiousness_multiplier_for_person(&self, person_id: PersonId) -> f64;
 
     /// For a given person, use the person's itinerary and associated setting properties to
@@ -291,7 +313,11 @@ impl ContextSettingExt for Context {
             .insert(setting_category, alpha)
     }
 
-    fn add_itinerary_for_person(&mut self, person_id: PersonId, itinerary: Itinerary) -> bool {
+    fn add_itinerary_for_person(
+        &mut self,
+        person_id: PersonId,
+        itinerary: Itinerary,
+    ) -> Option<Itinerary> {
         let container = self.get_data_container_mut(SettingDataPlugin);
         container.add_itinerary_for_person(person_id, itinerary)
     }
@@ -319,168 +345,168 @@ mod test {
     use crate::assert_almost_eq;
     use crate::settings::ContextSettingExt;
     use crate::ContextPeopleExt;
+    use fips::{FIPSCode, USState};
     #[test]
     fn test_setting_type_creation() {
         let mut context = Context::new();
-        context.set_alpha_for_setting_category(SettingCategory::Home, 0.1);
-        context.set_alpha_for_setting_category(SettingCategory::CensusTract, 0.001);
+        // Set new values
+        assert!(context
+            .set_alpha_for_setting_category(SettingCategory::Home, 0.1)
+            .is_none());
+        assert!(context
+            .set_alpha_for_setting_category(SettingCategory::CensusTract, 0.001)
+            .is_none());
 
-        let home_props = context.get_setting_properties::<Home>();
-        let tract_props = context.get_setting_properties::<CensusTract>();
-
-        assert_almost_eq!(0.1, home_props.alpha, 0.0);
-        assert_almost_eq!(0.001, tract_props.alpha, 0.0);
+        // Assert that:
+        //   1) the old value is returned when a new value is set
+        //   2) the original value was inserted correctly to begin with
+        assert_almost_eq!(
+            context
+                .set_alpha_for_setting_category(SettingCategory::Home, 0.9)
+                .unwrap(),
+            0.1,
+            0.0
+        );
+        assert_almost_eq!(
+            context
+                .set_alpha_for_setting_category(SettingCategory::CensusTract, 0.5)
+                .unwrap(),
+            0.001,
+            0.0
+        );
     }
 
     #[test]
     fn test_duplicated_itinerary() {
-        let mut context = Context::new();
-        context.register_setting_type(Home {}, SettingProperties { alpha: 1.0 });
-        context.register_setting_type(CensusTract {}, SettingProperties { alpha: 1.0 });
+        // Different homes is ok. (Also, different person from person1 with same home is ok.)
+        let itinerary0 = Itinerary::from_vec(vec![
+            ItineraryEntry::new(
+                FIPSCode::with_category(USState::AK, 0, 0, SettingCategory::Home),
+                0.5,
+            ),
+            ItineraryEntry::new(
+                FIPSCode::with_category(USState::TN, 0, 0, SettingCategory::Home),
+                0.5,
+            ),
+        ]);
+        assert!(itinerary0.is_ok());
 
-        // Different homes is ok. (Different person from person1 with same home is ok.)
-        let person0 = context.add_person(()).unwrap();
-        let itinerary0 = vec![
-            ItineraryEntry::new(&SettingId::<Home>::new(2), 0.5),
-            ItineraryEntry::new(&SettingId::<Home>::new(3), 0.5),
-        ];
+        // Same value in "id" field but different setting type is ok.
+        let itinerary1 = Itinerary::from_vec(vec![
+            ItineraryEntry::new(
+                FIPSCode::new(USState::AK, 0, 0, SettingCategory::Home, 314, 0),
+                0.5,
+            ),
+            ItineraryEntry::new(
+                FIPSCode::new(USState::AK, 0, 0, SettingCategory::CensusTract, 314, 0),
+                0.5,
+            ),
+        ]);
+        assert!(itinerary1.is_ok());
 
-        // Same id but different setting type is ok.
-        let person1 = context.add_person(()).unwrap();
-        let itinerary1 = vec![
-            ItineraryEntry::new(&SettingId::<Home>::new(3), 0.5),
-            ItineraryEntry::new(&SettingId::<CensusTract>::new(3), 0.5),
-        ];
-
-        // Same ID and same setting type should be an error.
-        let person2 = context.add_person(()).unwrap();
-        let itinerary2 = vec![
-            ItineraryEntry::new(&SettingId::<Home>::new(2), 0.25),
-            ItineraryEntry::new(&SettingId::<Home>::new(2), 0.75),
-        ];
-
-        context
-            .add_itinerary(person0, itinerary0)
-            .expect("Failed to add itinerary");
-
-        context
-            .add_itinerary(person1, itinerary1)
-            .expect("Failed to add itinerary");
-
-        match context.add_itinerary(person2, itinerary2) {
-            Err(IxaError::IxaError(msg)) => {
-                assert_eq!(msg, "Duplicated setting");
-            }
-            Err(e) => panic!("Unexpected error in itinerary: {}", e),
-            Ok(_) => panic!("itinerary should be error"),
-        }
+        // Differing only in "data field" should be an error.
+        let itinerary2 = Itinerary::from_vec(vec![
+            ItineraryEntry::new(
+                FIPSCode::new(USState::AK, 0, 0, SettingCategory::Home, 314, 1),
+                0.5,
+            ),
+            ItineraryEntry::new(
+                FIPSCode::new(USState::AK, 0, 0, SettingCategory::Home, 314, 0),
+                0.5,
+            ),
+        ]);
+        assert!(itinerary2.is_err());
     }
 
     #[test]
     fn test_add_itinerary() {
+        // Put two people into the same setting and sample one from the other's settings.
         let mut context = Context::new();
-        context.register_setting_type(Home {}, SettingProperties { alpha: 1.0 });
+        context.init_random(42);
+        context.set_alpha_for_setting_category(SettingCategory::Home, 0.1);
+
+        let common_setting = FIPSCode::with_category(USState::AK, 0, 0, SettingCategory::Home);
 
         let person = context.add_person(()).unwrap();
-        let itinerary = vec![
-            ItineraryEntry::new(&SettingId::<Home>::new(1), 0.5),
-            ItineraryEntry::new(&SettingId::<Home>::new(2), 0.5),
-        ];
-        let _ = context.add_itinerary(person, itinerary);
-        let members = context
-            .get_setting_members::<Home>(SettingId::<Home>::new(2))
-            .unwrap();
-        assert_eq!(members.len(), 1);
+        let itinerary =
+            Itinerary::from_vec(vec![ItineraryEntry::new(common_setting, 1.0)]).unwrap();
+        assert!(context
+            .add_itinerary_for_person(person, itinerary)
+            .is_none());
 
         let person2 = context.add_person(()).unwrap();
-        let itinerary2 = vec![ItineraryEntry::new(&SettingId::<Home>::new(2), 1.0)];
-        let _ = context.add_itinerary(person2, itinerary2);
+        let itinerary2 =
+            Itinerary::from_vec(vec![ItineraryEntry::new(common_setting, 1.0)]).unwrap();
+        assert!(context
+            .add_itinerary_for_person(person2, itinerary2)
+            .is_none());
 
-        let members2 = context
-            .get_setting_members::<Home>(SettingId::<Home>::new(2))
-            .unwrap();
-        assert_eq!(members2.len(), 2);
-    }
-
-    #[test]
-    fn test_setting_registration() {
-        let mut context = Context::new();
-        context.register_setting_type(Home {}, SettingProperties { alpha: 0.1 });
-        context.register_setting_type(CensusTract {}, SettingProperties { alpha: 0.01 });
-        for s in 0..5 {
-            // Create 5 people
-            for _ in 0..5 {
-                let person = context.add_person(()).unwrap();
-                let itinerary = vec![
-                    ItineraryEntry::new(&SettingId::<Home>::new(s), 0.5),
-                    ItineraryEntry::new(&SettingId::<CensusTract>::new(s), 0.5),
-                ];
-                let _ = context.add_itinerary(person, itinerary);
-            }
-            let members = context
-                .get_setting_members::<Home>(SettingId::<Home>::new(s))
-                .unwrap();
-            let tract_members = context
-                .get_setting_members::<CensusTract>(SettingId::<CensusTract>::new(s))
-                .unwrap();
-            // Get the number of people for these settings and should be 5
-            assert_eq!(members.len(), 5);
-            assert_eq!(tract_members.len(), 5);
-        }
+        let sampled_person = context.draw_contact_from_itinerary(person);
+        let sampled_person = sampled_person.unwrap();
+        assert_eq!(sampled_person, person2);
     }
 
     #[test]
     fn test_setting_multiplier() {
         // TODO: if setting not registered, shouldn't be able to register people to setting
         let mut context = Context::new();
-        context.register_setting_type(Home {}, SettingProperties { alpha: 0.1 });
+        context.init_random(42);
+        context.set_alpha_for_setting_category(SettingCategory::Home, 0.1);
+
+        let setting_prototype = FIPSCode::with_category(USState::AK, 0, 0, SettingCategory::Home);
+
         for s in 0..5 {
+            let itinerary_prototype =
+                Itinerary::from_vec(vec![ItineraryEntry::new(setting_prototype.set_id(s), 0.5)])
+                    .unwrap();
             // Create 5 people
             for _ in 0..5 {
                 let person = context.add_person(()).unwrap();
-                let itinerary = vec![ItineraryEntry::new(&SettingId::<Home>::new(s), 0.5)];
-                let _ = context.add_itinerary(person, itinerary);
+                let _ = context.add_itinerary_for_person(person, itinerary_prototype.clone());
             }
         }
 
-        let home_id = 0;
+        // Has id = 0.
+        let itinerary =
+            Itinerary::from_vec(vec![ItineraryEntry::new(setting_prototype, 0.5)]).unwrap();
         let person = context.add_person(()).unwrap();
-        let itinerary = vec![ItineraryEntry::new(&SettingId::<Home>::new(home_id), 0.5)];
-        let _ = context.add_itinerary(person, itinerary);
-        let members = context
-            .get_setting_members::<Home>(SettingId::<Home>::new(home_id))
-            .unwrap();
+        let _ = context.add_itinerary_for_person(person, itinerary);
 
-        let setting_type = Home {};
-
-        let inf_multiplier =
-            setting_type.calculate_multiplier(members, SettingProperties { alpha: 0.1 });
+        let inf_multiplier = context.calculate_total_infectiousness_multiplier_for_person(person);
 
         // This is assuming we know what the function for Home is (N - 1) ^ alpha
-        assert_almost_eq!(inf_multiplier, f64::from(6 - 1).powf(0.1), 0.0);
+        assert_almost_eq!(inf_multiplier, 0.5 * f64::from(6 - 1).powf(0.1), 0.0);
     }
 
     #[test]
     fn test_total_infectiousness_multiplier() {
         // Go through all the settings and compute infectiousness multiplier
         let mut context = Context::new();
-        context.register_setting_type(Home {}, SettingProperties { alpha: 0.1 });
-        context.register_setting_type(CensusTract {}, SettingProperties { alpha: 0.01 });
+        context.set_alpha_for_setting_category(SettingCategory::Home, 0.1);
+        context.set_alpha_for_setting_category(SettingCategory::CensusTract, 0.01);
 
+        let home_prototype = FIPSCode::with_category(USState::AK, 0, 0, SettingCategory::Home);
+        let tract_prototype =
+            FIPSCode::with_category(USState::AK, 0, 0, SettingCategory::CensusTract);
+
+        // Create 5 homes and census tracts with 5 people each.
         for s in 0..5 {
+            let itinerary_prototype = Itinerary::from_vec(vec![
+                ItineraryEntry::new(home_prototype.set_id(s), 0.5),
+                ItineraryEntry::new(tract_prototype.set_id(s), 0.5),
+            ])
+            .unwrap();
             for _ in 0..5 {
                 let person = context.add_person(()).unwrap();
-                let itinerary = vec![
-                    ItineraryEntry::new(&SettingId::<Home>::new(s), 0.5),
-                    ItineraryEntry::new(&SettingId::<CensusTract>::new(s), 0.5),
-                ];
-                let _ = context.add_itinerary(person, itinerary);
+                let _ = context.add_itinerary_for_person(person, itinerary_prototype.clone());
             }
         }
+
         // Create a new person and register to home 0
-        let itinerary = vec![ItineraryEntry::new(&SettingId::<Home>::new(0), 1.0)];
+        let itinerary =
+            Itinerary::from_vec(vec![ItineraryEntry::new(home_prototype.set_id(0), 1.0)]).unwrap();
         let person = context.add_person(()).unwrap();
-        let _ = context.add_itinerary(person, itinerary);
+        let _ = context.add_itinerary_for_person(person, itinerary);
 
         // If only registered at home, total infectiousness multiplier should be (6 - 1) ^ (alpha)
         let inf_multiplier = context.calculate_total_infectiousness_multiplier_for_person(person);
@@ -490,20 +516,13 @@ mod test {
         // CensusTract 0 should have 6 members, Home 0 should have 7 members
         // the total infectiousness should be the sum of infs * proportion
         let person = context.add_person(()).unwrap();
-        let itinerary_complete = vec![
-            ItineraryEntry::new(&SettingId::<Home>::new(0), 0.5),
-            ItineraryEntry::new(&SettingId::<CensusTract>::new(0), 0.5),
-        ];
-        let _ = context.add_itinerary(person, itinerary_complete);
-        let members_home = context
-            .get_setting_members::<Home>(SettingId::<Home>::new(0))
-            .unwrap();
-        let members_tract = context
-            .get_setting_members::<CensusTract>(SettingId::<CensusTract>::new(0))
-            .unwrap();
-        assert_eq!(members_home.len(), 7);
-        assert_eq!(members_tract.len(), 6);
+        let itinerary_complete = Itinerary::from_vec(vec![
+            ItineraryEntry::new(home_prototype.set_id(0), 0.5),
+            ItineraryEntry::new(tract_prototype.set_id(0), 0.5),
+        ])
+        .unwrap();
 
+        let _ = context.add_itinerary_for_person(person, itinerary_complete);
         let inf_multiplier_two_settings =
             context.calculate_total_infectiousness_multiplier_for_person(person);
 
@@ -516,33 +535,40 @@ mod test {
 
     #[test]
     fn test_get_contact_from_setting() {
-        // Register two people to a setting and make sure that the person chosen is the other one
+        // Register two people to a setting and make sure that the person chosen is the other one.
         // Attempt to draw a contact from a setting with only the person trying to get a contact
-        // TODO: What happens if the person isn't registered in the setting?
         let mut context = Context::new();
         context.init_random(42);
-        context.register_setting_type(Home {}, SettingProperties { alpha: 0.1 });
-        context.register_setting_type(CensusTract {}, SettingProperties { alpha: 0.01 });
+        context.set_alpha_for_setting_category(SettingCategory::Home, 0.1);
+        context.set_alpha_for_setting_category(SettingCategory::CensusTract, 0.01);
 
         let person_a = context.add_person(()).unwrap();
         let person_b = context.add_person(()).unwrap();
-        let itinerary_a = vec![
-            ItineraryEntry::new(&SettingId::<Home>::new(0), 0.5),
-            ItineraryEntry::new(&SettingId::<CensusTract>::new(0), 0.5),
-        ];
-        let itinerary_b = vec![ItineraryEntry::new(&SettingId::<Home>::new(0), 1.0)];
-        let _ = context.add_itinerary(person_a, itinerary_a);
-        let _ = context.add_itinerary(person_b, itinerary_b);
+
+        let home_prototype = FIPSCode::with_category(USState::AK, 0, 0, SettingCategory::Home);
+        let tract_prototype =
+            FIPSCode::with_category(USState::AK, 0, 0, SettingCategory::CensusTract);
+
+        let itinerary_a = Itinerary::from_vec(vec![
+            ItineraryEntry::new(home_prototype, 0.5),
+            ItineraryEntry::new(tract_prototype, 0.5),
+        ])
+        .unwrap();
+
+        let itinerary_b =
+            Itinerary::from_vec(vec![ItineraryEntry::new(home_prototype, 1.0)]).unwrap();
+
+        let _ = context.add_itinerary_for_person(person_a, itinerary_a);
+        let _ = context.add_itinerary_for_person(person_b, itinerary_b);
 
         assert_eq!(
             person_b,
-            context
-                .get_contact::<Home>(person_a, SettingId::<Home>::new(0))
-                .unwrap()
+            context.draw_contact_from_itinerary(person_a).unwrap()
         );
-        assert!(context
-            .get_contact::<CensusTract>(person_a, SettingId::<CensusTract>::new(0))
-            .is_none());
+        assert_eq!(
+            person_a,
+            context.draw_contact_from_itinerary(person_b).unwrap()
+        );
     }
 
     #[test]
@@ -558,54 +584,68 @@ mod test {
          - Test 1 Itinerary with 0 proportion at census tract, contacts drawn should be from home (0-2)
          - Test 2 Itinerary with 0 proportion at home, contacts should be drawn from census tract (3-6)
         */
+        // We keep track of the people at home and at census tract
+        let mut people_at_home = vec![];
+        let mut people_at_tract = vec![];
+
         for seed in 0..100 {
             let mut context = Context::new();
             context.init_random(seed);
-            context.register_setting_type(Home {}, SettingProperties { alpha: 0.1 });
-            context.register_setting_type(CensusTract {}, SettingProperties { alpha: 0.01 });
+            context.set_alpha_for_setting_category(SettingCategory::Home, 0.1);
+            context.set_alpha_for_setting_category(SettingCategory::CensusTract, 0.01);
 
-            for _ in 0..3 {
-                let person = context.add_person(()).unwrap();
-                let itinerary = vec![ItineraryEntry::new(&SettingId::<Home>::new(0), 1.0)];
-                let _ = context.add_itinerary(person, itinerary);
+            let home_prototype = FIPSCode::with_category(USState::AK, 0, 0, SettingCategory::Home);
+            let tract_prototype =
+                FIPSCode::with_category(USState::AK, 0, 0, SettingCategory::CensusTract);
+
+            {
+                let itinerary_home =
+                    Itinerary::from_vec(vec![ItineraryEntry::new(home_prototype, 1.0)]).unwrap();
+                for _ in 0..3 {
+                    let person = context.add_person(()).unwrap();
+                    people_at_home.push(person);
+                    let _ = context.add_itinerary_for_person(person, itinerary_home.clone());
+                }
             }
 
-            for _ in 0..3 {
-                let person = context.add_person(()).unwrap();
-                let itinerary = vec![ItineraryEntry::new(&SettingId::<CensusTract>::new(0), 1.0)];
-                let _ = context.add_itinerary(person, itinerary);
+            {
+                let itinerary_tract =
+                    Itinerary::from_vec(vec![ItineraryEntry::new(tract_prototype, 1.0)]).unwrap();
+                for _ in 0..3 {
+                    let person = context.add_person(()).unwrap();
+                    people_at_tract.push(person);
+                    let _ = context.add_itinerary_for_person(person, itinerary_tract.clone());
+                }
             }
 
+            // The 7th person whose contact we shall draw
             let person = context.add_person(()).unwrap();
-            let itinerary_home = vec![
-                ItineraryEntry::new(&SettingId::<Home>::new(0), 1.0),
-                ItineraryEntry::new(&SettingId::<CensusTract>::new(0), 0.0),
-            ];
-            let itinerary_censustract = vec![
-                ItineraryEntry::new(&SettingId::<Home>::new(0), 0.0),
-                ItineraryEntry::new(&SettingId::<CensusTract>::new(0), 1.0),
-            ];
-            let home_members = context
-                .get_setting_members::<Home>(SettingId::<Home>::new(0))
-                .unwrap()
-                .clone();
-            let tract_members = context
-                .get_setting_members::<CensusTract>(SettingId::<CensusTract>::new(0))
-                .unwrap()
-                .clone();
 
-            let _ = context.add_itinerary(person, itinerary_home);
-            let contact_id_home = context.draw_contact_from_itinerary(person);
-            assert!(home_members.contains(&contact_id_home.unwrap()));
+            // An itinerary with proportion 1 at home and 0 at census tract
+            let itinerary_home = Itinerary::from_vec(vec![
+                ItineraryEntry::new(home_prototype, 1.0),
+                ItineraryEntry::new(tract_prototype, 0.0),
+            ])
+            .unwrap();
+            // An itinerary with proportion 0 at home and 1 at census tract
+            let itinerary_tract = Itinerary::from_vec(vec![
+                ItineraryEntry::new(home_prototype, 0.0),
+                ItineraryEntry::new(tract_prototype, 1.0),
+            ])
+            .unwrap();
 
-            let _ = context.add_itinerary(person, itinerary_censustract);
-            let contact_id_tract = context.draw_contact_from_itinerary(person);
-            assert!(tract_members.contains(&contact_id_tract.unwrap()));
+            // First draw a contact from the itinerary with 1 at home and 0 at census tract
+            let _ = context.add_itinerary_for_person(person, itinerary_home);
+            let contact_id_home = context.draw_contact_from_itinerary(person).unwrap();
+            assert!(people_at_home.contains(&contact_id_home));
+
+            // Now draw a contact from the itinerary with 0 at home and 1 at census tract
+            let _ = context.add_itinerary_for_person(person, itinerary_tract);
+            let contact_id_tract = context.draw_contact_from_itinerary(person).unwrap();
+            assert!(people_at_tract.contains(&contact_id_tract));
         }
     }
-    /*TODO:
-    Test failure of getting properties if not initialized
-    Test failure if a setting is registered more than once?
-    Test that proportions either add to 1 or that they are weighted based on proportion
-    */
+
+    // TODO: Test failure of getting properties if not initialized
+    // TODO: Test that proportions either add to 1 or that they are weighted based on proportion
 }

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -1,0 +1,648 @@
+//! Settings (locations) represent places that are contexts in which transmission takes place. A
+//! setting determines which other people are in contact with a particular person and for how long.
+//! The `SettingProperties::alpha` parameter determines how the hazard is distributed among an
+//! infected person's contacts within a setting.
+//!
+//! Data related to settings is managed by the `SettingsDataContainer`. A setting is a type that
+//! implements the `SettingType` trait.
+//!
+//!
+
+use crate::people::PersonId;
+use crate::{
+    define_data_plugin, define_rng, Context, ContextRandomExt, HashMap, HashSet, IxaError,
+};
+use std::any::TypeId;
+use std::marker::PhantomData;
+
+define_rng!(SettingsRng);
+
+/// In a setting with `n` people (including the source of infection), the rate of the total infectiousness process
+/// is computed as
+///      (intrinsic infectiousness) × (n - 1)ᵅ
+/// where 0 ≤ 𝛼 ≤ 1. This interpolates between having the total hazard _distributed_ equally and the total hazard
+/// applying equally to the nonsources.
+#[derive(Debug, Clone, Copy)]
+pub struct SettingProperties {
+    alpha: f64,
+}
+
+pub trait SettingType {
+    fn calculate_multiplier(
+        &self,
+        members: &[PersonId],
+        setting_properties: SettingProperties,
+    ) -> f64;
+}
+
+#[derive(Hash, Eq, PartialEq, Ord, PartialOrd)]
+pub struct SettingId<T: SettingType + 'static> {
+    pub id: usize,
+
+    phantom: PhantomData<*const T>,
+}
+
+#[allow(dead_code)]
+impl<T: SettingType + 'static> SettingId<T> {
+    pub fn new(id: usize) -> SettingId<T> {
+        SettingId {
+            id,
+            phantom: PhantomData,
+        }
+    }
+}
+
+pub struct ItineraryEntry {
+    setting_type: TypeId,
+    setting_id: usize,
+    ratio: f64,
+}
+
+#[allow(dead_code)]
+impl ItineraryEntry {
+    fn new<T: SettingType>(setting_id: &SettingId<T>, ratio: f64) -> ItineraryEntry {
+        ItineraryEntry {
+            setting_type: TypeId::of::<T>(),
+            setting_id: setting_id.id,
+            ratio,
+        }
+    }
+}
+
+pub struct SettingsDataContainer {
+    setting_types: HashMap<TypeId, Box<dyn SettingType>>,
+    // For each setting type (e.g., Home) store the properties (e.g., alpha)
+    setting_properties: HashMap<TypeId, SettingProperties>,
+    // For each setting type, have a map of each setting id and a list of members
+    // Maps `T: SettingType` -> `Map<SettingId<T>, People>`
+    members: HashMap<TypeId, HashMap<usize, Vec<PersonId>>>,
+    itineraries: HashMap<PersonId, Vec<ItineraryEntry>>,
+}
+
+impl SettingsDataContainer {
+    fn new() -> Self {
+        SettingsDataContainer {
+            setting_types: HashMap::default(),
+            setting_properties: HashMap::default(),
+            members: HashMap::default(),
+            itineraries: HashMap::default(),
+        }
+    }
+    fn get_setting_members(
+        &self,
+        setting_type: &TypeId,
+        setting_id: usize,
+    ) -> Option<&Vec<PersonId>> {
+        self.members.get(setting_type)?.get(&setting_id)
+    }
+    fn with_itinerary<F>(&self, person_id: PersonId, mut callback: F)
+    where
+        F: FnMut(&dyn SettingType, &SettingProperties, &Vec<PersonId>, f64),
+    {
+        if let Some(itinerary) = self.itineraries.get(&person_id) {
+            for entry in itinerary {
+                let setting_type = self.setting_types.get(&entry.setting_type).unwrap();
+                let setting_props = self.setting_properties.get(&entry.setting_type).unwrap();
+                let members = self
+                    .get_setting_members(&entry.setting_type, entry.setting_id)
+                    .unwrap();
+                callback(setting_type.as_ref(), setting_props, members, entry.ratio);
+            }
+        }
+    }
+}
+
+// Define a home setting
+#[derive(Default, Debug, Hash, Eq, PartialEq)]
+pub struct Home {}
+
+impl SettingType for Home {
+    // Read members and setting_properties as arguments
+    fn calculate_multiplier(
+        &self,
+        members: &[PersonId],
+        setting_properties: SettingProperties,
+    ) -> f64 {
+        let n_members = members.len();
+        #[allow(clippy::cast_precision_loss)]
+        ((n_members - 1) as f64).powf(setting_properties.alpha)
+    }
+}
+
+#[derive(Default, Debug, Hash, Eq, PartialEq)]
+pub struct CensusTract {}
+impl SettingType for CensusTract {
+    fn calculate_multiplier(
+        &self,
+        members: &[PersonId],
+        setting_properties: SettingProperties,
+    ) -> f64 {
+        let n_members = members.len();
+        #[allow(clippy::cast_precision_loss)]
+        ((n_members - 1) as f64).powf(setting_properties.alpha)
+    }
+}
+
+define_data_plugin!(
+    SettingDataPlugin,
+    SettingsDataContainer,
+    SettingsDataContainer::new()
+);
+
+#[allow(dead_code)]
+pub trait ContextSettingExt {
+    fn get_setting_properties<T: SettingType + 'static>(&self) -> SettingProperties;
+    fn register_setting_type<T: SettingType + 'static>(
+        &mut self,
+        setting: T,
+        setting_props: SettingProperties,
+    );
+    fn add_itinerary(
+        &mut self,
+        person_id: PersonId,
+        itinerary: Vec<ItineraryEntry>,
+    ) -> Result<(), IxaError>;
+    fn get_setting_members<T: SettingType + 'static>(
+        &self,
+        setting_id: SettingId<T>,
+    ) -> Option<&Vec<PersonId>>;
+    fn calculate_total_infectiousness_multiplier_for_person(&self, person_id: PersonId) -> f64;
+    fn get_itinerary(&self, person_id: PersonId) -> Option<&Vec<ItineraryEntry>>;
+    fn get_contact<T: SettingType + 'static>(
+        &self,
+        person_id: PersonId,
+        setting_id: SettingId<T>,
+    ) -> Option<PersonId>;
+    fn draw_contact_from_itinerary(&self, person_id: PersonId) -> Option<PersonId>;
+}
+
+trait ContextSettingInternalExt {
+    fn get_contact_internal(
+        &self,
+        person_id: PersonId,
+        setting_type: TypeId,
+        setting_id: usize,
+    ) -> Option<PersonId>;
+    fn get_setting_members_internal(
+        &self,
+        setting_type: TypeId,
+        setting_id: usize,
+    ) -> Option<&Vec<PersonId>>;
+}
+
+impl ContextSettingInternalExt for Context {
+    fn get_contact_internal(
+        &self,
+        person_id: PersonId,
+        setting_type: TypeId,
+        setting_id: usize,
+    ) -> Option<PersonId> {
+        if let Some(members) = self.get_setting_members_internal(setting_type, setting_id) {
+            if members.len() == 1 {
+                return None;
+            }
+            let mut contact_id = person_id;
+            while contact_id == person_id {
+                contact_id = members[self.sample_range(SettingsRng, 0..members.len())];
+            }
+            Some(contact_id)
+        } else {
+            None
+        }
+    }
+    fn get_setting_members_internal(
+        &self,
+        setting_type: TypeId,
+        setting_id: usize,
+    ) -> Option<&Vec<PersonId>> {
+        self.get_data_container(SettingDataPlugin)?
+            .get_setting_members(&setting_type, setting_id)
+    }
+}
+
+impl ContextSettingExt for Context {
+    fn get_setting_properties<T: SettingType + 'static>(&self) -> SettingProperties {
+        let data_container = self
+            .get_data_container(SettingDataPlugin)
+            .unwrap()
+            .setting_properties
+            .get(&TypeId::of::<T>())
+            .unwrap();
+        *data_container
+    }
+    fn register_setting_type<T: SettingType + 'static>(
+        &mut self,
+        setting_type: T,
+        setting_props: SettingProperties,
+    ) {
+        let container = self.get_data_container_mut(SettingDataPlugin);
+
+        // Add the setting
+        container
+            .setting_types
+            .insert(TypeId::of::<T>(), Box::new(setting_type));
+
+        // Add properties
+        container
+            .setting_properties
+            .insert(TypeId::of::<T>(), setting_props);
+    }
+    fn add_itinerary(
+        &mut self,
+        person_id: PersonId,
+        itinerary: Vec<ItineraryEntry>,
+    ) -> Result<(), IxaError> {
+        let container = self.get_data_container_mut(SettingDataPlugin);
+        // `setting_counts` maps `T: SettingType` to set of `SettingId<T>`,
+        // its list of setting instances for this person.
+        let mut setting_counts: HashMap<TypeId, HashSet<usize>> = HashMap::default();
+        for itinerary_entry in &itinerary {
+            let setting_id = itinerary_entry.setting_id;
+            let setting_type = itinerary_entry.setting_type;
+            if let Some(setting_count_set) = setting_counts.get(&setting_type) {
+                if setting_count_set.contains(&setting_id) {
+                    return Err(IxaError::from("Duplicated setting".to_string()));
+                }
+            }
+            #[allow(clippy::redundant_closure)]
+            setting_counts
+                .entry(setting_type)
+                .or_insert_with(|| HashSet::default())
+                .insert(setting_id);
+            // TODO: If we are changing a person's itinerary, the person_id should be removed from vector
+            // This isn't the same as the concept of being present or not.
+            #[allow(clippy::redundant_closure)]
+            container
+                .members
+                .entry(itinerary_entry.setting_type)
+                .or_insert_with(|| HashMap::default())
+                .entry(setting_id)
+                .or_insert_with(|| Vec::new())
+                .push(person_id);
+        }
+        container.itineraries.insert(person_id, itinerary);
+        Ok(())
+    }
+
+    fn get_setting_members<T: SettingType + 'static>(
+        &self,
+        setting_id: SettingId<T>,
+    ) -> Option<&Vec<PersonId>> {
+        self.get_data_container(SettingDataPlugin)?
+            .get_setting_members(&TypeId::of::<T>(), setting_id.id)
+    }
+
+    fn calculate_total_infectiousness_multiplier_for_person(&self, person_id: PersonId) -> f64 {
+        let container = self.get_data_container(SettingDataPlugin).unwrap();
+        let mut collector = 0.0;
+        container.with_itinerary(person_id, |setting_type, setting_props, members, ratio| {
+            let multiplier = setting_type.calculate_multiplier(members, *setting_props);
+            collector += ratio * multiplier;
+        });
+        collector
+    }
+
+    // Perhaps setting ids should include type and id so that one can have a vector of setting ids
+    fn get_itinerary(&self, person_id: PersonId) -> Option<&Vec<ItineraryEntry>> {
+        self.get_data_container(SettingDataPlugin)
+            .expect("Person should be added to settings")
+            .itineraries
+            .get(&person_id)
+    }
+
+    fn get_contact<T: SettingType + 'static>(
+        &self,
+        person_id: PersonId,
+        setting_id: SettingId<T>,
+    ) -> Option<PersonId> {
+        if let Some(members) = self.get_setting_members::<T>(setting_id) {
+            if members.len() == 1 {
+                return None;
+            }
+            let mut contact_id = person_id;
+            while contact_id == person_id {
+                contact_id = members[self.sample_range(SettingsRng, 0..members.len())];
+            }
+            Some(contact_id)
+        } else {
+            None
+        }
+    }
+    fn draw_contact_from_itinerary(&self, person_id: PersonId) -> Option<PersonId> {
+        let container = self.get_data_container(SettingDataPlugin).unwrap();
+        let mut itinerary_multiplier = Vec::new();
+        container.with_itinerary(person_id, |setting_type, setting_props, members, ratio| {
+            let multiplier = setting_type.calculate_multiplier(members, *setting_props);
+            itinerary_multiplier.push(ratio * multiplier);
+        });
+
+        let setting_index = self.sample_weighted(SettingsRng, &itinerary_multiplier);
+
+        if let Some(itinerary) = self.get_itinerary(person_id) {
+            let itinerary_entry = &itinerary[setting_index];
+            self.get_contact_internal(
+                person_id,
+                itinerary_entry.setting_type,
+                itinerary_entry.setting_id,
+            )
+        } else {
+            None
+        }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use crate::assert_almost_eq;
+    use crate::settings::ContextSettingExt;
+    use crate::ContextPeopleExt;
+    #[test]
+    fn test_setting_type_creation() {
+        let mut context = Context::new();
+        context.register_setting_type(Home {}, SettingProperties { alpha: 0.1 });
+        context.register_setting_type(CensusTract {}, SettingProperties { alpha: 0.001 });
+        let home_props = context.get_setting_properties::<Home>();
+        let tract_props = context.get_setting_properties::<CensusTract>();
+
+        assert_almost_eq!(0.1, home_props.alpha, 0.0);
+        assert_almost_eq!(0.001, tract_props.alpha, 0.0);
+    }
+
+    #[test]
+    fn test_duplicated_itinerary() {
+        let mut context = Context::new();
+        context.register_setting_type(Home {}, SettingProperties { alpha: 1.0 });
+        context.register_setting_type(CensusTract {}, SettingProperties { alpha: 1.0 });
+
+        // Different homes is ok. (Different person from person1 with same home is ok.)
+        let person0 = context.add_person(()).unwrap();
+        let itinerary0 = vec![
+            ItineraryEntry::new(&SettingId::<Home>::new(2), 0.5),
+            ItineraryEntry::new(&SettingId::<Home>::new(3), 0.5),
+        ];
+
+        // Same id but different setting type is ok.
+        let person1 = context.add_person(()).unwrap();
+        let itinerary1 = vec![
+            ItineraryEntry::new(&SettingId::<Home>::new(3), 0.5),
+            ItineraryEntry::new(&SettingId::<CensusTract>::new(3), 0.5),
+        ];
+
+        // Same ID and same setting type should be an error.
+        let person2 = context.add_person(()).unwrap();
+        let itinerary2 = vec![
+            ItineraryEntry::new(&SettingId::<Home>::new(2), 0.25),
+            ItineraryEntry::new(&SettingId::<Home>::new(2), 0.75),
+        ];
+
+        context
+            .add_itinerary(person0, itinerary0)
+            .expect("Failed to add itinerary");
+
+        context
+            .add_itinerary(person1, itinerary1)
+            .expect("Failed to add itinerary");
+
+        match context.add_itinerary(person2, itinerary2) {
+            Err(IxaError::IxaError(msg)) => {
+                assert_eq!(msg, "Duplicated setting");
+            }
+            Err(e) => panic!("Unexpected error in itinerary: {}", e),
+            Ok(_) => panic!("itinerary should be error"),
+        }
+    }
+
+    #[test]
+    fn test_add_itinerary() {
+        let mut context = Context::new();
+        context.register_setting_type(Home {}, SettingProperties { alpha: 1.0 });
+
+        let person = context.add_person(()).unwrap();
+        let itinerary = vec![
+            ItineraryEntry::new(&SettingId::<Home>::new(1), 0.5),
+            ItineraryEntry::new(&SettingId::<Home>::new(2), 0.5),
+        ];
+        let _ = context.add_itinerary(person, itinerary);
+        let members = context
+            .get_setting_members::<Home>(SettingId::<Home>::new(2))
+            .unwrap();
+        assert_eq!(members.len(), 1);
+
+        let person2 = context.add_person(()).unwrap();
+        let itinerary2 = vec![ItineraryEntry::new(&SettingId::<Home>::new(2), 1.0)];
+        let _ = context.add_itinerary(person2, itinerary2);
+
+        let members2 = context
+            .get_setting_members::<Home>(SettingId::<Home>::new(2))
+            .unwrap();
+        assert_eq!(members2.len(), 2);
+    }
+
+    #[test]
+    fn test_setting_registration() {
+        let mut context = Context::new();
+        context.register_setting_type(Home {}, SettingProperties { alpha: 0.1 });
+        context.register_setting_type(CensusTract {}, SettingProperties { alpha: 0.01 });
+        for s in 0..5 {
+            // Create 5 people
+            for _ in 0..5 {
+                let person = context.add_person(()).unwrap();
+                let itinerary = vec![
+                    ItineraryEntry::new(&SettingId::<Home>::new(s), 0.5),
+                    ItineraryEntry::new(&SettingId::<CensusTract>::new(s), 0.5),
+                ];
+                let _ = context.add_itinerary(person, itinerary);
+            }
+            let members = context
+                .get_setting_members::<Home>(SettingId::<Home>::new(s))
+                .unwrap();
+            let tract_members = context
+                .get_setting_members::<CensusTract>(SettingId::<CensusTract>::new(s))
+                .unwrap();
+            // Get the number of people for these settings and should be 5
+            assert_eq!(members.len(), 5);
+            assert_eq!(tract_members.len(), 5);
+        }
+    }
+
+    #[test]
+    fn test_setting_multiplier() {
+        // TODO: if setting not registered, shouldn't be able to register people to setting
+        let mut context = Context::new();
+        context.register_setting_type(Home {}, SettingProperties { alpha: 0.1 });
+        for s in 0..5 {
+            // Create 5 people
+            for _ in 0..5 {
+                let person = context.add_person(()).unwrap();
+                let itinerary = vec![ItineraryEntry::new(&SettingId::<Home>::new(s), 0.5)];
+                let _ = context.add_itinerary(person, itinerary);
+            }
+        }
+
+        let home_id = 0;
+        let person = context.add_person(()).unwrap();
+        let itinerary = vec![ItineraryEntry::new(&SettingId::<Home>::new(home_id), 0.5)];
+        let _ = context.add_itinerary(person, itinerary);
+        let members = context
+            .get_setting_members::<Home>(SettingId::<Home>::new(home_id))
+            .unwrap();
+
+        let setting_type = Home {};
+
+        let inf_multiplier =
+            setting_type.calculate_multiplier(members, SettingProperties { alpha: 0.1 });
+
+        // This is assuming we know what the function for Home is (N - 1) ^ alpha
+        assert_almost_eq!(inf_multiplier, f64::from(6 - 1).powf(0.1), 0.0);
+    }
+
+    #[test]
+    fn test_total_infectiousness_multiplier() {
+        // Go through all the settings and compute infectiousness multiplier
+        let mut context = Context::new();
+        context.register_setting_type(Home {}, SettingProperties { alpha: 0.1 });
+        context.register_setting_type(CensusTract {}, SettingProperties { alpha: 0.01 });
+
+        for s in 0..5 {
+            for _ in 0..5 {
+                let person = context.add_person(()).unwrap();
+                let itinerary = vec![
+                    ItineraryEntry::new(&SettingId::<Home>::new(s), 0.5),
+                    ItineraryEntry::new(&SettingId::<CensusTract>::new(s), 0.5),
+                ];
+                let _ = context.add_itinerary(person, itinerary);
+            }
+        }
+        // Create a new person and register to home 0
+        let itinerary = vec![ItineraryEntry::new(&SettingId::<Home>::new(0), 1.0)];
+        let person = context.add_person(()).unwrap();
+        let _ = context.add_itinerary(person, itinerary);
+
+        // If only registered at home, total infectiousness multiplier should be (6 - 1) ^ (alpha)
+        let inf_multiplier = context.calculate_total_infectiousness_multiplier_for_person(person);
+        assert_almost_eq!(inf_multiplier, f64::from(6 - 1).powf(0.1), 0.0);
+
+        // If person's itinerary is changed for two settings,
+        // CensusTract 0 should have 6 members, Home 0 should have 7 members
+        // the total infectiousness should be the sum of infs * proportion
+        let person = context.add_person(()).unwrap();
+        let itinerary_complete = vec![
+            ItineraryEntry::new(&SettingId::<Home>::new(0), 0.5),
+            ItineraryEntry::new(&SettingId::<CensusTract>::new(0), 0.5),
+        ];
+        let _ = context.add_itinerary(person, itinerary_complete);
+        let members_home = context
+            .get_setting_members::<Home>(SettingId::<Home>::new(0))
+            .unwrap();
+        let members_tract = context
+            .get_setting_members::<CensusTract>(SettingId::<CensusTract>::new(0))
+            .unwrap();
+        assert_eq!(members_home.len(), 7);
+        assert_eq!(members_tract.len(), 6);
+
+        let inf_multiplier_two_settings =
+            context.calculate_total_infectiousness_multiplier_for_person(person);
+
+        assert_almost_eq!(
+            inf_multiplier_two_settings,
+            (f64::from(7 - 1).powf(0.1)) * 0.5 + (f64::from(6 - 1).powf(0.01)) * 0.5,
+            0.0
+        );
+    }
+
+    #[test]
+    fn test_get_contact_from_setting() {
+        // Register two people to a setting and make sure that the person chosen is the other one
+        // Attempt to draw a contact from a setting with only the person trying to get a contact
+        // TODO: What happens if the person isn't registered in the setting?
+        let mut context = Context::new();
+        context.init_random(42);
+        context.register_setting_type(Home {}, SettingProperties { alpha: 0.1 });
+        context.register_setting_type(CensusTract {}, SettingProperties { alpha: 0.01 });
+
+        let person_a = context.add_person(()).unwrap();
+        let person_b = context.add_person(()).unwrap();
+        let itinerary_a = vec![
+            ItineraryEntry::new(&SettingId::<Home>::new(0), 0.5),
+            ItineraryEntry::new(&SettingId::<CensusTract>::new(0), 0.5),
+        ];
+        let itinerary_b = vec![ItineraryEntry::new(&SettingId::<Home>::new(0), 1.0)];
+        let _ = context.add_itinerary(person_a, itinerary_a);
+        let _ = context.add_itinerary(person_b, itinerary_b);
+
+        assert_eq!(
+            person_b,
+            context
+                .get_contact::<Home>(person_a, SettingId::<Home>::new(0))
+                .unwrap()
+        );
+        assert!(context
+            .get_contact::<CensusTract>(person_a, SettingId::<CensusTract>::new(0))
+            .is_none());
+    }
+
+    #[test]
+    fn test_draw_contact_from_itinerary() {
+        /*
+        Run 100 times
+        - Create 3 people at home, and 3 people at censustract
+        - Create 7th person with itinerary at home and census tract
+        - Call "draw contact from itinerary":
+          + Compute total infectiousness
+          + Draw a setting weighted by total infectiousness
+          + Sample contact from chosen setting
+         - Test 1 Itinerary with 0 proportion at census tract, contacts drawn should be from home (0-2)
+         - Test 2 Itinerary with 0 proportion at home, contacts should be drawn from census tract (3-6)
+        */
+        for seed in 0..100 {
+            let mut context = Context::new();
+            context.init_random(seed);
+            context.register_setting_type(Home {}, SettingProperties { alpha: 0.1 });
+            context.register_setting_type(CensusTract {}, SettingProperties { alpha: 0.01 });
+
+            for _ in 0..3 {
+                let person = context.add_person(()).unwrap();
+                let itinerary = vec![ItineraryEntry::new(&SettingId::<Home>::new(0), 1.0)];
+                let _ = context.add_itinerary(person, itinerary);
+            }
+
+            for _ in 0..3 {
+                let person = context.add_person(()).unwrap();
+                let itinerary = vec![ItineraryEntry::new(&SettingId::<CensusTract>::new(0), 1.0)];
+                let _ = context.add_itinerary(person, itinerary);
+            }
+
+            let person = context.add_person(()).unwrap();
+            let itinerary_home = vec![
+                ItineraryEntry::new(&SettingId::<Home>::new(0), 1.0),
+                ItineraryEntry::new(&SettingId::<CensusTract>::new(0), 0.0),
+            ];
+            let itinerary_censustract = vec![
+                ItineraryEntry::new(&SettingId::<Home>::new(0), 0.0),
+                ItineraryEntry::new(&SettingId::<CensusTract>::new(0), 1.0),
+            ];
+            let home_members = context
+                .get_setting_members::<Home>(SettingId::<Home>::new(0))
+                .unwrap()
+                .clone();
+            let tract_members = context
+                .get_setting_members::<CensusTract>(SettingId::<CensusTract>::new(0))
+                .unwrap()
+                .clone();
+
+            let _ = context.add_itinerary(person, itinerary_home);
+            let contact_id_home = context.draw_contact_from_itinerary(person);
+            assert!(home_members.contains(&contact_id_home.unwrap()));
+
+            let _ = context.add_itinerary(person, itinerary_censustract);
+            let contact_id_tract = context.draw_contact_from_itinerary(person);
+            assert!(tract_members.contains(&contact_id_tract.unwrap()));
+        }
+    }
+    /*TODO:
+    Test failure of getting properties if not initialized
+    Test failure if a setting is registered more than once?
+    Test that proportions either add to 1 or that they are weighted based on proportion
+    */
+}


### PR DESCRIPTION
Implements Settings ("groups"). This implementation is a lot simpler than the one in [epi-isolation](https://github.com/CDCgov/ixa-epi-isolation/blob/main/src/settings.rs). 

Some issues for discussion:

- Functions that exist in [[Epi-isolation](https://github.com/CDCgov/ixa-epi-isolation/blob/main/src/settings.rs)](https://github.com/CDCgov/ixa-epi-isolation/blob/main/src/settings.rs) but not implemented here:
  - `ContextSettingExt::calculate_total_infectiousness_multiplier_for_person` is only called in tests. Is this method needed?
  - a public getter for the `alpha`s - only used in tests
  - `get_setting_members` - only used in tests and private implementation
  - `get_contact` for a given person and setting -- only used to sample using itinerary
- Nothing enforces the constraint that $\displaystyle \sum_{ratio \in itinerary}ratio = 1$. We can either enforce the constraint or normalize. Right now we do neither.
- Do we need custom `calculate_multiplier()` functions for each setting category (a.k.a. `SettingType`)? Because all of them are computed using the same formula: $(n-1)^\alpha$ where `n` is the number of people in the setting. Can we just have a single function of $n$ and $\alpha$?