### PR TITLE
chore: Declare workspace dependencies, which members inherit. Fixes #337.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,10 @@
 [workspace]
 resolver = "2"
-members = ["ixa-*"]
+members = [
+    "ixa-*",
+    "examples/basic-infection",
+    "examples/births-deaths"
+]
 
 [workspace.package]
 edition = "2021"
@@ -9,17 +13,7 @@ license = "Apache-2.0"
 homepage = "https://github.com/CDCgov/ixa"
 authors = ["The Ixa Developers <cfa@cdc.gov>"]
 
-[package]
-name = "ixa"
-version = "0.1.1"
-description = "A framework for building agent-based models"
-repository.workspace = true
-license.workspace = true
-edition.workspace = true
-homepage.workspace = true
-authors.workspace = true
-
-[dependencies]
+[workspace.dependencies]
 approx = "^0.5.1"
 rand = "^0.8.5"
 csv = "^1.3.1"
@@ -47,15 +41,60 @@ tower-http = { version = "^0.6.2", features = ["full"] }
 mime = "^0.3.17"
 rustc-hash = "^2.1.1"
 
-[dev-dependencies]
 rand_distr = "^0.4.3"
 tempfile = "^3.15.0"
 assert_cmd = "^2.0.16"
 criterion = "^0.5.1"
 roots = "0.0.8"
 assert_approx_eq = "1.1.0"
-ixa-integration-tests = { path = "./ixa-integration-tests" }
+strum = { version = "0.27", features = ["derive"] }
+quote = "^1.0.38"
+syn = "^2.0.95"
 
+
+[package]
+name = "ixa"
+version = "0.1.1"
+description = "A framework for building agent-based models"
+repository.workspace = true
+license.workspace = true
+edition.workspace = true
+homepage.workspace = true
+authors.workspace = true
+
+[dependencies]
+approx.workspace = true
+rand.workspace = true
+csv.workspace = true
+serde.workspace = true
+serde_derive.workspace = true
+serde_json.workspace = true
+bincode.workspace = true
+reikna.workspace = true
+ixa-derive.workspace = true
+seq-macro.workspace = true
+paste.workspace = true
+ctor.workspace = true
+clap.workspace = true
+shlex.workspace = true
+rustyline.workspace = true
+log.workspace = true
+log4rs.workspace = true
+axum.workspace = true
+tokio.workspace = true
+reqwest.workspace = true
+uuid.workspace = true
+tower-http.workspace = true
+mime.workspace = true
+rustc-hash.workspace = true
+
+[dev-dependencies]
+rand_distr.workspace = true
+tempfile.workspace = true
+assert_cmd.workspace = true
+criterion.workspace = true
+roots.workspace = true
+assert_approx_eq.workspace = true
 
 # Example Libraries
 ixa_example_basic_infection = { path = "examples/basic-infection" }

--- a/examples/basic-infection/Cargo.toml
+++ b/examples/basic-infection/Cargo.toml
@@ -13,11 +13,11 @@ publish = false
 ixa = { path = "../../../ixa" }
 ixa-derive = { path = "../../ixa-derive" }
 
-csv = "^1.3.1"
-serde = "^1.0.217"
-rand = "^0.8.5"
-rand_distr = "^0.4.3"
-paste = "^1.0.15"
+csv.workspace = true
+serde.workspace = true
+rand.workspace = true
+rand_distr.workspace = true
+paste.workspace = true
 
 [lints]
 workspace = true

--- a/examples/births-deaths/Cargo.toml
+++ b/examples/births-deaths/Cargo.toml
@@ -13,12 +13,12 @@ publish = false
 ixa = { path = "../../../ixa" }
 ixa-derive = { path = "../../ixa-derive" }
 
-csv = "^1.3.1"
-ctor = "^0.2.8"
-serde = "^1.0.217"
-rand = "^0.8.5"
-rand_distr = "^0.4.3"
-paste = "^1.0.15"
+csv.workspace = true
+ctor.workspace = true
+serde.workspace = true
+rand.workspace = true
+rand_distr.workspace = true
+paste.workspace = true
 
 [lints]
 workspace = true

--- a/ixa-bench/Cargo.toml
+++ b/ixa-bench/Cargo.toml
@@ -13,8 +13,8 @@ authors.workspace = true
 release = false
 
 [dev-dependencies]
-criterion = "^0.5.1"
-tempfile = "^3.15.0"
+criterion.workspace = true
+tempfile.workspace = true
 ixa = { path = "../" }
 
 ixa_example_basic_infection = { path = "../examples/basic-infection" }

--- a/ixa-derive/Cargo.toml
+++ b/ixa-derive/Cargo.toml
@@ -9,8 +9,8 @@ homepage.workspace = true
 authors.workspace = true
 
 [dependencies]
-quote = "^1.0.38"
-syn = "^2.0.95"
+quote.workspace = true
+syn.workspace = true
 
 [lints]
 workspace = true

--- a/ixa-fips/Cargo.toml
+++ b/ixa-fips/Cargo.toml
@@ -9,7 +9,7 @@ homepage.workspace = true
 authors.workspace = true
 
 [dependencies]
-strum = { version = "0.27", features = ["derive"] }
+strum .workspace = true
 
 [lints]
 workspace = true

--- a/ixa-integration-tests/Cargo.toml
+++ b/ixa-integration-tests/Cargo.toml
@@ -11,7 +11,7 @@ authors.workspace = true
 
 [dependencies]
 ixa = { path = "../" }
-clap = { version = "^4.5.26", features = ["derive"] }
+clap.workspace = true
 
 [dev-dependencies]
 assert_cmd = "^2.0.16"


### PR DESCRIPTION
Dependencies are now listed in `[workspace.dependencies]` in the root Cargo.toml and are inherited in workspace member packages that depend on them via `my_dependency.workspace = true`.

~This PR is stacked on top of #350.~ (merged)