### PR TITLE
Add dependabot.yaml. Closes #355.

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -9,7 +9,7 @@ updates:
     directory: "/" # Location of package manifests
     schedule:
       interval: "weekly"
-    versioning-strategy: "increase"
+    versioning-strategy: "auto"
     commit-message:
       prefix: "chore: "
   # Enable version updates for GitHub Actions


### PR DESCRIPTION
Same as in ixa-epi-isolation, but adding commit prefixes to be consistent with the conventional commits strategy.