### PR TITLE
feat: Wasm Compatibility, including a new Wasm logger

### DIFF
--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -23,8 +23,12 @@ jobs:
             ~/.cargo/git/db/
             target/
           key: cargo-${{ hashFiles('Cargo.toml') }}
+      - name: Install wasm32 target
+        run: rustup target add wasm32-unknown-unknown
       - name: Build
         run: cargo build --verbose
+      - name: Build Wasm
+        run: cargo build --verbose --target wasm32-unknown-unknown --no-default-features --features logging
       - name: Build benchmarks
         run: cargo bench -p ixa-bench --no-run
       - name: Run tests

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,6 +52,10 @@ quote = "^1.0.38"
 syn = "^2.0.95"
 delegate = "^0.13.3"
 
+console_log = "^1.0"
+fern = "0.7.1"
+getrandom = "0.2"
+
 [package]
 name = "ixa"
 version = "0.1.2"
@@ -63,8 +67,14 @@ homepage.workspace = true
 authors.workspace = true
 
 [features]
-default = ["debugger"]
+default = ["wasm"]
 
+# `wasm` is pairwise mutually exclusive with `standard_logging`, `debugger`, and `web_api`. When `wasm` is enabled,
+# the JS logger is used.
+wasm = ["getrandom"]
+
+# `standard_logging` is mutually exclusive with the `wasm` feature. This feature enables logging with the `log4rs` crate.
+standard_logging = ["log4rs"]
 debugger = ["shlex", "rustyline"]
 web_api = ["debugger", "mime", "tower-http", "axum", "tokio", "uuid"]
 
@@ -74,9 +84,10 @@ bincode.workspace = true
 clap.workspace = true
 csv.workspace = true
 ctor.workspace = true
+#fern = { workspace = true, optional = true }
 ixa-derive.workspace = true
 log.workspace = true
-log4rs.workspace = true
+log4rs = { workspace = true, optional = true }
 paste.workspace = true
 rand.workspace = true
 rustc-hash.workspace = true
@@ -85,6 +96,9 @@ serde.workspace = true
 serde_derive.workspace = true
 serde_json.workspace = true
 delegate.workspace = true
+
+# WASM
+getrandom = { workspace = true,  optional = true, features = ["js"] }
 
 # Debugger
 rustyline = { workspace = true, optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -68,14 +68,9 @@ homepage.workspace = true
 authors.workspace = true
 
 [features]
-default = ["wasm"]
+default = ["logging"]
 
-# `wasm` is pairwise mutually exclusive with `standard_logging`, `debugger`, and `web_api`. When `wasm` is enabled,
-# the JS logger is used.
-wasm = ["getrandom", "web-sys", "console_log", "fern"]
-
-# `standard_logging` is mutually exclusive with the `wasm` feature. This feature enables logging with the `log4rs` crate.
-standard_logging = ["log4rs"]
+logging = ["log4rs", "console_log", "fern"]
 debugger = ["shlex", "rustyline"]
 web_api = ["debugger", "mime", "tower-http", "axum", "tokio", "uuid"]
 
@@ -87,7 +82,6 @@ csv.workspace = true
 ctor.workspace = true
 ixa-derive.workspace = true
 log.workspace = true
-log4rs = { workspace = true, optional = true }
 paste.workspace = true
 rand.workspace = true
 rustc-hash.workspace = true
@@ -97,15 +91,15 @@ serde_derive.workspace = true
 serde_json.workspace = true
 delegate.workspace = true
 
-# WASM
-getrandom = { workspace = true,  optional = true, features = ["js"] }
-web-sys = { workspace = true, optional = true }
-console_log = { workspace = true, optional = true, features = ["color"] }
-fern = { workspace = true, optional = true }
+# Non-WASM targets
+[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
+# Logging
+log4rs = { workspace = true, optional = true }
 
 # Debugger
 rustyline = { workspace = true, optional = true }
 shlex = { workspace = true, optional = true }
+
 # Web API
 axum = { workspace = true, optional = true }
 mime = { workspace = true, optional = true }
@@ -113,6 +107,11 @@ tokio = { workspace = true, optional = true }
 tower-http = { workspace = true, optional = true }
 uuid = { workspace = true, optional = true }
 
+[target.'cfg(target_arch = "wasm32")'.dependencies]
+console_log = { workspace = true, optional = true, features = ["color"] }
+fern = { workspace = true, optional = true }
+getrandom = { workspace = true,  features = ["js"] }
+web-sys = { workspace = true }
 
 [dev-dependencies]
 assert_approx_eq.workspace = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,8 +53,9 @@ syn = "^2.0.95"
 delegate = "^0.13.3"
 
 console_log = "^1.0"
-fern = "0.7.1"
+web-sys = "0.3"
 getrandom = "0.2"
+fern = "0.7"
 
 [package]
 name = "ixa"
@@ -71,7 +72,7 @@ default = ["wasm"]
 
 # `wasm` is pairwise mutually exclusive with `standard_logging`, `debugger`, and `web_api`. When `wasm` is enabled,
 # the JS logger is used.
-wasm = ["getrandom"]
+wasm = ["getrandom", "web-sys", "console_log", "fern"]
 
 # `standard_logging` is mutually exclusive with the `wasm` feature. This feature enables logging with the `log4rs` crate.
 standard_logging = ["log4rs"]
@@ -84,7 +85,6 @@ bincode.workspace = true
 clap.workspace = true
 csv.workspace = true
 ctor.workspace = true
-#fern = { workspace = true, optional = true }
 ixa-derive.workspace = true
 log.workspace = true
 log4rs = { workspace = true, optional = true }
@@ -99,6 +99,9 @@ delegate.workspace = true
 
 # WASM
 getrandom = { workspace = true,  optional = true, features = ["js"] }
+web-sys = { workspace = true, optional = true }
+console_log = { workspace = true, optional = true, features = ["color"] }
+fern = { workspace = true, optional = true }
 
 # Debugger
 rustyline = { workspace = true, optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,10 +52,10 @@ quote = "^1.0.38"
 syn = "^2.0.95"
 delegate = "^0.13.3"
 
-console_log = "^1.0"
 web-sys = "0.3"
 getrandom = "0.2"
 fern = "0.7"
+wasm-bindgen = "0.2"
 
 [package]
 name = "ixa"
@@ -70,7 +70,7 @@ authors.workspace = true
 [features]
 default = ["logging"]
 
-logging = ["log4rs", "console_log", "fern"]
+logging = ["log4rs", "fern", "wasm-bindgen",  "web-sys"]
 debugger = ["shlex", "rustyline"]
 web_api = ["debugger", "mime", "tower-http", "axum", "tokio", "uuid"]
 
@@ -108,10 +108,10 @@ tower-http = { workspace = true, optional = true }
 uuid = { workspace = true, optional = true }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
-console_log = { workspace = true, optional = true, features = ["color"] }
 fern = { workspace = true, optional = true }
 getrandom = { workspace = true,  features = ["js"] }
-web-sys = { workspace = true }
+wasm-bindgen = { workspace = true, optional = true }
+web-sys = { workspace = true, optional = true, features = ["console"]  }
 
 [dev-dependencies]
 assert_approx_eq.workspace = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -68,7 +68,7 @@ homepage.workspace = true
 authors.workspace = true
 
 [features]
-default = ["logging"]
+default = ["logging", "debugger"]
 
 logging = ["log4rs", "fern", "wasm-bindgen",  "web-sys"]
 debugger = ["shlex", "rustyline"]

--- a/ixa-integration-tests/Cargo.toml
+++ b/ixa-integration-tests/Cargo.toml
@@ -10,7 +10,7 @@ homepage.workspace = true
 authors.workspace = true
 
 [dependencies]
-ixa = { path = "../" }
+ixa = { path = "../", features = ["logging", "debugger"] }
 clap.workspace = true
 
 [dev-dependencies]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -102,3 +102,9 @@ pub mod prelude_for_plugins {
     pub use crate::IxaEvent;
     pub use ixa_derive::IxaEvent;
 }
+
+#[cfg(all(feature = "wasm", feature = "debugger"))]
+compile_error!("Features `wasm` and `debugger` are mutually exclusive — enable at most one.");
+
+#[cfg(all(feature = "wasm", feature = "standard_logging"))]
+compile_error!("Features `wasm` and `standard_logging` are mutually exclusive — enable at most one.");

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -103,8 +103,7 @@ pub mod prelude_for_plugins {
     pub use ixa_derive::IxaEvent;
 }
 
-#[cfg(all(feature = "wasm", feature = "debugger"))]
-compile_error!("Features `wasm` and `debugger` are mutually exclusive — enable at most one.");
-
-#[cfg(all(feature = "wasm", feature = "standard_logging"))]
-compile_error!("Features `wasm` and `standard_logging` are mutually exclusive — enable at most one.");
+#[cfg(all(target_arch = "wasm32", feature = "debugger"))]
+compile_error!(
+    "Target `wasm32` and feature `debugger` are mutually exclusive — enable at most one."
+);

--- a/src/log/mod.rs
+++ b/src/log/mod.rs
@@ -45,9 +45,9 @@ mod standard_logger;
 
 #[cfg(feature = "wasm")]
 // Use `wasm` logging
-// mod wasm_logger;
+mod wasm_logger;
 
-// #[cfg(not(any(feature = "wasm", feature = "standard_logging")))]
+#[cfg(not(any(feature = "wasm", feature = "standard_logging")))]
 // No logging
 mod null_logger;
 
@@ -68,8 +68,10 @@ const DEFAULT_MODULE_FILTERS: [(&str, LevelFilter); 1] = [
     // `rustyline` logs are noisy.
     ("rustyline", LevelFilter::Off),
 ];
+
+#[cfg(feature = "standard_logging")]
 // Use an ISO 8601 timestamp format and color coded level tag
-// const DEFAULT_LOG_PATTERN: &str = "{d(%Y-%m-%dT%H:%M:%SZ)} {h({l})} {t} - {m}{n}";
+const DEFAULT_LOG_PATTERN: &str = "{d(%Y-%m-%dT%H:%M:%SZ)} {h({l})} {t} - {m}{n}";
 
 /// A global instance of the logging configuration.
 static LOG_CONFIGURATION: LazyLock<Mutex<LogConfiguration>> = LazyLock::new(Mutex::default);
@@ -112,8 +114,9 @@ pub(in crate::log) struct LogConfiguration {
     /// Handle to the `log4rs` logger.
     root_handle: Option<Handle>,
     
-    // #[cfg(feature = "wasm")]
-    // root_handle: 
+    #[cfg(feature = "wasm")]
+    initialized: bool,
+    
 }
 
 impl Default for LogConfiguration {
@@ -127,6 +130,9 @@ impl Default for LogConfiguration {
             
             #[cfg(feature = "standard_logging")]
             root_handle: None,
+
+            #[cfg(feature = "wasm")]
+            initialized: false,
         }
     }
 }

--- a/src/log/mod.rs
+++ b/src/log/mod.rs
@@ -39,15 +39,15 @@
 //!     set_module_filter("transmission_manager", LevelFilter::Trace);
 //! }
 //! ```
-#[cfg(feature = "standard_logging")]
+#[cfg(all(not(target_arch = "wasm32"), feature = "logging"))]
 // Use `log4rs` logging
 mod standard_logger;
 
-#[cfg(feature = "wasm")]
+#[cfg(all(target_arch = "wasm32", feature = "logging"))]
 // Use `wasm` logging
 mod wasm_logger;
 
-#[cfg(not(any(feature = "wasm", feature = "standard_logging")))]
+#[cfg(not(feature = "logging"))]
 // No logging
 mod null_logger;
 
@@ -57,7 +57,7 @@ pub use log::{debug, error, info, trace, warn, LevelFilter};
 
 use std::sync::LazyLock;
 use std::sync::{Mutex, MutexGuard};
-#[cfg(feature = "standard_logging")]
+#[cfg(all(not(target_arch = "wasm32"), feature = "logging"))]
 use log4rs::Handle;
 use crate::HashMap;
 
@@ -69,7 +69,7 @@ const DEFAULT_MODULE_FILTERS: [(&str, LevelFilter); 1] = [
     ("rustyline", LevelFilter::Off),
 ];
 
-#[cfg(feature = "standard_logging")]
+#[cfg(all(not(target_arch = "wasm32"), feature = "logging"))]
 // Use an ISO 8601 timestamp format and color coded level tag
 const DEFAULT_LOG_PATTERN: &str = "{d(%Y-%m-%dT%H:%M:%SZ)} {h({l})} {t} - {m}{n}";
 
@@ -109,12 +109,12 @@ pub(in crate::log) struct LogConfiguration {
     /// global filter level of `LevelFilter::Off` disables logging.
     pub(in crate::log) global_log_level: LevelFilter,
     pub(in crate::log) module_configurations: HashMap<String, ModuleLogConfiguration>,
-    
-    #[cfg(feature = "standard_logging")]
+
+    #[cfg(all(not(target_arch = "wasm32"), feature = "logging"))]
     /// Handle to the `log4rs` logger.
     root_handle: Option<Handle>,
-    
-    #[cfg(feature = "wasm")]
+
+    #[cfg(all(target_arch = "wasm32", feature = "logging"))]
     initialized: bool,
     
 }
@@ -127,11 +127,11 @@ impl Default for LogConfiguration {
         Self {
             global_log_level: DEFAULT_LOG_LEVEL,
             module_configurations,
-            
-            #[cfg(feature = "standard_logging")]
+
+            #[cfg(all(not(target_arch = "wasm32"), feature = "logging"))]
             root_handle: None,
 
-            #[cfg(feature = "wasm")]
+            #[cfg(all(target_arch = "wasm32", feature = "logging"))]
             initialized: false,
         }
     }

--- a/src/log/mod.rs
+++ b/src/log/mod.rs
@@ -40,26 +40,22 @@
 //! }
 //! ```
 #[cfg(all(not(target_arch = "wasm32"), feature = "logging"))]
-// Use `log4rs` logging
 mod standard_logger;
 
 #[cfg(all(target_arch = "wasm32", feature = "logging"))]
-// Use `wasm` logging
 mod wasm_logger;
 
 #[cfg(not(feature = "logging"))]
-// No logging
 mod null_logger;
 
-use std::collections::hash_map::Entry;
 pub use log::{debug, error, info, trace, warn, LevelFilter};
+use std::collections::hash_map::Entry;
 
-
-use std::sync::LazyLock;
-use std::sync::{Mutex, MutexGuard};
+use crate::HashMap;
 #[cfg(all(not(target_arch = "wasm32"), feature = "logging"))]
 use log4rs::Handle;
-use crate::HashMap;
+use std::sync::LazyLock;
+use std::sync::{Mutex, MutexGuard};
 
 // Logging disabled
 const DEFAULT_LOG_LEVEL: LevelFilter = LevelFilter::Off;
@@ -68,10 +64,6 @@ const DEFAULT_MODULE_FILTERS: [(&str, LevelFilter); 1] = [
     // `rustyline` logs are noisy.
     ("rustyline", LevelFilter::Off),
 ];
-
-#[cfg(all(not(target_arch = "wasm32"), feature = "logging"))]
-// Use an ISO 8601 timestamp format and color coded level tag
-const DEFAULT_LOG_PATTERN: &str = "{d(%Y-%m-%dT%H:%M:%SZ)} {h({l})} {t} - {m}{n}";
 
 /// A global instance of the logging configuration.
 static LOG_CONFIGURATION: LazyLock<Mutex<LogConfiguration>> = LazyLock::new(Mutex::default);
@@ -96,7 +88,6 @@ impl From<(&str, LevelFilter)> for ModuleLogConfiguration {
     }
 }
 
-
 /// Holds logging configuration. It's primary responsibility is to keep track of the filter levels
 /// of modules and hold a handle to the global logger.
 ///
@@ -116,7 +107,6 @@ pub(in crate::log) struct LogConfiguration {
 
     #[cfg(all(target_arch = "wasm32", feature = "logging"))]
     initialized: bool,
-    
 }
 
 impl Default for LogConfiguration {
@@ -138,7 +128,6 @@ impl Default for LogConfiguration {
 }
 
 impl LogConfiguration {
-
     pub(in crate::log) fn set_log_level(&mut self, level: LevelFilter) {
         self.global_log_level = level;
         self.set_config();
@@ -196,7 +185,6 @@ impl LogConfiguration {
         }
     }
 }
-
 
 // The public API
 

--- a/src/log/mod.rs
+++ b/src/log/mod.rs
@@ -42,7 +42,7 @@
 #[cfg(all(not(target_arch = "wasm32"), feature = "logging"))]
 mod standard_logger;
 
-#[cfg(all(target_arch = "wasm32", feature = "logging"))]
+#[cfg(any(all(target_arch = "wasm32", feature = "logging"), test))]
 mod wasm_logger;
 
 #[cfg(not(feature = "logging"))]

--- a/src/log/mod.rs
+++ b/src/log/mod.rs
@@ -39,19 +39,27 @@
 //!     set_module_filter("transmission_manager", LevelFilter::Trace);
 //! }
 //! ```
+#[cfg(feature = "standard_logging")]
+// Use `log4rs` logging
+mod standard_logger;
 
+#[cfg(feature = "wasm")]
+// Use `wasm` logging
+// mod wasm_logger;
+
+// #[cfg(not(any(feature = "wasm", feature = "standard_logging")))]
+// No logging
+mod null_logger;
+
+use std::collections::hash_map::Entry;
 pub use log::{debug, error, info, trace, warn, LevelFilter};
 
-use crate::HashMap;
-use log4rs;
-use log4rs::append::console::ConsoleAppender;
-use log4rs::config::runtime::ConfigBuilder;
-use log4rs::config::{Appender, Logger, Root};
-use log4rs::encode::pattern::PatternEncoder;
-use log4rs::{Config, Handle};
-use std::collections::hash_map::Entry;
+
 use std::sync::LazyLock;
 use std::sync::{Mutex, MutexGuard};
+#[cfg(feature = "standard_logging")]
+use log4rs::Handle;
+use crate::HashMap;
 
 // Logging disabled
 const DEFAULT_LOG_LEVEL: LevelFilter = LevelFilter::Off;
@@ -61,7 +69,7 @@ const DEFAULT_MODULE_FILTERS: [(&str, LevelFilter); 1] = [
     ("rustyline", LevelFilter::Off),
 ];
 // Use an ISO 8601 timestamp format and color coded level tag
-const DEFAULT_LOG_PATTERN: &str = "{d(%Y-%m-%dT%H:%M:%SZ)} {h({l})} {t} - {m}{n}";
+// const DEFAULT_LOG_PATTERN: &str = "{d(%Y-%m-%dT%H:%M:%SZ)} {h({l})} {t} - {m}{n}";
 
 /// A global instance of the logging configuration.
 static LOG_CONFIGURATION: LazyLock<Mutex<LogConfiguration>> = LazyLock::new(Mutex::default);
@@ -86,11 +94,6 @@ impl From<(&str, LevelFilter)> for ModuleLogConfiguration {
     }
 }
 
-impl From<&ModuleLogConfiguration> for Logger {
-    fn from(module_config: &ModuleLogConfiguration) -> Self {
-        Logger::builder().build(module_config.module.clone(), module_config.level)
-    }
-}
 
 /// Holds logging configuration. It's primary responsibility is to keep track of the filter levels
 /// of modules and hold a handle to the global logger.
@@ -99,12 +102,18 @@ impl From<&ModuleLogConfiguration> for Logger {
 /// public API are free functions which fetch the singleton and call the appropriate member
 /// function.
 #[derive(Debug)]
-struct LogConfiguration {
+pub(in crate::log) struct LogConfiguration {
     /// The "default" level filter for modules ("targets") without an explicitly set filter. A
     /// global filter level of `LevelFilter::Off` disables logging.
-    global_log_level: LevelFilter,
-    module_configurations: HashMap<String, ModuleLogConfiguration>,
+    pub(in crate::log) global_log_level: LevelFilter,
+    pub(in crate::log) module_configurations: HashMap<String, ModuleLogConfiguration>,
+    
+    #[cfg(feature = "standard_logging")]
+    /// Handle to the `log4rs` logger.
     root_handle: Option<Handle>,
+    
+    // #[cfg(feature = "wasm")]
+    // root_handle: 
 }
 
 impl Default for LogConfiguration {
@@ -115,48 +124,14 @@ impl Default for LogConfiguration {
         Self {
             global_log_level: DEFAULT_LOG_LEVEL,
             module_configurations,
+            
+            #[cfg(feature = "standard_logging")]
             root_handle: None,
         }
     }
 }
 
 impl LogConfiguration {
-    /// Sets the global logger to conform to this `LogConfiguration`.
-    fn set_config(&mut self) {
-        let stdout: ConsoleAppender = ConsoleAppender::builder()
-            .encoder(Box::new(PatternEncoder::new(DEFAULT_LOG_PATTERN)))
-            .build();
-        let mut config: ConfigBuilder =
-            Config::builder().appender(Appender::builder().build("stdout", Box::new(stdout)));
-
-        // Add module specific configuration
-        for module_config in self.module_configurations.values() {
-            config = config.logger(module_config.into());
-        }
-
-        // The `Root` determines the global log level
-        let root = Root::builder()
-            .appender("stdout")
-            .build(self.global_log_level);
-        let new_config = match config.build(root) {
-            Err(e) => {
-                panic!("failed to build config: {e}");
-            }
-            Ok(config) => config,
-        };
-
-        match self.root_handle {
-            Some(ref mut handle) => {
-                // The global logger has already been initialized
-                handle.set_config(new_config);
-            }
-
-            None => {
-                // The global logger has not yet been initialized
-                self.root_handle = Some(log4rs::init_config(new_config).unwrap());
-            }
-        }
-    }
 
     pub(in crate::log) fn set_log_level(&mut self, level: LevelFilter) {
         self.global_log_level = level;
@@ -215,6 +190,9 @@ impl LogConfiguration {
         }
     }
 }
+
+
+// The public API
 
 /// Enables the logger with no global level filter / full logging. Equivalent to
 /// `set_log_level(LevelFilter::Trace)`.

--- a/src/log/null_logger.rs
+++ b/src/log/null_logger.rs
@@ -4,7 +4,7 @@ This module provides a "logger" that does not output anything anywhere but satis
 
 */
 
-use crate::log::{LogConfiguration};
+use crate::log::LogConfiguration;
 
 impl LogConfiguration {
     /// Sets the global logger to conform to this `LogConfiguration`.

--- a/src/log/null_logger.rs
+++ b/src/log/null_logger.rs
@@ -1,0 +1,15 @@
+/*!
+
+This module provides a "logger" that does not output anything anywhere but satisfies the public API.
+
+*/
+
+use crate::log::{LogConfiguration};
+
+impl LogConfiguration {
+    /// Sets the global logger to conform to this `LogConfiguration`.
+    pub(in crate::log) fn set_config(&mut self) {
+        // No global logger. We still keep up appearances.
+        log::set_max_level(self.global_log_level);
+    }
+}

--- a/src/log/standard_logger.rs
+++ b/src/log/standard_logger.rs
@@ -1,0 +1,59 @@
+use crate::log::{LogConfiguration, ModuleLogConfiguration, DEFAULT_LOG_PATTERN};
+use log::LevelFilter;
+use log4rs::{
+    config::{
+        runtime::ConfigBuilder,
+        Appender,
+        Logger,
+        Root
+    },
+    append::console::ConsoleAppender,
+    encode::pattern::PatternEncoder,
+    Config
+};
+use std::collections::hash_map::Entry;
+
+impl From<&ModuleLogConfiguration> for Logger {
+    fn from(module_config: &ModuleLogConfiguration) -> Self {
+        Logger::builder().build(module_config.module.clone(), module_config.level)
+    }
+}
+
+impl LogConfiguration {
+    /// Sets the global logger to conform to this `LogConfiguration`.
+    fn set_config(&mut self) {
+        let stdout: ConsoleAppender = ConsoleAppender::builder()
+            .encoder(Box::new(PatternEncoder::new(DEFAULT_LOG_PATTERN)))
+            .build();
+        let mut config: ConfigBuilder =
+            Config::builder().appender(Appender::builder().build("stdout", Box::new(stdout)));
+
+        // Add module specific configuration
+        for module_config in self.module_configurations.values() {
+            config = config.logger(module_config.into());
+        }
+
+        // The `Root` determines the global log level
+        let root = Root::builder()
+            .appender("stdout")
+            .build(self.global_log_level);
+        let new_config = match config.build(root) {
+            Err(e) => {
+                panic!("failed to build config: {e}");
+            }
+            Ok(config) => config,
+        };
+
+        match self.root_handle {
+            Some(ref mut handle) => {
+                // The global logger has already been initialized
+                handle.set_config(new_config);
+            }
+
+            None => {
+                // The global logger has not yet been initialized
+                self.root_handle = Some(log4rs::init_config(new_config).unwrap());
+            }
+        }
+    }
+}

--- a/src/log/standard_logger.rs
+++ b/src/log/standard_logger.rs
@@ -1,5 +1,4 @@
 use crate::log::{LogConfiguration, ModuleLogConfiguration, DEFAULT_LOG_PATTERN};
-use log::LevelFilter;
 use log4rs::{
     config::{
         runtime::ConfigBuilder,
@@ -11,7 +10,7 @@ use log4rs::{
     encode::pattern::PatternEncoder,
     Config
 };
-use std::collections::hash_map::Entry;
+
 
 impl From<&ModuleLogConfiguration> for Logger {
     fn from(module_config: &ModuleLogConfiguration) -> Self {
@@ -21,7 +20,7 @@ impl From<&ModuleLogConfiguration> for Logger {
 
 impl LogConfiguration {
     /// Sets the global logger to conform to this `LogConfiguration`.
-    fn set_config(&mut self) {
+    pub(in crate::log) fn set_config(&mut self) {
         let stdout: ConsoleAppender = ConsoleAppender::builder()
             .encoder(Box::new(PatternEncoder::new(DEFAULT_LOG_PATTERN)))
             .build();

--- a/src/log/standard_logger.rs
+++ b/src/log/standard_logger.rs
@@ -1,16 +1,10 @@
-use crate::log::{LogConfiguration, ModuleLogConfiguration, DEFAULT_LOG_PATTERN};
+use crate::log::{LogConfiguration, ModuleLogConfiguration};
 use log4rs::{
-    config::{
-        runtime::ConfigBuilder,
-        Appender,
-        Logger,
-        Root
-    },
     append::console::ConsoleAppender,
+    config::{runtime::ConfigBuilder, Appender, Logger, Root},
     encode::pattern::PatternEncoder,
-    Config
+    Config,
 };
-
 
 impl From<&ModuleLogConfiguration> for Logger {
     fn from(module_config: &ModuleLogConfiguration) -> Self {
@@ -56,3 +50,7 @@ impl LogConfiguration {
         }
     }
 }
+
+#[cfg(all(not(target_arch = "wasm32"), feature = "logging"))]
+// Use an ISO 8601 timestamp format and color coded level tag
+const DEFAULT_LOG_PATTERN: &str = "{d(%Y-%m-%dT%H:%M:%SZ)} {h({l})} {t} - {m}{n}";

--- a/src/log/standard_logger.rs
+++ b/src/log/standard_logger.rs
@@ -6,6 +6,9 @@ use log4rs::{
     Config,
 };
 
+// Use an ISO 8601 timestamp format and color coded level tag
+const DEFAULT_LOG_PATTERN: &str = "{d(%Y-%m-%dT%H:%M:%SZ)} {h({l})} {t} - {m}{n}";
+
 impl From<&ModuleLogConfiguration> for Logger {
     fn from(module_config: &ModuleLogConfiguration) -> Self {
         Logger::builder().build(module_config.module.clone(), module_config.level)
@@ -50,7 +53,3 @@ impl LogConfiguration {
         }
     }
 }
-
-#[cfg(all(not(target_arch = "wasm32"), feature = "logging"))]
-// Use an ISO 8601 timestamp format and color coded level tag
-const DEFAULT_LOG_PATTERN: &str = "{d(%Y-%m-%dT%H:%M:%SZ)} {h({l})} {t} - {m}{n}";

--- a/src/log/wasm_logger.rs
+++ b/src/log/wasm_logger.rs
@@ -1,0 +1,47 @@
+/*!
+
+A logger for WASM builds.
+
+*/
+
+use crate::log::{LogConfiguration, ModuleLogConfiguration, DEFAULT_LOG_PATTERN};
+use fern::{Dispatch, FormatCallback};
+use log::{LevelFilter, Record};
+use std::io;
+use std::time::{SystemTime, UNIX_EPOCH};
+use std::fmt::Arguments;
+
+fn format_timestamp() -> String {
+    let now = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default();
+    format!("{}.{:03}Z", now.as_secs(), now.subsec_millis())
+}
+
+impl LogConfiguration {
+    /// Sets up logging using `fern` according to this configuration.
+    pub fn set_config(&self) {
+        let formatter = move |out: FormatCallback, message: &Arguments, record: &Record| {
+            out.finish(format_args!(
+                "{} [{}] {}",
+                format_timestamp(),
+                record.level(),
+                message
+            ))
+        };
+
+        // Start the base dispatcher
+        let mut base = Dispatch::new()
+            .format(formatter)
+            .level(self.global_log_level)
+            .chain(io::stdout());
+
+        // Add per-module overrides
+        for (module_name, module_config) in &self.module_configurations {
+            base = base.level_for(module_name.clone(), module_config.level);
+        }
+
+        // Apply the configuration
+        base.apply().expect("Failed to initialize fern logger");
+    }
+}

--- a/src/log/wasm_logger.rs
+++ b/src/log/wasm_logger.rs
@@ -1,20 +1,15 @@
 /*!
 
-A logger for WASM builds.
+A logger for WASM builds that logs to the JavaScript console.
 
 */
 
 use crate::log::{LogConfiguration, ModuleLogConfiguration, LOG_CONFIGURATION};
-use log::{LevelFilter};
-use std::time::{SystemTime, UNIX_EPOCH};
 use fern::Dispatch;
-
-// fn format_timestamp() -> String {
-//     let now = SystemTime::now()
-//         .duration_since(UNIX_EPOCH)
-//         .unwrap_or_default();
-//     format!("{}.{:03}Z", now.as_secs(), now.subsec_millis())
-// }
+use log::LevelFilter;
+use log::{Level, Record};
+use wasm_bindgen::JsValue;
+use web_sys::console;
 
 impl LogConfiguration {
     pub fn set_config(&mut self) {
@@ -22,7 +17,7 @@ impl LogConfiguration {
             self.init()
         }
     }
-    
+
     fn init(&mut self) {
         // Setup fern with custom filtering and formatting
         Dispatch::new()
@@ -31,7 +26,7 @@ impl LogConfiguration {
                 let config = LOG_CONFIGURATION.lock().unwrap();
                 config.should_log(metadata.target(), metadata.level())
             })
-            .chain(fern::Output::call(console_log::log))
+            .chain(fern::Output::call(log_to_browser_console))
             .apply()
             .expect("Could not set up logging");
         self.initialized = true;
@@ -42,16 +37,81 @@ impl LogConfiguration {
         let mut longest_match = None;
         for (prefix, config) in &self.module_configurations {
             if target.starts_with(prefix)
-                && longest_match.as_ref().map_or(true, |(m, _): &(&String, &ModuleLogConfiguration)| m.len() < prefix.len())
+                && longest_match
+                    .as_ref()
+                    .map_or(true, |(m, _): &(&String, &ModuleLogConfiguration)| {
+                        m.len() < prefix.len()
+                    })
             {
                 longest_match = Some((prefix, config));
             }
         }
 
         match longest_match {
-            Some((_, ModuleLogConfiguration { level: module_level, .. })) => level <= *module_level,
+            Some((
+                _,
+                ModuleLogConfiguration {
+                    level: module_level,
+                    ..
+                },
+            )) => level <= *module_level,
             None => level <= self.global_log_level,
         }
     }
 }
 
+struct Style {
+    trace: &'static str,
+    debug: &'static str,
+    info: &'static str,
+    warn: &'static str,
+    error: &'static str,
+    file_line: &'static str,
+    text: &'static str,
+}
+
+const STYLE: Style = Style {
+    trace: "color: gray",
+    debug: "color: blue",
+    info: "color: black",
+    warn: "color: orange",
+    error: "color: red; font-weight: bold",
+    file_line: "color: gray",
+    text: "",
+};
+
+/// Logs to the browser console with styled formatting.
+/// Intended to be used in `.chain(fern::Output::call(...))`
+pub fn log_to_browser_console(record: &Record) {
+    let console_fn = match record.level() {
+        Level::Error => console::error_4,
+        Level::Warn => console::warn_4,
+        Level::Info => console::info_4,
+        Level::Debug => console::log_4,
+        Level::Trace => console::debug_4,
+    };
+
+    let message = format!(
+        "%c{:<5}%c {:>20}:{:<4} %c\n{}",
+        record.level(),
+        record.file().unwrap_or_else(|| record.target()),
+        record
+            .line()
+            .map_or("[unknown]".to_string(), |l| l.to_string()),
+        record.args()
+    );
+
+    let level_style = JsValue::from_str(match record.level() {
+        Level::Trace => STYLE.trace,
+        Level::Debug => STYLE.debug,
+        Level::Info => STYLE.info,
+        Level::Warn => STYLE.warn,
+        Level::Error => STYLE.error,
+    });
+
+    let file_line_style = JsValue::from_str(STYLE.file_line);
+    let text_style = JsValue::from_str(STYLE.text);
+    let message = JsValue::from_str(&message);
+
+    console_fn(&message, &level_style, &file_line_style, &text_style);
+}


### PR DESCRIPTION
- made log4rs optional
- added a "null" logger that does nothing
- added `wasm` feature flag
- added getrandom wasm support when `wasm` feature enabled

ToDo:

- [x] Create a "wasm" logger (in progress)
	- [x] Optional loggers
	- [x] Implement `console_log` functionality
	- [x] make platform/target features/dependencies
- [x] pre-commit lints
- [x] `cargo build --target wasm32-unknown-unknown` in CI
- [x] Change default features to `logging` & `debugger`
- [x] Rework tests to run the Wasm tests that don't require the Wasm target

Probably later:

- [ ] Integration tests, Issue #384 
- [ ] Implement a browser-compatible "reports"
- [ ] Expose debugger API to frontend