### PR TITLE
chore: Use glob pattern for workspace members

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,10 +1,6 @@
 [workspace]
 resolver = "2"
-members = [
-    "ixa-bench",
-    "ixa-derive",
-    "ixa-integration-tests",
-]
+members = ["ixa-*"]
 
 [workspace.package]
 edition = "2021"


### PR DESCRIPTION
Since we're adding more and more workspace crates...