### PR TITLE
Added the `'static` constraint to `PersonProperty`

### DIFF
--- a/src/people/context_extension.rs
+++ b/src/people/context_extension.rs
@@ -36,18 +36,15 @@ pub trait ContextPeopleExt {
     /// provided, and the property is not set this will panic, as long
     /// as the property has been set or subscribed to at least once before.
     /// Otherwise, Ixa doesn't know about the property.
-    fn get_person_property<T: PersonProperty + 'static>(
-        &self,
-        person_id: PersonId,
-        _property: T,
-    ) -> T::Value;
+    fn get_person_property<T: PersonProperty>(&self, person_id: PersonId, _property: T)
+        -> T::Value;
 
     #[doc(hidden)]
-    fn register_property<T: PersonProperty + 'static>(&self);
+    fn register_property<T: PersonProperty>(&self);
 
     /// Given a [`PersonId`], sets the value of a defined person property
     /// Panics if the property is not initialized. Fires a change event.
-    fn set_person_property<T: PersonProperty + 'static>(
+    fn set_person_property<T: PersonProperty>(
         &mut self,
         person_id: PersonId,
         _property: T,
@@ -61,7 +58,7 @@ pub trait ContextPeopleExt {
     /// Ixa may choose to create an index for its own reasons even if
     /// [`Context::index_property()`] is not called, so this function just ensures
     /// that one is created.
-    fn index_property<T: PersonProperty + 'static>(&mut self, property: T);
+    fn index_property<T: PersonProperty>(&mut self, property: T);
 
     /// Query for all people matching a given set of criteria.
     ///
@@ -130,11 +127,7 @@ impl ContextPeopleExt for Context {
         Ok(person_id)
     }
 
-    fn get_person_property<T: PersonProperty + 'static>(
-        &self,
-        person_id: PersonId,
-        property: T,
-    ) -> T::Value {
+    fn get_person_property<T: PersonProperty>(&self, person_id: PersonId, property: T) -> T::Value {
         let data_container = self.get_data_container(PeoplePlugin)
             .expect("PeoplePlugin is not initialized; make sure you add a person before accessing properties");
         self.register_property::<T>();
@@ -156,7 +149,7 @@ impl ContextPeopleExt for Context {
     }
 
     #[allow(clippy::single_match_else)]
-    fn set_person_property<T: PersonProperty + 'static>(
+    fn set_person_property<T: PersonProperty>(
         &mut self,
         person_id: PersonId,
         property: T,
@@ -242,7 +235,7 @@ impl ContextPeopleExt for Context {
         }
     }
 
-    fn index_property<T: PersonProperty + 'static>(&mut self, _property: T) {
+    fn index_property<T: PersonProperty>(&mut self, _property: T) {
         // Ensure that the data container exists
         {
             let _ = self.get_data_container_mut(PeoplePlugin);
@@ -309,7 +302,7 @@ impl ContextPeopleExt for Context {
         true
     }
 
-    fn register_property<T: PersonProperty + 'static>(&self) {
+    fn register_property<T: PersonProperty>(&self) {
         let data_container = self.get_data_container(PeoplePlugin).
             expect("PeoplePlugin is not initialized; make sure you add a person before accessing properties");
         if data_container
@@ -443,13 +436,9 @@ impl ContextPeopleExt for Context {
 }
 
 pub trait ContextPeopleExtInternal {
-    fn register_indexer<T: PersonProperty + 'static>(&self);
-    fn add_to_index_maybe<T: PersonProperty + 'static>(&mut self, person_id: PersonId, property: T);
-    fn remove_from_index_maybe<T: PersonProperty + 'static>(
-        &mut self,
-        person_id: PersonId,
-        property: T,
-    );
+    fn register_indexer<T: PersonProperty>(&self);
+    fn add_to_index_maybe<T: PersonProperty>(&mut self, person_id: PersonId, property: T);
+    fn remove_from_index_maybe<T: PersonProperty>(&mut self, person_id: PersonId, property: T);
     fn query_people_internal(
         &self,
         accumulator: impl FnMut(PersonId),
@@ -458,7 +447,7 @@ pub trait ContextPeopleExtInternal {
 }
 
 impl ContextPeopleExtInternal for Context {
-    fn register_indexer<T: PersonProperty + 'static>(&self) {
+    fn register_indexer<T: PersonProperty>(&self) {
         {
             let data_container = self.get_data_container(PeoplePlugin).unwrap();
 
@@ -475,11 +464,7 @@ impl ContextPeopleExtInternal for Context {
         property_indexes.insert(TypeId::of::<T>(), index);
     }
 
-    fn add_to_index_maybe<T: PersonProperty + 'static>(
-        &mut self,
-        person_id: PersonId,
-        property: T,
-    ) {
+    fn add_to_index_maybe<T: PersonProperty>(&mut self, person_id: PersonId, property: T) {
         let data_container = self.get_data_container(PeoplePlugin).unwrap();
 
         if let Some(mut index) = data_container.get_index_ref_mut_by_prop(property) {
@@ -490,11 +475,7 @@ impl ContextPeopleExtInternal for Context {
         }
     }
 
-    fn remove_from_index_maybe<T: PersonProperty + 'static>(
-        &mut self,
-        person_id: PersonId,
-        property: T,
-    ) {
+    fn remove_from_index_maybe<T: PersonProperty>(&mut self, person_id: PersonId, property: T) {
         let data_container = self.get_data_container(PeoplePlugin).unwrap();
 
         if let Some(mut index) = data_container.get_index_ref_mut_by_prop(property) {

--- a/src/people/data.rs
+++ b/src/people/data.rs
@@ -18,7 +18,7 @@ pub(super) struct StoredPeopleProperties {
 }
 
 impl StoredPeopleProperties {
-    fn new<T: PersonProperty + 'static>() -> Self {
+    fn new<T: PersonProperty>() -> Self {
         StoredPeopleProperties {
             is_required: T::is_required(),
             values: Box::<Vec<Option<T::Value>>>::default(),
@@ -69,7 +69,7 @@ pub trait PersonPropertyHolder {
 
 impl<T> PersonPropertyHolder for T
 where
-    T: PersonProperty + 'static,
+    T: PersonProperty,
 {
     fn dependency_changed(
         &self,
@@ -143,7 +143,7 @@ impl PeopleData {
     /// Returns `RefMut<Option<T::Value>>`: `Some(value)` if the property exists for the given person,
     /// or `None` if it doesn't.
     #[allow(clippy::needless_pass_by_value)]
-    pub(super) fn get_person_property_ref<T: PersonProperty + 'static>(
+    pub(super) fn get_person_property_ref<T: PersonProperty>(
         &self,
         person: PersonId,
         _property: T,
@@ -167,7 +167,7 @@ impl PeopleData {
 
     /// Sets the value of a property for a person
     #[allow(clippy::needless_pass_by_value)]
-    pub(super) fn set_person_property<T: PersonProperty + 'static>(
+    pub(super) fn set_person_property<T: PersonProperty>(
         &self,
         person_id: PersonId,
         property: T,
@@ -195,7 +195,7 @@ impl PeopleData {
         }
     }
 
-    pub(super) fn get_index_ref_mut_by_prop<T: PersonProperty + 'static>(
+    pub(super) fn get_index_ref_mut_by_prop<T: PersonProperty>(
         &self,
         _property: T,
     ) -> Option<RefMut<Index>> {

--- a/src/people/event.rs
+++ b/src/people/event.rs
@@ -24,7 +24,7 @@ pub struct PersonPropertyChangeEvent<T: PersonProperty> {
     pub previous: T::Value,
 }
 
-impl<T: PersonProperty + 'static> IxaEvent for PersonPropertyChangeEvent<T> {
+impl<T: PersonProperty> IxaEvent for PersonPropertyChangeEvent<T> {
     fn on_subscribe(context: &mut Context) {
         if T::is_derived() {
             let _ = context.get_data_container_mut(PeoplePlugin); // make sure the plugin is initialized

--- a/src/people/index.rs
+++ b/src/people/index.rs
@@ -72,7 +72,7 @@ pub struct Index {
 }
 
 impl Index {
-    pub(super) fn new<T: PersonProperty + 'static>(_context: &Context, _property: T) -> Self {
+    pub(super) fn new<T: PersonProperty>(_context: &Context, _property: T) -> Self {
         Self {
             name: std::any::type_name::<T>(),
             lookup: None,
@@ -139,10 +139,7 @@ pub static MULTI_PROPERTY_INDEX_MAP: LazyLock<
 > = LazyLock::new(|| Mutex::new(RefCell::new(HashMap::new())));
 
 #[allow(dead_code)]
-pub fn add_multi_property_index<T: PersonProperty + 'static>(
-    property_ids: &[TypeId],
-    index_type: TypeId,
-) {
+pub fn add_multi_property_index<T: PersonProperty>(property_ids: &[TypeId], index_type: TypeId) {
     let current_map = MULTI_PROPERTY_INDEX_MAP.lock().unwrap();
     let mut map = current_map.borrow_mut();
     let mut ordered_property_ids = property_ids.to_owned();

--- a/src/people/methods.rs
+++ b/src/people/methods.rs
@@ -14,7 +14,7 @@ pub(crate) struct Methods {
 }
 
 impl Methods {
-    pub(super) fn new<T: PersonProperty + 'static>() -> Self {
+    pub(super) fn new<T: PersonProperty>() -> Self {
         Self {
             indexer: Box::new(move |context: &Context, person_id: PersonId| {
                 let value = context.get_person_property(person_id, T::get_instance());

--- a/src/people/mod.rs
+++ b/src/people/mod.rs
@@ -144,7 +144,7 @@ impl InitializationList for () {
     fn set_properties(&self, _context: &mut Context, _person_id: PersonId) {}
 }
 
-impl<T1: PersonProperty + 'static> InitializationList for (T1, T1::Value) {
+impl<T1: PersonProperty> InitializationList for (T1, T1::Value) {
     fn has_property(&self, t: TypeId) -> bool {
         t == TypeId::of::<T1>()
     }
@@ -160,7 +160,7 @@ macro_rules! impl_initialization_list {
         seq!(N in 0..$ct {
             impl<
                 #(
-                    T~N : PersonProperty + 'static,
+                    T~N : PersonProperty,
                 )*
             > InitializationList for (
                 #(

--- a/src/people/property.rs
+++ b/src/people/property.rs
@@ -9,7 +9,7 @@ use std::fmt::Debug;
 /// Person properties should be defined with the [`define_person_property!()`],
 /// [`define_person_property_with_default!()`] and [`define_derived_property!()`]
 /// macros.
-pub trait PersonProperty: Copy {
+pub trait PersonProperty: Copy + 'static {
     type Value: Copy + Debug + PartialEq + Serialize;
     #[must_use]
     fn is_derived() -> bool {

--- a/src/people/query.rs
+++ b/src/people/query.rs
@@ -22,7 +22,7 @@ impl Query for () {
 }
 
 // Implement the query version with one parameter.
-impl<T1: PersonProperty + 'static> Query for (T1, T1::Value) {
+impl<T1: PersonProperty> Query for (T1, T1::Value) {
     fn setup(&self, context: &Context) {
         context.register_property::<T1>();
     }
@@ -38,7 +38,7 @@ macro_rules! impl_query {
         seq!(N in 0..$ct {
             impl<
                 #(
-                    T~N : PersonProperty + 'static,
+                    T~N : PersonProperty,
                 )*
             > Query for (
                 #(

--- a/src/tabulator.rs
+++ b/src/tabulator.rs
@@ -10,7 +10,7 @@ pub trait Tabulator {
     fn get_columns(&self) -> Vec<String>;
 }
 
-impl<T: PersonProperty + 'static> Tabulator for (T,) {
+impl<T: PersonProperty> Tabulator for (T,) {
     fn setup(&self, context: &Context) -> Result<(), IxaError> {
         context.register_property::<T>();
         context.index_property_by_id(std::any::TypeId::of::<T>());
@@ -29,7 +29,7 @@ macro_rules! impl_tabulator {
         seq!(N in 0..$ct {
             impl<
                 #(
-                    T~N : PersonProperty + 'static,
+                    T~N : PersonProperty,
                 )*
             > Tabulator for (
                 #(


### PR DESCRIPTION
We have `PersonProperty + 'static` all over our public API. This PR adds the `'static` constraint to the `PersonProperty` trait itself and replaces all instances of `PersonProperty + 'static` with just `PersonProperty`:

```rust
pub trait PersonProperty: Copy + 'static {
    // ...
}
```