### PR TITLE
feat: Added a progress bar feature. Fixes 408.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,28 +34,28 @@ log4rs = { version = "^1.3.0", default-features = false, features = [
     "console_appender",
 ] }
 axum = "^0.8.1"
-tokio = { version = "^1", features = ["full"] }
+tokio = { version = "^1.45.1", features = ["full"] }
 reqwest = { version = "^0.12.12", features = ["blocking", "json"] }
 uuid = "^1.12.1"
 tower-http = { version = "^0.6.2", features = ["full"] }
 mime = "^0.3.17"
 rustc-hash = "^2.1.1"
-
 rand_distr = "^0.4.3"
 tempfile = "^3.15.0"
 assert_cmd = "^2.0.16"
 criterion = "^0.5.1"
 roots = "0.0.8"
-assert_approx_eq = "1.1.0"
-strum = { version = "0.27", features = ["derive"] }
+assert_approx_eq = "^1.1.0"
+strum = { version = "^0.27.1", features = ["derive"] }
 quote = "^1.0.38"
 syn = "^2.0.95"
 delegate = "^0.13.3"
-
-web-sys = "0.3"
+web-sys = "^0.3.77"
 getrandom = "0.2"
-fern = "0.7"
-wasm-bindgen = "0.2"
+fern = "^0.7.1"
+wasm-bindgen = "^0.2.100"
+progress_bar = "^1.2.1"
+anyhow = "^1.0.28"
 
 [package]
 name = "ixa"
@@ -73,6 +73,7 @@ default = ["logging", "debugger"]
 logging = ["log4rs", "fern", "wasm-bindgen",  "web-sys"]
 debugger = ["shlex", "rustyline"]
 web_api = ["debugger", "mime", "tower-http", "axum", "tokio", "uuid"]
+progress_bar = ["dep:progress_bar", "anyhow"]
 
 [dependencies]
 approx.workspace = true # Macros
@@ -106,6 +107,10 @@ mime = { workspace = true, optional = true }
 tokio = { workspace = true, optional = true }
 tower-http = { workspace = true, optional = true }
 uuid = { workspace = true, optional = true }
+
+# Progress Bar
+progress_bar = { workspace = true, optional = true, features = ["logger"] }
+anyhow = { workspace = true, optional = true }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 fern = { workspace = true, optional = true }

--- a/src/context.rs
+++ b/src/context.rs
@@ -3,6 +3,8 @@
 //! Defines a `Context` that is intended to provide the foundational mechanism
 //! for storing and manipulating the state of a given simulation.
 use crate::plan::{PlanId, Queue};
+#[cfg(feature = "progress_bar")]
+use crate::progress::update_timeline_progress;
 #[cfg(feature = "debugger")]
 use crate::{debugger::enter_debugger, plan::PlanSchedule};
 use crate::{error, trace};
@@ -381,6 +383,11 @@ impl Context {
         trace!("entering event loop");
         // Start plan loop
         loop {
+            #[cfg(feature = "progress_bar")]
+            if crate::progress::MAX_TIME.get().is_some() {
+                update_timeline_progress(self.current_time);
+            }
+
             #[cfg(feature = "debugger")]
             if self.break_requested {
                 enter_debugger(self);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -76,6 +76,9 @@ pub use log::{
     set_module_filters, trace, warn, LevelFilter,
 };
 
+#[cfg(feature = "progress_bar")]
+pub mod progress;
+
 #[cfg(feature = "debugger")]
 pub mod external_api;
 mod hashing;
@@ -106,4 +109,9 @@ pub mod prelude_for_plugins {
 #[cfg(all(target_arch = "wasm32", feature = "debugger"))]
 compile_error!(
     "Target `wasm32` and feature `debugger` are mutually exclusive — enable at most one."
+);
+
+#[cfg(all(target_arch = "wasm32", feature = "progress_bar"))]
+compile_error!(
+    "Target `wasm32` and feature `progress_bar` are mutually exclusive — enable at most one."
 );

--- a/src/log/mod.rs
+++ b/src/log/mod.rs
@@ -47,6 +47,8 @@ mod wasm_logger;
 
 #[cfg(not(feature = "logging"))]
 mod null_logger;
+#[cfg(feature = "progress_bar")]
+mod progress_bar_encoder;
 
 pub use log::{debug, error, info, trace, warn, LevelFilter};
 use std::collections::hash_map::Entry;

--- a/src/log/progress_bar_encoder.rs
+++ b/src/log/progress_bar_encoder.rs
@@ -1,0 +1,28 @@
+//! Without this wrapper, when a log message is written to the console while the progress bar
+//! is active, artifacts from the part of the progress bar that were not overwritten by the
+//! log message will remain.
+
+use log::Record;
+use log4rs::encode::{Encode, Write};
+
+/// Wraps a PatternEncoder and prepends whatever is written to it to clear the current line.
+#[derive(Debug)]
+pub struct PBWrapperEncoder {
+    inner: Box<dyn Encode>,
+}
+
+impl PBWrapperEncoder {
+    pub fn new(inner: Box<dyn Encode>) -> Self {
+        Self { inner }
+    }
+}
+
+impl Encode for PBWrapperEncoder {
+    fn encode(&self, w: &mut dyn Write, record: &Record) -> Result<(), anyhow::Error> {
+        // This prefix clears the entire line and returns the cursor to the beginning.
+        w.write_all("\x1B[2K\r".as_bytes())?;
+
+        // Delegate to the inner encoder
+        self.inner.encode(w, record)
+    }
+}

--- a/src/log/standard_logger.rs
+++ b/src/log/standard_logger.rs
@@ -1,3 +1,5 @@
+#[cfg(feature = "progress_bar")]
+use super::progress_bar_encoder::PBWrapperEncoder;
 use crate::log::{LogConfiguration, ModuleLogConfiguration};
 use log4rs::{
     append::console::ConsoleAppender,
@@ -18,9 +20,11 @@ impl From<&ModuleLogConfiguration> for Logger {
 impl LogConfiguration {
     /// Sets the global logger to conform to this `LogConfiguration`.
     pub(in crate::log) fn set_config(&mut self) {
-        let stdout: ConsoleAppender = ConsoleAppender::builder()
-            .encoder(Box::new(PatternEncoder::new(DEFAULT_LOG_PATTERN)))
-            .build();
+        let encoder = Box::new(PatternEncoder::new(DEFAULT_LOG_PATTERN));
+        // Appends an ANSI escape code to clear to end of line.
+        #[cfg(feature = "progress_bar")]
+        let encoder = Box::new(PBWrapperEncoder::new(encoder));
+        let stdout: ConsoleAppender = ConsoleAppender::builder().encoder(encoder).build();
         let mut config: ConfigBuilder =
             Config::builder().appender(Appender::builder().build("stdout", Box::new(stdout)));
 

--- a/src/progress.rs
+++ b/src/progress.rs
@@ -1,0 +1,146 @@
+//! Provides functions to set up and update a progress bar.
+//!
+//! A progress bar has a label, a maximum progress value, and its current progress, which
+//! starts at zero. The maximum and current progress values are constrained to be of type
+//! `usize`. However, convenience methods are provided for the common case of a progress bar
+//! for the timeline that take `f64` time values and rounds them to nearest integers for you.
+//!
+//! Only one progress bar can be active at a time. If you try to set a second progress bar, the
+//! new progress bar will replace this first. This is useful if you want to track the progress
+//! of a simulation in multiple phases. Keep in mind, however, that if you define a timeline
+//! progress bar, the `Context` will try to update it in its event loop with the current time,
+//! which might not be what you want if you have replaced the progress bar with a new one.
+//!
+//! # Timeline Progress Bar
+//!
+//! ```ignore
+//! /// Initialize the progress bar with the maximum time until the simulation ends.
+//! pub fn init_timeline_progress_bar(max_time: f64);
+//! /// Updates the progress bar with the current time. Finalizes the progress bar when
+//! /// `current_time >= max_time`.
+//! pub fn update_timeline_progress(mut current_time: f64);
+//! ```
+//!
+//! # Custom Progress Bar
+//!
+//! If the timeline is not a good indication of progress for your simulation, you can set up a
+//! custom progress bar.
+//!
+//! ```ignore
+//! /// Initializes a custom progress bar with the given label and max value.
+//! pub fn init_custom_progress_bar(label: &str, max_value: usize);
+//!
+//! /// Updates the current value of the custom progress bar.
+//! pub fn update_custom_progress(current_value: usize);
+//!
+//! /// Increments the custom progress bar by 1. Use this if you don't want to keep track of the
+//! /// current value.
+//! pub fn increment_custom_progress()
+//! ```
+//!
+//! # Custom Example: People Infected
+//!
+//! Suppose you want a progress bar that tracks how much of the population has been infected (or
+//! infected and then recovered). You first initialize a custom progress bar before executing
+//! the simulation.
+//!
+//! ```ignore
+//! use crate::progress_bar::{init_custom_progress_bar};
+//!
+//! init_custom_progress_bar("People Infected", POPULATION_SIZE);
+//! ```
+//!
+//! To update the progress bar, we need to listen to the infection status property change event.
+//!
+//! ```ignore
+//! use crate::progress_bar::{increment_custom_progress};
+//!
+//! // You might already have this event defined for other purposes.
+//! pub type InfectionStatusEvent = PersonPropertyChangeEvent<InfectionStatus>;
+//!
+//! // This will handle the status change event, updating the progress bar
+//! // if there is a new infection.
+//! fn handle_infection_status_change(context: &mut Context, event: InfectionStatusEvent) {
+//!   // We only increment the progress bar when a new infection occurs.
+//!   if (InfectionStatusValue::Susceptible, InfectionStatusValue::Infected)
+//!   		== (event.previous, event.current)
+//!   {
+//!     increment_custom_progress();
+//!   }
+//! }
+//!
+//! // Be sure to subscribe to the event when you initialize the context.
+//! pub fn init(context: &mut Context) -> Result<(), IxaError> {
+//!     // ... other initialization code ...
+//!     context.subscribe_to_event::<InfectionStatusEvent>(handle_infection_status_change);
+//!     // ...
+//!     Ok(())
+//! }
+//! ```
+//!
+
+use crate::log::{trace, warn};
+use progress_bar::{
+    finalize_progress_bar, inc_progress_bar, init_progress_bar, set_progress_bar_action,
+    set_progress_bar_progress, Color, Style,
+};
+// Requires at least rustc@1.70
+use std::sync::OnceLock;
+
+/// We want to store the original `f64` max value, not the `usize` we initialized the progress
+/// bar with.
+pub(crate) static MAX_TIME: OnceLock<f64> = OnceLock::new();
+
+/// Initialize the progress bar with the maximum time until the simulation ends.
+pub fn init_timeline_progress_bar(max_time: f64) {
+    trace!(
+        "initializing timeline progress bar with max time {}",
+        max_time
+    );
+    MAX_TIME
+        .set(max_time)
+        .expect("Timeline progress already initialized");
+    init_progress_bar(max_time.round() as usize);
+    set_progress_bar_action("Time", Color::Blue, Style::Bold);
+}
+
+/// Updates the timeline progress bar with the current time.
+pub(crate) fn update_timeline_progress(mut current_time: f64) {
+    if let Some(max_time) = MAX_TIME.get() {
+        if current_time >= *max_time {
+            current_time = *max_time;
+        }
+        set_progress_bar_progress(current_time.round() as usize);
+        // It's possible that `progress.round() == max_time.round()` but `progress < max_time`.
+        // We only finalize if they are equal as floats.
+        if current_time == *max_time {
+            finalize_progress_bar();
+        }
+    } else {
+        warn!("attempted to update timeline progress bar before it was initialized");
+    }
+}
+
+/// Initializes a custom progress bar with the given label and max value.
+///
+/// Note: If you attempt to set two progress bars, the second progress bar will replace the first.
+pub fn init_custom_progress_bar(label: &str, max_value: usize) {
+    trace!(
+        "initializing custom progress bar with label {} and max value {}",
+        label,
+        max_value
+    );
+    init_progress_bar(max_value);
+    set_progress_bar_action(label, Color::Blue, Style::Bold);
+}
+
+/// Updates the current value of the custom progress bar.
+pub fn update_custom_progress(current_value: usize) {
+    set_progress_bar_progress(current_value);
+}
+
+/// Increments the custom progress bar by 1. Use this if you don't want to keep track of the
+/// current value.
+pub fn increment_custom_progress() {
+    inc_progress_bar();
+}


### PR DESCRIPTION
There is a tricky bit to make sure the progress bar doesn't interfere with logging.

Questions:
- Should we have a command line flag that enables a progress bar for the timeline?
- I put it behind a feature flag, but we could include it unconditionally and leave it to the client code to enable it in code.
- Should the feature be enabled by default? The two additional dependencies are pretty small.