### PR TITLE
feat: Added `FIPSError` for data out of range errors.

### DIFF
--- a/ixa-fips/README.md
+++ b/ixa-fips/README.md
@@ -34,6 +34,7 @@ are:
 | `FIPSCode`    | 64-bit value encoding state + county + tract + category + id *(10 spare bits for you)* |
 | `parser`      | Zero-allocation conversions <br/>`&str` ⇆ `FIPSCode` / fragments                       |
 | `USState`     | Exhaustive enum of valid state codes\* (fits in the 6 bits allocated by `FIPSCode`)    |
+| `FIPSError`   | Represents value out of range errors.                                                  |
 
 \* This is a minimal subset of FIPS state and state equivalent codes which have been stable for every FIPS standard
 revision so far. See the

--- a/ixa-fips/src/errors.rs
+++ b/ixa-fips/src/errors.rs
@@ -1,0 +1,117 @@
+//!
+//! We only have one error case, namely when a value is out of range. Instances of `FIPSError` are constructed
+//! with the `FIPSError::from_*_code()` constructor methods in the `FIPSCode::encode_*()` constructor methods.
+//!
+
+use crate::{CountyCode, DataCode, IdCode, SettingCategoryCode, StateCode, TractCode};
+use std::error::Error;
+use std::fmt::{Debug, Display, Formatter};
+
+#[derive(Copy, Clone, Eq, PartialEq, Hash, Debug)]
+pub struct FIPSError {
+    parameter_name: &'static str,
+    value: u64,
+    min: u64,
+    max: u64,
+}
+
+impl Display for FIPSError {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "value {} provided for {} is outside valid range of {}..{}",
+            self.value, self.parameter_name, self.min, self.max
+        )
+    }
+}
+
+impl Error for FIPSError {}
+
+impl FIPSError {
+    #[must_use]
+    pub fn new(parameter_name: &'static str, value: u64, min: u64, max: u64) -> Self {
+        Self {
+            parameter_name,
+            value,
+            min,
+            max,
+        }
+    }
+
+    // Convenience constructors for the code types. These should be kept in sync with the module-level documentation
+    // in `fips_code.rs`.
+
+    /// This one is unique in that it represents an error converting a (presumably valid) `StateCode` to a `USState`
+    /// variant. We lie a little bit and claim that values in 1..57 are valid when 3, 7, 14, 43, and 52 are not.
+    #[must_use]
+    pub fn from_us_state(value: StateCode) -> Self {
+        Self {
+            parameter_name: "USState Code",
+            value: value as u64,
+            min: 1,
+            max: 57, // 1..57
+        }
+    }
+
+    #[must_use]
+    pub fn from_state_code(value: StateCode) -> Self {
+        Self {
+            parameter_name: "StateCode",
+            value: value as u64,
+            min: 1,
+            max: 100, // Two decimal digits
+        }
+    }
+
+    #[must_use]
+    pub fn from_county_code(value: CountyCode) -> Self {
+        Self {
+            parameter_name: "CountyCode",
+            value: value as u64,
+            min: 0,
+            max: 1000, // Three decimal digits
+        }
+    }
+
+    #[must_use]
+    pub fn from_tract_code(value: TractCode) -> Self {
+        Self {
+            parameter_name: "TractCode",
+            value: value as u64,
+            min: 0,
+            max: 1_000_000, // Six decimal digits
+        }
+    }
+
+    #[must_use]
+    pub fn from_setting_category_code(value: SettingCategoryCode) -> Self {
+        Self {
+            parameter_name: "SettingCategoryCode",
+            value: value as u64,
+            min: 0,
+            max: 16, // 2^4
+        }
+    }
+
+    #[must_use]
+    pub fn from_id_code(value: IdCode) -> Self {
+        Self {
+            parameter_name: "IdCode",
+            value: value as u64,
+            min: 0,
+            max: 16_384, // 2^14
+        }
+    }
+
+    #[must_use]
+    pub fn from_data_code(value: DataCode) -> Self {
+        Self {
+            parameter_name: "DataCode",
+            value: value as u64,
+            min: 0,
+            max: 512, // 2^9
+        }
+    }
+}
+
+// Tested in `fips_code.rs`.

--- a/ixa-fips/src/lib.rs
+++ b/ixa-fips/src/lib.rs
@@ -17,10 +17,12 @@
 #![allow(clippy::cast_possible_truncation)]
 #![allow(clippy::cast_lossless)]
 
+mod errors;
 pub mod fips_code;
 pub mod parser;
 pub mod states;
 
+pub use errors::FIPSError;
 pub use fips_code::{ExpandedFIPSCode, FIPSCode};
 pub use states::USState;
 

--- a/ixa-fips/src/states.rs
+++ b/ixa-fips/src/states.rs
@@ -5,6 +5,7 @@
 //! Note that the `FIPSCode` encoded type only uses six bits to encode the state code, which can accommodate codes <= 63.
 //! Thus, it is best to only use `FIPSCode` for these states.
 
+use crate::errors::FIPSError;
 use crate::StateCode;
 use strum::{AsRefStr, FromRepr};
 
@@ -84,9 +85,9 @@ impl USState {
     }
 
     /// Returns the state for the given numeric FIPS code.
-    /// Returns `Err(())` if the code is invalid.
-    pub fn decode(value: StateCode) -> Result<USState, ()> {
-        Self::from_repr(value).ok_or(())
+    /// Returns `Err(FIPSError)` if the code is invalid.
+    pub fn decode(value: StateCode) -> Result<USState, FIPSError> {
+        Self::from_repr(value).ok_or(FIPSError::from_us_state(value))
     }
 }
 


### PR DESCRIPTION
Because the data ranges are nonobvious, I thought it would be helpful to have more helpful error messages when there is a data out of range error. 

- Added `FIPSError` for representing data out of range errors.
- Changed `FIPSCode::encode_*()` methods to validate according to the actual FIPS standard rather than the field's bitwidth, which is purely incidental.