### PR TITLE
chore: Exposed dependencies for use in macros. Fixes 352.

### DIFF
--- a/examples/basic-infection/Cargo.toml
+++ b/examples/basic-infection/Cargo.toml
@@ -13,11 +13,8 @@ publish = false
 ixa = { path = "../../../ixa" }
 ixa-derive = { path = "../../ixa-derive" }
 
-csv.workspace = true
 serde.workspace = true
-rand.workspace = true
 rand_distr.workspace = true
-paste.workspace = true
 
 [lints]
 workspace = true

--- a/examples/births-deaths/Cargo.toml
+++ b/examples/births-deaths/Cargo.toml
@@ -13,12 +13,8 @@ publish = false
 ixa = { path = "../../../ixa" }
 ixa-derive = { path = "../../ixa-derive" }
 
-csv.workspace = true
-ctor.workspace = true
 serde.workspace = true
-rand.workspace = true
 rand_distr.workspace = true
-paste.workspace = true
 
 [lints]
 workspace = true

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -70,6 +70,7 @@ pub mod prelude;
 pub mod web_api;
 
 // Re-export for macros
+pub use csv;
 pub use ctor;
 pub use paste;
 pub use rand;

--- a/src/report.rs
+++ b/src/report.rs
@@ -77,7 +77,7 @@ macro_rules! create_report_trait {
                 std::any::TypeId::of::<$name>()
             }
 
-            fn serialize(&self, writer: &mut csv::Writer<std::fs::File>) {
+            fn serialize(&self, writer: &mut $crate::csv::Writer<std::fs::File>) {
                 writer.serialize(self).unwrap();
             }
         }


### PR DESCRIPTION
Exposed dependencies for use in macros.
Modified dependencies of `births-deaths` and `basic-infection` accordingly.