### PR TITLE
Integrating book feedback closes #317

### DIFF
--- a/docs/book/models/disease_model/src/incidence_report.rs
+++ b/docs/book/models/disease_model/src/incidence_report.rs
@@ -1,18 +1,25 @@
+//ANCHOR: imports
 use crate::{infection_manager::InfectionStatusEvent, people::InfectionStatusValue};
 use csv;
 use ixa::{prelude::*, trace, PersonId, Report};
 use serde::{Deserialize, Serialize};
 use std::path::PathBuf;
+//ANCHOR_END: imports
 
+//ANCHOR: IncidenceReportItem
 #[derive(Serialize, Deserialize, Clone)]
 struct IncidenceReportItem {
     time: f64,
     person_id: PersonId,
     infection_status: InfectionStatusValue,
 }
+//ANCHOR_END: IncidenceReportItem
 
+//ANCHOR: create_report_trait
 create_report_trait!(IncidenceReportItem);
+//ANCHOR_END: create_report_trait
 
+//ANCHOR: handle_infection_status_change
 fn handle_infection_status_change(context: &mut Context, event: InfectionStatusEvent) {
     trace!(
         "Recording infection status change from {:?} to {:?} for {:?}",
@@ -26,7 +33,9 @@ fn handle_infection_status_change(context: &mut Context, event: InfectionStatusE
         infection_status: event.current,
     });
 }
+//ANCHOR_END: handle_infection_status_change
 
+// ANCHOR: init
 pub fn init(context: &mut Context) -> Result<(), IxaError> {
     trace!("Initializing incidence_report");
 
@@ -42,3 +51,4 @@ pub fn init(context: &mut Context) -> Result<(), IxaError> {
     context.subscribe_to_event::<InfectionStatusEvent>(handle_infection_status_change);
     Ok(())
 }
+// ANCHOR_END: init

--- a/docs/book/models/disease_model/src/infection_manager.rs
+++ b/docs/book/models/disease_model/src/infection_manager.rs
@@ -5,10 +5,12 @@ use rand_distr::Exp;
 use crate::people::{InfectionStatus, InfectionStatusValue};
 use crate::INFECTION_DURATION;
 
+// ANCHOR: infection_status_event
 pub type InfectionStatusEvent = PersonPropertyChangeEvent<InfectionStatus>;
-
+// ANCHOR_END: infection_status_event
 define_rng!(InfectionRng);
 
+// ANCHOR: schedule_recovery
 fn schedule_recovery(context: &mut Context, person_id: PersonId) {
     trace!("Scheduling recovery");
     let recovery_time = context.get_current_time()
@@ -21,7 +23,9 @@ fn schedule_recovery(context: &mut Context, person_id: PersonId) {
         );
     });
 }
+// ANCHOR_END: schedule_recovery
 
+// ANCHOR: handle_infection_status_change
 fn handle_infection_status_change(context: &mut Context, event: InfectionStatusEvent) {
     trace!(
         "Handling infection status change from {:?} to {:?} for {:?}",
@@ -33,8 +37,11 @@ fn handle_infection_status_change(context: &mut Context, event: InfectionStatusE
         schedule_recovery(context, event.person_id);
     }
 }
+// ANCHOR_END: handle_infection_status_change
 
+// ANCHOR: init
 pub fn init(context: &mut Context) {
     trace!("Initializing infection_manager");
     context.subscribe_to_event::<InfectionStatusEvent>(handle_infection_status_change);
 }
+// ANCHOR_END: init

--- a/docs/book/models/disease_model/src/main.rs
+++ b/docs/book/models/disease_model/src/main.rs
@@ -12,6 +12,11 @@ static INFECTION_DURATION: f64 = 10.0;
 
 fn main() {
     let result = run_with_args(|context: &mut Context, _args, _| {
+        // Add a plan to shut down the simulation after `max_time`, regardless of
+        // what else is happening in the model.
+        context.add_plan(MAX_TIME, |context| {
+            context.shutdown();
+        });
         people::init(context);
         transmission_manager::init(context);
         infection_manager::init(context);

--- a/docs/book/models/disease_model/src/people.rs
+++ b/docs/book/models/disease_model/src/people.rs
@@ -1,20 +1,26 @@
+/* ANCHOR: all */
 use crate::POPULATION;
 use ixa::{prelude::*, trace};
 use serde::{Deserialize, Serialize};
 
+// ANCHOR: InfectionStatusValue
 #[derive(Debug, Hash, Eq, PartialEq, Clone, Copy, Serialize, Deserialize)]
 pub enum InfectionStatusValue {
     S,
     I,
     R,
 }
+// ANCHOR_END: InfectionStatusValue
 
+//ANCHOR: define_person_property
 define_person_property_with_default!(
     InfectionStatus,         // Property Name
     InfectionStatusValue,    // Type of the Property Values
     InfectionStatusValue::S  // Default value used when a person is added to the simulation
 );
+// ANCHOR_END: define_person_property
 
+// ANCHOR: init
 /// Populates the "world" with the `POPULATION` number of people.
 pub fn init(context: &mut Context) {
     trace!("Initializing people");
@@ -22,3 +28,5 @@ pub fn init(context: &mut Context) {
         context.add_person(()).expect("failed to add person");
     }
 }
+// ANCHOR_END: init
+/* ANCHOR_END: all */

--- a/docs/book/models/disease_model/src/transmission_manager.rs
+++ b/docs/book/models/disease_model/src/transmission_manager.rs
@@ -1,35 +1,36 @@
+// ANCHOR: imports
 use rand_distr::Exp;
 
 use ixa::{prelude::*, trace, PersonId};
 
 use crate::people::{InfectionStatus, InfectionStatusValue};
 use crate::FORCE_OF_INFECTION;
-use crate::MAX_TIME;
 use crate::POPULATION;
 
 define_rng!(TransmissionRng);
+// ANCHOR_END: imports
 
+// ANCHOR: attempt_infection
 fn attempt_infection(context: &mut Context) {
     trace!("Attempting infection");
 
-    let person_to_infect: PersonId = context.sample_person(TransmissionRng, ()).unwrap();
-    let person_status: InfectionStatusValue =
-        context.get_person_property(person_to_infect, InfectionStatus);
+    if let Some(person_to_infect) = context.sample_person(TransmissionRng, ()) {
+        let person_status: InfectionStatusValue =
+            context.get_person_property(person_to_infect, InfectionStatus);
 
-    if person_status == InfectionStatusValue::S {
-        context.set_person_property::<InfectionStatus>(
-            person_to_infect,
-            InfectionStatus,
-            InfectionStatusValue::I,
-        );
-    }
+        if person_status == InfectionStatusValue::S {
+            context.set_person_property::<InfectionStatus>(
+                person_to_infect,
+                InfectionStatus,
+                InfectionStatusValue::I,
+            );
+        }
 
-    #[allow(clippy::cast_precision_loss)]
-    let next_attempt_time = context.get_current_time()
-        + context.sample_distr(TransmissionRng, Exp::new(FORCE_OF_INFECTION).unwrap())
-            / POPULATION as f64;
+        #[allow(clippy::cast_precision_loss)]
+        let next_attempt_time = context.get_current_time()
+            + context.sample_distr(TransmissionRng, Exp::new(FORCE_OF_INFECTION).unwrap())
+                / POPULATION as f64;
 
-    if next_attempt_time <= MAX_TIME {
         context.add_plan(next_attempt_time, attempt_infection);
     }
 }
@@ -38,3 +39,4 @@ pub fn init(context: &mut Context) {
     trace!("Initializing transmission manager");
     context.add_plan(0.0, attempt_infection);
 }
+// ANCHOR_END: attempt_infection

--- a/docs/book/src/first_model/infection.md
+++ b/docs/book/src/first_model/infection.md
@@ -8,21 +8,21 @@ Modules can subscribe to events. The infection manager registers a function with
 
 ```rust
 // in infection_manager.rs
-{{#rustdoc_include ../../models/disease_model/src/infection_manager.rs:8}}
+{{#rustdoc_include ../../models/disease_model/src/infection_manager.rs:infection_status_event}}
 ```
 
 This line isn't defining a new struct or even a new type. Rather, it defines an alias for `PersonPropertyChangeEvent\<T>` with the generic type  `T` instantiated with the property we want to monitor, `InfectionStatus`. This is effectively the name of the event we subscribe to in the module's `init()` function:
 
 ```rust
 // in infection_manager.rs
-{{#rustdoc_include ../../models/disease_model/src/infection_manager.rs:37:40}}
+{{#rustdoc_include ../../models/disease_model/src/infection_manager.rs:init}}
 ```
 
 The event handler is just a regular Rust function that takes a `Context` and an `InfectionStatusEvent`, the latter of which holds the `PersonId` of the person whose `InfectionStatus` changed, the current `InfectionStatusValue`, and the previous `InfectionStatusValue`.
 
 ```rust
 // in infection_manager.rs
-{{#rustdoc_include ../../models/disease_model/src/infection_manager.rs:25:35}}
+{{#rustdoc_include ../../models/disease_model/src/infection_manager.rs:handle_infection_status_change}}
 ```
 
 We only care about new infections in this model.
@@ -32,7 +32,7 @@ We only care about new infections in this model.
 As in `attempt_infection()`, we sample the recovery time from the exponential distribution with mean `INFECTION_DURATION`. We define a random number source for this module's exclusive use with `define_rng!(InfectionRng)`.
 
 ```rust
-{{#rustdoc_include ../../models/disease_model/src/infection_manager.rs:12:23}}
+{{#rustdoc_include ../../models/disease_model/src/infection_manager.rs:schedule_recovery}}
 ```
 
 Notice that the plan is again just a Rust function, but this time it takes the form of a closure rather than a traditionally define function. This is convenient when the function is only a line or two.

--- a/docs/book/src/first_model/next-steps.md
+++ b/docs/book/src/first_model/next-steps.md
@@ -9,6 +9,6 @@ We have created several new modules. We need to make sure they are each initiali
 
 Exercises:
 
-1. Currently the simulation runs until `MAX_TIME` has passed even if every single person has been infected and has recovered. Add a check somewhere that calls `context.shutdown()` if there is no more work for the simulation to do. Where should this check live?
+1. Currently the simulation runs until `MAX_TIME` even if every single person has been infected and has recovered. Add a check somewhere that calls `context.shutdown()` if there is no more work for the simulation to do. Where should this check live? Hint: take a look at the methods available to through `ContextPeopleExt`.
 2. Analyze the data output by the incident reporter. Plot the number of people with each `InfectionStatus` on the same axis to see how they change over the course of the simulation. Are the curves what we expect to see given our abstract model?
 3. Add another person property that moderates the risk of infection of the individual. (Imagine, for example, people wearing face masks for an airborne illness.) Give a randomly sampled subpopulation that intervention, and add a check to the transmission module to see if the person that we are attempting to infect has that property. Change the probability of infection accordingly.

--- a/docs/book/src/first_model/people.md
+++ b/docs/book/src/first_model/people.md
@@ -10,7 +10,7 @@ Ixa is a framework for developing *agent*-based models. In most of our models, t
 ## `PersonProperty`
 
 ```rust
-{{#rustdoc_include ../../models/disease_model/src/people.rs:5:10}}
+{{#rustdoc_include ../../models/disease_model/src/people.rs:InfectionStatusValue}}
 ```
 
 To each person we will associate a value of the enum (short for “enumeration”) named `InfectionStatusValue`. An enum is a way to create a type that can be one of several predefined values. Here, we have three values:
@@ -34,7 +34,7 @@ The attributes written above the enum declaration, such as `#[derive(Debug, Hash
 All of our "person properties" in our models will "derive" these attributes. It is not enough to define this enum. We have to tell Ixa that it will be a `PersonProperty`:
 
 ```rust
-{{#rustdoc_include ../../models/disease_model/src/people.rs:12:16}}
+{{#rustdoc_include ../../models/disease_model/src/people.rs:define_person_property}}
 ```
 
 > [!NOTE] Name Tags and Values
@@ -71,7 +71,7 @@ The `context.add_person()` method call might look a little odd, because we are n
 Having "magic numbers" embedded in your code, such as the constant `1000` here representing the total number of people in our model, is ***bad practice***. What if we want to change this value later? Will we even be able to find it in all of our source code? Ixa has a formal mechanism for managing these kinds of model parameters, but for now we will just define a "static constant" near the top of `src/main.rs` named `POPULATION` and replace the literal `1000` with `POPULATION`:
 
 ```rust
-{{#rustdoc_include ../../models/disease_model/src/people.rs:18:24}}
+{{#rustdoc_include ../../models/disease_model/src/people.rs:init}}
 ```
 
 Let's revisit `src/main.rs`:
@@ -90,5 +90,5 @@ Turning back to `src/people.rs`, your IDE might have been complaining to you abo
 
 ```rust
 //people.rs
-{{#rustdoc_include ../../models/disease_model/src/people.rs}}
+{{#rustdoc_include ../../models/disease_model/src/people.rs:all}}
 ```

--- a/docs/book/src/first_model/reporter.md
+++ b/docs/book/src/first_model/reporter.md
@@ -6,19 +6,19 @@ Our model will only have a single report that records the current in-simulation 
 
 ```rust
 // in incidence_report.rs
-{{#rustdoc_include ../../models/disease_model/src/incidence_report.rs:7:12}}
+{{#rustdoc_include ../../models/disease_model/src/incidence_report.rs:IncidenceReportItem}}
 ```
 
 The fact that `IncidenceReportItem` derives `Serialize` is what makes this magic work. We define a report for this struct using the `create_report_trait!` macro.
 
 ```rust
-{{#rustdoc_include ../../models/disease_model/src/incidence_report.rs:14}}
+{{#rustdoc_include ../../models/disease_model/src/incidence_report.rs:create_report_trait}}
 ```
 
 The way we listen to events is almost identical to how we did it in the `infection` module. First let's make the event handler, that is, the callback that will be called whenever an event is emitted.
 
 ```rust
-{{#rustdoc_include ../../models/disease_model/src/incidence_report.rs:16:28}}
+{{#rustdoc_include ../../models/disease_model/src/incidence_report.rs:handle_infection_status_change}}
 ```
 
 Just pass a `IncidenceReportItem` to `context.send_report()`! We also emit a trace log message so we can trace the execution of our model.
@@ -26,7 +26,7 @@ Just pass a `IncidenceReportItem` to `context.send_report()`! We also emit a tra
 In the `init()` function there is a little bit of setup needed. Also, we can't forget to register this callback to listen to `InfectionStatusEvent`s.
 
 ```rust
-{{#rustdoc_include ../../models/disease_model/src/incidence_report.rs:30:44}}
+{{#rustdoc_include ../../models/disease_model/src/incidence_report.rs:init}}
 ```
 
 Note that:
@@ -43,5 +43,5 @@ Note that:
 If your IDE isn't capable of adding imports for you, the external symbols we need for this module are as follows.
 
 ```rust
-{{#rustdoc_include ../../models/disease_model/src/incidence_report.rs:1:5}}
+{{#rustdoc_include ../../models/disease_model/src/incidence_report.rs:imports}}
 ```

--- a/docs/book/src/first_model/setup.md
+++ b/docs/book/src/first_model/setup.md
@@ -149,8 +149,7 @@ cargo run -- --log-level disease_model=trace
 >
 > - Turn log messages on and off as needed.
 > - Enable only messages with a specified priority (for example, only warnings or higher).
-> - Filter messages to show only those emitted from a specific module, like the `people` module we write in the next
-    section.
+> - Filter messages to show only those emitted from a specific module, like the `people` module we write in the next section.
 >
 > See the logging documentation for more details.
 > [!INFO] Command Line Arguments

--- a/docs/book/src/first_model/transmission.md
+++ b/docs/book/src/first_model/transmission.md
@@ -56,7 +56,7 @@ The function `attempt_infection()` needs to do the following:
 
 Read through this implementation and make sure you understand how it accomplishes the three tasks above. A few observations:
 
-- The method `context.sample_person(())` returns an `Option\<PersonId>`, which can have the value of `PersonId` or `None`. In this case, `if let Some(person_to_infect)` evaluates the `Option\<PersonId>` and continues into the following block of code if a `PersonId` is found.
+- The method `context.sample_person(())` returns an `Option\<PersonId>`, which can have the value of `PersonId` or `None`. In this case, `if let Some(person_to_infect)` matches against the `Option\<PersonId>` and continues into the following block of code if a `PersonId` is found.
 - The `#[allow(clippy::cast_precision_loss)]` is optional; without it the compiler will warn you about converting `population` 's integral type `usize` to the floating point type `f64`, but we know that this conversion is safe to do in this context.
 - If the sampled person is not susceptible, then the only thing this function does is schedule the next attempt at infection.
 - The time at which the next attempt is scheduled is sampled randomly from the exponential distribution according to our abstract model and using the random number source `TransmissionRng` that we defined specifically for this purpose.

--- a/docs/book/src/first_model/transmission.md
+++ b/docs/book/src/first_model/transmission.md
@@ -31,7 +31,6 @@ use ixa::Context;
 
 static POPULATION: u64 = 1000;
 static FORCE_OF_INFECTION: f64 = 0.1;
-static MAX_TIME: f64 = 300.0;
 // ...the rest of the file...
 ```
 
@@ -41,7 +40,7 @@ We need to import these constants into `transmission_manager`. To define a new r
 
 ```rust
 // transmission_manager.rs
-{{#rustdoc_include ../../models/disease_model/src/transmission_manager.rs:1:10}}
+{{#rustdoc_include ../../models/disease_model/src/transmission_manager.rs:imports}}
 // ...the rest of the file...
 ```
 
@@ -52,11 +51,12 @@ The function `attempt_infection()` needs to do the following:
 3. Schedule the next infection attempt by inserting a plan into the timeline that will run `attempt_infection()` again.
 
 ```rust
-{{#rustdoc_include ../../models/disease_model/src/transmission_manager.rs:12:41}}
+{{#rustdoc_include ../../models/disease_model/src/transmission_manager.rs:attempt_infection}}
 ```
 
 Read through this implementation and make sure you understand how it accomplishes the three tasks above. A few observations:
 
+- The method `context.sample_person(())` returns an `Option\<PersonId>`, which can have the value of `PersonId` or `None`. In this case, `if let Some(person_to_infect)` evaluates the `Option\<PersonId>` and continues into the following block of code if a `PersonId` is found.
 - The `#[allow(clippy::cast_precision_loss)]` is optional; without it the compiler will warn you about converting `population` 's integral type `usize` to the floating point type `f64`, but we know that this conversion is safe to do in this context.
 - If the sampled person is not susceptible, then the only thing this function does is schedule the next attempt at infection.
 - The time at which the next attempt is scheduled is sampled randomly from the exponential distribution according to our abstract model and using the random number source `TransmissionRng` that we defined specifically for this purpose.


### PR DESCRIPTION
This PR addresses issue #317. It removes `MAX_TIME` from the transmission manager and adds a plan in main to end the simulation. The exercise remains the same with slightly modified language, and encourages people to explore the `ContextPeopleExt` functionality. It also introduces the `if let Some()` pattern.

The rust snippets of code are also now linked using ANCHORs rather than line numbers to improve robustness. 