### PR TITLE
Add PluginContext trait for Context

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,6 +50,7 @@ assert_approx_eq = "1.1.0"
 strum = { version = "0.27", features = ["derive"] }
 quote = "^1.0.38"
 syn = "^2.0.95"
+delegate = "^0.13.3"
 
 [package]
 name = "ixa"
@@ -83,6 +84,7 @@ seq-macro.workspace = true
 serde.workspace = true
 serde_derive.workspace = true
 serde_json.workspace = true
+delegate.workspace = true
 
 # Debugger
 rustyline = { workspace = true, optional = true }

--- a/examples/load-people/README.md
+++ b/examples/load-people/README.md
@@ -111,7 +111,7 @@ define_person_property!(
     }
 );
 
-impl VaccineContextExt for Context {
+trait VaccineContextExt: PluginContext {
     fn get_random_vaccine() {
         //....
     }

--- a/examples/load-people/vaccine.rs
+++ b/examples/load-people/vaccine.rs
@@ -1,5 +1,6 @@
 use crate::population_loader::{Age, RiskCategoryValue};
 use ixa::prelude::*;
+use ixa::prelude_for_plugins::*;
 use serde_derive::Serialize;
 
 define_rng!(VaccineRng);
@@ -22,12 +23,8 @@ define_person_property!(VaccineDoses, u8, |context: &Context, person_id| {
     }
 });
 
-pub trait ContextVaccineExt {
-    fn get_vaccine_props(&self, risk: RiskCategoryValue) -> (VaccineTypeValue, f64);
-}
-
-impl ContextVaccineExt for Context {
-    fn get_vaccine_props(self: &Context, risk: RiskCategoryValue) -> (VaccineTypeValue, f64) {
+pub trait ContextVaccineExt: PluginContext {
+    fn get_vaccine_props(&self, risk: RiskCategoryValue) -> (VaccineTypeValue, f64) {
         if risk == RiskCategoryValue::High {
             (VaccineTypeValue::A, 0.9)
         } else {
@@ -35,3 +32,4 @@ impl ContextVaccineExt for Context {
         }
     }
 }
+impl ContextVaccineExt for Context {}

--- a/src/context.rs
+++ b/src/context.rs
@@ -452,6 +452,62 @@ impl Context {
     }
 }
 
+/// A supertrait that exposes useful methods from `Context`
+/// for plugins implementing Context extensions.
+///
+/// Usage:
+/// ```rust
+/// use ixa::prelude_for_plugins::*;
+/// define_data_plugin!(MyData, bool, false);
+/// pub trait MyPlugin: PluginContext {
+///     fn set_my_data(&mut self) {
+///         let my_data = self.get_data_container_mut(MyData);
+///         *my_data = true;
+///     }
+/// }
+pub trait PluginContext: Sized {
+    fn subscribe_to_event<E: IxaEvent + Copy + 'static>(
+        &mut self,
+        handler: impl Fn(&mut Context, E) + 'static,
+    );
+    fn emit_event<E: IxaEvent + Copy + 'static>(&mut self, event: E);
+    fn add_plan(&mut self, time: f64, callback: impl FnOnce(&mut Context) + 'static) -> PlanId;
+    fn add_plan_with_phase(
+        &mut self,
+        time: f64,
+        callback: impl FnOnce(&mut Context) + 'static,
+        phase: ExecutionPhase,
+    ) -> PlanId;
+    fn add_periodic_plan_with_phase(
+        &mut self,
+        period: f64,
+        callback: impl Fn(&mut Context) + 'static,
+        phase: ExecutionPhase,
+    );
+    fn cancel_plan(&mut self, plan_id: &PlanId);
+    fn queue_callback(&mut self, callback: impl FnOnce(&mut Context) + 'static);
+    fn get_data_container_mut<T: DataPlugin>(&mut self, plugin: T) -> &mut T::DataContainer;
+    fn get_data_container<T: DataPlugin>(&self, plugin: T) -> Option<&T::DataContainer>;
+    fn get_current_time(&self) -> f64;
+}
+
+impl PluginContext for Context {
+    delegate::delegate! {
+        to self {
+            fn subscribe_to_event<E: IxaEvent + Copy + 'static>(&mut self, handler: impl Fn(&mut Context, E) + 'static);
+            fn emit_event<E: IxaEvent + Copy + 'static>(&mut self, event: E);
+            fn add_plan(&mut self, time: f64, callback: impl FnOnce(&mut Context) + 'static) -> PlanId;
+            fn add_plan_with_phase(&mut self, time: f64, callback: impl FnOnce(&mut Context) + 'static, phase: ExecutionPhase) -> PlanId;
+            fn add_periodic_plan_with_phase(&mut self, period: f64, callback: impl Fn(&mut Context) + 'static, phase: ExecutionPhase);
+            fn cancel_plan(&mut self, plan_id: &PlanId);
+            fn queue_callback(&mut self, callback: impl FnOnce(&mut Context) + 'static);
+            fn get_data_container_mut<T: DataPlugin>(&mut self, plugin: T) -> &mut T::DataContainer;
+            fn get_data_container<T: DataPlugin>(&self, plugin: T) -> Option<&T::DataContainer>;
+            fn get_current_time(&self) -> f64;
+        }
+    }
+}
+
 // TODO(cym4@cdc.gov): This is a temporary hack to let you
 // run a plan with mutable references to both the context
 // and a plugin's data. In the future we hope to make a
@@ -886,5 +942,101 @@ mod tests {
             *context.get_data_container(ComponentA).unwrap(),
             vec![0, 1, 2]
         ); // time 0.0, 1.0, and 2.0
+    }
+
+    mod plugin_context_example {
+        use crate::prelude_for_plugins::*;
+        #[derive(Copy, Clone, IxaEvent)]
+        struct MyEvent {
+            pub data: usize,
+        }
+
+        define_data_plugin!(MyData, i32, 0);
+
+        fn do_stuff_with_context(context: &mut impl PluginContext) {
+            context.add_plan(1.0, |context| {
+                let data = context.get_data_container(MyData).unwrap();
+                assert_eq!(*data, 42);
+            });
+        }
+
+        trait MyDataExt: PluginContext {
+            fn all_methods(&mut self) {
+                assert_eq!(self.get_current_time(), 0.0);
+            }
+            fn all_methods_mut(&mut self) {
+                self.setup();
+                self.subscribe_to_event(|_: &mut Context, event: MyEvent| {
+                    assert_eq!(event.data, 42);
+                });
+                self.emit_event(MyEvent { data: 42 });
+                self.add_plan_with_phase(
+                    1.0,
+                    |context| {
+                        let data = context.get_data_container(MyData).unwrap();
+                        assert_eq!(*data, 42);
+                        context.set_my_data(100);
+                    },
+                    crate::ExecutionPhase::Last,
+                );
+                self.add_plan(1.0, |context| {
+                    assert_eq!(context.get_my_data(), 42);
+                });
+                self.add_periodic_plan_with_phase(
+                    1.0,
+                    |context| {
+                        println!(
+                            "Periodic plan at time {} with data {}",
+                            context.get_current_time(),
+                            context.get_my_data()
+                        );
+                    },
+                    crate::ExecutionPhase::Normal,
+                );
+                self.queue_callback(|context| {
+                    let data = context.get_data_container(MyData).unwrap();
+                    assert_eq!(*data, 42);
+                });
+            }
+            fn setup(&mut self) {
+                let data = self.get_data_container_mut(MyData);
+                *data = 42;
+                do_stuff_with_context(self);
+            }
+            fn get_my_data(&self) -> i32 {
+                *self.get_data_container(MyData).unwrap()
+            }
+            fn set_my_data(&mut self, value: i32) {
+                let data = self.get_data_container_mut(MyData);
+                *data = value;
+            }
+            fn test_external_function(&mut self) {
+                self.setup();
+                do_stuff_with_context(self);
+            }
+        }
+        impl MyDataExt for Context {}
+
+        #[test]
+        fn test_all_methods() {
+            let mut context = Context::new();
+            context.all_methods_mut();
+            context.all_methods();
+            context.execute();
+        }
+
+        #[test]
+        fn test_plugin_context() {
+            let mut context = Context::new();
+            context.setup();
+            assert_eq!(context.get_my_data(), 42);
+        }
+
+        #[test]
+        fn test_external_function() {
+            let mut context = Context::new();
+            context.test_external_function();
+            assert_eq!(context.get_my_data(), 42);
+        }
     }
 }

--- a/src/context.rs
+++ b/src/context.rs
@@ -508,6 +508,107 @@ impl PluginContext for Context {
     }
 }
 
+// Tests for the PluginContext trait, including:
+// - Making sure all the methods work identically to Context
+// - Defining a trait extension that uses it compiles correctly
+// - External functions can use impl PluginContext if necessary
+#[cfg(test)]
+mod test_plugin_context {
+    use crate::prelude_for_plugins::*;
+    #[derive(Copy, Clone, IxaEvent)]
+    struct MyEvent {
+        pub data: usize,
+    }
+
+    define_data_plugin!(MyData, i32, 0);
+
+    fn do_stuff_with_context(context: &mut impl PluginContext) {
+        context.add_plan(1.0, |context| {
+            let data = context.get_data_container(MyData).unwrap();
+            assert_eq!(*data, 42);
+        });
+    }
+
+    trait MyDataExt: PluginContext {
+        fn all_methods(&mut self) {
+            assert_eq!(self.get_current_time(), 0.0);
+        }
+        fn all_methods_mut(&mut self) {
+            self.setup();
+            self.subscribe_to_event(|_: &mut Context, event: MyEvent| {
+                assert_eq!(event.data, 42);
+            });
+            self.emit_event(MyEvent { data: 42 });
+            self.add_plan_with_phase(
+                1.0,
+                |context| {
+                    let data = context.get_data_container(MyData).unwrap();
+                    assert_eq!(*data, 42);
+                    context.set_my_data(100);
+                },
+                crate::ExecutionPhase::Last,
+            );
+            self.add_plan(1.0, |context| {
+                assert_eq!(context.get_my_data(), 42);
+            });
+            self.add_periodic_plan_with_phase(
+                1.0,
+                |context| {
+                    println!(
+                        "Periodic plan at time {} with data {}",
+                        context.get_current_time(),
+                        context.get_my_data()
+                    );
+                },
+                crate::ExecutionPhase::Normal,
+            );
+            self.queue_callback(|context| {
+                let data = context.get_data_container(MyData).unwrap();
+                assert_eq!(*data, 42);
+            });
+        }
+        fn setup(&mut self) {
+            let data = self.get_data_container_mut(MyData);
+            *data = 42;
+            do_stuff_with_context(self);
+        }
+        fn get_my_data(&self) -> i32 {
+            *self.get_data_container(MyData).unwrap()
+        }
+        fn set_my_data(&mut self, value: i32) {
+            let data = self.get_data_container_mut(MyData);
+            *data = value;
+        }
+        fn test_external_function(&mut self) {
+            self.setup();
+            do_stuff_with_context(self);
+        }
+    }
+    impl MyDataExt for Context {}
+
+    #[test]
+    fn test_all_methods() {
+        let mut context = Context::new();
+        context.all_methods_mut();
+        context.all_methods();
+        context.execute();
+    }
+
+    #[test]
+    fn test_plugin_context() {
+        let mut context = Context::new();
+        context.setup();
+        assert_eq!(context.get_my_data(), 42);
+    }
+
+    #[test]
+    fn test_external_function() {
+        let mut context = Context::new();
+        context.test_external_function();
+        assert_eq!(context.get_my_data(), 42);
+    }
+}
+
 // TODO(cym4@cdc.gov): This is a temporary hack to let you
 // run a plan with mutable references to both the context
 // and a plugin's data. In the future we hope to make a
@@ -942,101 +1043,5 @@ mod tests {
             *context.get_data_container(ComponentA).unwrap(),
             vec![0, 1, 2]
         ); // time 0.0, 1.0, and 2.0
-    }
-
-    mod plugin_context_example {
-        use crate::prelude_for_plugins::*;
-        #[derive(Copy, Clone, IxaEvent)]
-        struct MyEvent {
-            pub data: usize,
-        }
-
-        define_data_plugin!(MyData, i32, 0);
-
-        fn do_stuff_with_context(context: &mut impl PluginContext) {
-            context.add_plan(1.0, |context| {
-                let data = context.get_data_container(MyData).unwrap();
-                assert_eq!(*data, 42);
-            });
-        }
-
-        trait MyDataExt: PluginContext {
-            fn all_methods(&mut self) {
-                assert_eq!(self.get_current_time(), 0.0);
-            }
-            fn all_methods_mut(&mut self) {
-                self.setup();
-                self.subscribe_to_event(|_: &mut Context, event: MyEvent| {
-                    assert_eq!(event.data, 42);
-                });
-                self.emit_event(MyEvent { data: 42 });
-                self.add_plan_with_phase(
-                    1.0,
-                    |context| {
-                        let data = context.get_data_container(MyData).unwrap();
-                        assert_eq!(*data, 42);
-                        context.set_my_data(100);
-                    },
-                    crate::ExecutionPhase::Last,
-                );
-                self.add_plan(1.0, |context| {
-                    assert_eq!(context.get_my_data(), 42);
-                });
-                self.add_periodic_plan_with_phase(
-                    1.0,
-                    |context| {
-                        println!(
-                            "Periodic plan at time {} with data {}",
-                            context.get_current_time(),
-                            context.get_my_data()
-                        );
-                    },
-                    crate::ExecutionPhase::Normal,
-                );
-                self.queue_callback(|context| {
-                    let data = context.get_data_container(MyData).unwrap();
-                    assert_eq!(*data, 42);
-                });
-            }
-            fn setup(&mut self) {
-                let data = self.get_data_container_mut(MyData);
-                *data = 42;
-                do_stuff_with_context(self);
-            }
-            fn get_my_data(&self) -> i32 {
-                *self.get_data_container(MyData).unwrap()
-            }
-            fn set_my_data(&mut self, value: i32) {
-                let data = self.get_data_container_mut(MyData);
-                *data = value;
-            }
-            fn test_external_function(&mut self) {
-                self.setup();
-                do_stuff_with_context(self);
-            }
-        }
-        impl MyDataExt for Context {}
-
-        #[test]
-        fn test_all_methods() {
-            let mut context = Context::new();
-            context.all_methods_mut();
-            context.all_methods();
-            context.execute();
-        }
-
-        #[test]
-        fn test_plugin_context() {
-            let mut context = Context::new();
-            context.setup();
-            assert_eq!(context.get_my_data(), 42);
-        }
-
-        #[test]
-        fn test_external_function() {
-            let mut context = Context::new();
-            context.test_external_function();
-            assert_eq!(context.get_my_data(), 42);
-        }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -38,7 +38,7 @@
 //!   REST endpoints. This feature implies the `debugger` feature.
 //!
 pub mod context;
-pub use context::{Context, ExecutionPhase, IxaEvent};
+pub use context::{Context, ExecutionPhase, IxaEvent, PluginContext};
 
 pub mod error;
 pub use error::IxaError;
@@ -79,7 +79,7 @@ pub use log::{
 #[cfg(feature = "debugger")]
 pub mod external_api;
 mod hashing;
-pub mod prelude;
+
 #[cfg(feature = "web_api")]
 pub mod web_api;
 
@@ -91,3 +91,14 @@ pub use rand;
 
 // Deterministic hashing data structures
 pub use crate::hashing::{HashMap, HashMapExt, HashSet, HashSetExt};
+
+// Preludes
+pub mod prelude;
+pub mod prelude_for_plugins {
+    pub use crate::context::PluginContext;
+    pub use crate::define_data_plugin;
+    pub use crate::error::IxaError;
+    pub use crate::prelude::*;
+    pub use crate::IxaEvent;
+    pub use ixa_derive::IxaEvent;
+}


### PR DESCRIPTION
This is an implementation of the first part of a new plugin design based on explorations here https://k88hudson-cfa.github.io/ixa-playground/context-as-trait/index.html based on feedback. I implemented it in a way that should be backwards-compatible, but allows people to migrate.

After this, we should follow up with migrating other context extensions; I migrated `Random` as a sanity check