### PR TITLE
Added `execution_stats.rs` that implements collecting profiling data.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,6 +56,9 @@ fern = "^0.7.1"
 wasm-bindgen = "^0.2.100"
 progress_bar = "^1.2.1"
 anyhow = "^1.0.28"
+sysinfo = "^0.35.2"
+humantime = "^2.2.0"
+bytesize = "^2.0.1"
 
 [package]
 name = "ixa"
@@ -91,6 +94,9 @@ serde.workspace = true
 serde_derive.workspace = true
 serde_json.workspace = true
 delegate.workspace = true
+sysinfo.workspace = true
+humantime.workspace = true
+bytesize.workspace = true
 
 # Non-WASM targets
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]

--- a/ixa-integration-tests/tests/runner.rs
+++ b/ixa-integration-tests/tests/runner.rs
@@ -12,7 +12,7 @@ mod tests {
         // and the entry point is in tests/bin/runner_test_custom_args
         run_external_runner("runner_test_custom_args")
             .unwrap()
-            .args(["-a", "42"])
+            .args(["-a", "42", "--no-stats"])
             .assert()
             .success()
             .stdout("42\n");

--- a/src/execution_stats.rs
+++ b/src/execution_stats.rs
@@ -1,0 +1,284 @@
+use bytesize::ByteSize;
+use humantime::format_duration;
+use log::{error, info};
+use std::time::{Duration, Instant};
+use sysinfo::{Pid, ProcessRefreshKind, ProcessesToUpdate, System};
+
+/// How frequently we update the max memory used value.
+const REFRESH_INTERVAL: Duration = Duration::from_secs(1);
+
+/// A container struct for computed final statistics. Note that if population size
+/// is zero, then the per person statistics are also zero, as they are meaningless.
+pub struct ExecutionStatistics {
+    max_memory_usage: u64,
+    cpu_time: Duration,
+    wall_time: Duration,
+
+    // Per person stats
+    population: usize,
+    cpu_time_per_person: Duration,
+    wall_time_per_person: Duration,
+    memory_per_person: u64,
+}
+
+pub struct ExecutionProfilingCollector {
+    /// Simulation start time, used to compute elapsed wall time for the simulation execution
+    start_time: Instant,
+    /// We keep track of the last time we refreshed so that client code doesn't have to and can
+    /// just call `ExecutionProfilingCollector::refresh` in its event loop.
+    last_refresh: Instant,
+    /// The accumulated CPU time of the process in CPU-milliseconds at simulation start, used
+    /// to compute the CPU time of the simulation execution
+    start_cpu_time: u64,
+    /// The maximum amount of real memory used by the process as reported by
+    /// `sysinfo:System::process::memory()`. This value is polled during execution to capture the
+    /// max.
+    max_memory_usage: u64,
+    /// A `sysinfo::System` for polling memory use
+    system: System,
+    /// Current process
+    process_id: Pid,
+}
+
+impl ExecutionProfilingCollector {
+    pub fn new() -> ExecutionProfilingCollector {
+        let process_id = sysinfo::get_current_pid().unwrap();
+        let mut new_stats = ExecutionProfilingCollector {
+            start_time: Instant::now(),
+            last_refresh: Instant::now(),
+            start_cpu_time: 0,
+            max_memory_usage: 0,
+            system: System::new(),
+            process_id,
+        };
+        let process_refresh_kind = ProcessRefreshKind::nothing().with_cpu().with_memory();
+        new_stats.update_system_info(process_refresh_kind);
+
+        let process = new_stats.system.process(process_id).unwrap();
+
+        new_stats.max_memory_usage = process.memory();
+        new_stats.start_cpu_time = process.accumulated_cpu_time();
+
+        new_stats
+    }
+
+    /// If at least 1 second has passed since the previous refresh, memory usage is polled and
+    /// updated. Call this method as frequently as you like, as it takes care of
+    pub fn refresh(&mut self) {
+        if self.last_refresh.elapsed() >= REFRESH_INTERVAL {
+            self.poll_memory();
+            self.last_refresh = Instant::now();
+        }
+    }
+
+    /// Updates maximum memory usage. This method should be called about once per second,
+    /// as it is a relatively expensive system call.
+    fn poll_memory(&mut self) {
+        let pid = self.process_id;
+        // Only refreshes memory statistics
+        self.update_system_info(ProcessRefreshKind::nothing().with_memory());
+        let process = self.system.process(pid).unwrap();
+        self.max_memory_usage = self.max_memory_usage.max(process.memory());
+    }
+
+    /// Gives accumulated CPU time of the process in CPU-milliseconds since simulation start.
+    #[allow(unused)]
+    pub fn cpu_time(&mut self) -> u64 {
+        // Only refresh cpu statistics
+        self.update_system_info(ProcessRefreshKind::nothing().with_cpu());
+
+        let process = self.system.process(self.process_id).unwrap();
+        process.accumulated_cpu_time() - self.start_cpu_time
+    }
+
+    /// Refreshes the internal `sysinfo::System` object for this process using the given
+    /// `ProcessRefreshKind`.
+    #[inline]
+    fn update_system_info(&mut self, process_refresh_kind: ProcessRefreshKind) {
+        let pid = self.process_id;
+
+        if self.system.refresh_processes_specifics(
+            ProcessesToUpdate::Some(&[pid]),
+            true,
+            process_refresh_kind,
+        ) < 1
+        {
+            error!("could not refresh process statistics");
+        }
+    }
+
+    /// Computes the final summary statistics
+    pub fn compute_final_statistics(&mut self, population: usize) -> ExecutionStatistics {
+        let pid = self.process_id;
+        // Update both memory and cpu statistics
+        self.update_system_info(ProcessRefreshKind::nothing().with_cpu().with_memory());
+        let process = self.system.process(pid).unwrap();
+
+        self.max_memory_usage = self.max_memory_usage.max(process.memory());
+        let cpu_time_millis = process.accumulated_cpu_time() - self.start_cpu_time;
+
+        // Convert to `Duration`s in preparation for formatting
+        let cpu_time = Duration::from_millis(cpu_time_millis);
+        let wall_time = self.start_time.elapsed();
+
+        // For the per person stats, it's not clear what scale this should be at. Duration can
+        // be constructed from seconds in `f64`, which is probably good enough for our purposes.
+        // For memory, we can just round to the nearest byte.
+
+        let cpu_time_per_person = if population > 0 {
+            Duration::from_secs_f64(cpu_time_millis as f64 / population as f64 / 1000.0)
+        } else {
+            Duration::new(0, 0)
+        };
+        let wall_time_per_person = if population > 0 {
+            Duration::from_secs_f64(wall_time.as_secs_f64() / population as f64)
+        } else {
+            Duration::new(0, 0)
+        };
+        let memory_per_person = if population > 0 {
+            self.max_memory_usage / population as u64
+        } else {
+            0
+        };
+
+        ExecutionStatistics {
+            max_memory_usage: self.max_memory_usage,
+            cpu_time,
+            wall_time,
+
+            // Per person stats
+            population,
+            cpu_time_per_person,
+            wall_time_per_person,
+            memory_per_person,
+        }
+    }
+}
+
+/// Prints execution statistics to the console.
+///
+/// Use `ExecutionProfilingCollector::compute_final_statistics()` to construct `ExecutionStatistics`.
+pub fn print_execution_statistics(summary: &ExecutionStatistics) {
+    println!("━━━━ Execution Summary ━━━━");
+    println!(
+        "{:<25}{}",
+        "Max memory usage:",
+        ByteSize::b(summary.max_memory_usage)
+    );
+    println!("{:<25}{}", "CPU time:", format_duration(summary.cpu_time));
+    println!("{:<25}{}", "Wall time:", format_duration(summary.wall_time));
+
+    if summary.population > 0 {
+        println!("{:<25}{}", "Population:", summary.population);
+        println!(
+            "{:<25}{}",
+            "CPU time per person:",
+            format_duration(summary.cpu_time_per_person)
+        );
+        println!(
+            "{:<25}{}",
+            "Wall time per person:",
+            format_duration(summary.wall_time_per_person)
+        );
+        println!(
+            "{:<25}{}",
+            "Memory per person:",
+            ByteSize::b(summary.memory_per_person)
+        );
+    }
+}
+
+/// Logs execution statistics with the logging system.
+///
+/// Use `ExecutionProfilingCollector::compute_final_statistics()` to construct `ExecutionStatistics`.
+pub fn log_execution_statistics(stats: &ExecutionStatistics) {
+    info!("Execution complete.");
+    info!("Max memory usage: {}", ByteSize::b(stats.max_memory_usage));
+    info!("CPU time: {}", format_duration(stats.cpu_time));
+    info!("Wall time: {}", format_duration(stats.wall_time));
+
+    if stats.population > 0 {
+        info!("Population: {}", stats.population);
+        info!(
+            "CPU time per person: {}",
+            format_duration(stats.cpu_time_per_person)
+        );
+        info!(
+            "Wall time per person: {}",
+            format_duration(stats.wall_time_per_person)
+        );
+        info!(
+            "Memory per person: {}",
+            ByteSize::b(stats.memory_per_person)
+        );
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::{thread, time::Duration};
+
+    #[test]
+    fn test_collector_initialization() {
+        let collector = ExecutionProfilingCollector::new();
+
+        // Ensure that initial max memory usage is non-zero
+        assert!(collector.max_memory_usage > 0);
+    }
+
+    #[test]
+    fn test_refresh_respects_interval() {
+        let mut collector = ExecutionProfilingCollector::new();
+        let before = collector.max_memory_usage;
+
+        // Call refresh immediately — it should not poll
+        collector.refresh();
+        let after = collector.max_memory_usage;
+        assert_eq!(before, after);
+
+        // Sleep enough time to trigger refresh
+        thread::sleep(Duration::from_secs(2));
+        collector.refresh();
+        // Now memory usage should be refreshed — allow it to stay same or increase
+        assert!(collector.max_memory_usage >= before);
+    }
+
+    #[test]
+    fn test_compute_final_statistics_structure() {
+        let mut collector = ExecutionProfilingCollector::new();
+
+        thread::sleep(Duration::from_millis(100));
+        let stats = collector.compute_final_statistics(10);
+
+        // Fields should be non-zero
+        assert!(stats.max_memory_usage > 0);
+        assert!(stats.wall_time > Duration::ZERO);
+        assert_eq!(stats.population, 10);
+    }
+
+    #[test]
+    fn test_zero_population_results() {
+        let mut collector = ExecutionProfilingCollector::new();
+
+        let stats = collector.compute_final_statistics(0);
+
+        assert_eq!(stats.population, 0);
+        assert_eq!(stats.cpu_time_per_person, Duration::ZERO);
+        assert_eq!(stats.wall_time_per_person, Duration::ZERO);
+        assert_eq!(stats.memory_per_person, 0);
+    }
+
+    #[test]
+    fn test_cpu_time_increases_over_time() {
+        let mut collector = ExecutionProfilingCollector::new();
+
+        thread::sleep(Duration::from_millis(50));
+        let cpu_time_1 = collector.cpu_time();
+
+        thread::sleep(Duration::from_millis(50));
+        let cpu_time_2 = collector.cpu_time();
+
+        assert!(cpu_time_2 > cpu_time_1);
+    }
+}

--- a/src/external_api.rs
+++ b/src/external_api.rs
@@ -110,7 +110,7 @@ pub(crate) mod breakpoint {
     use crate::debugger::enter_debugger;
     #[cfg(feature = "web_api")]
     use crate::web_api::enter_web_debugger;
-    use crate::{info, trace, IxaError};
+    use crate::{trace, IxaError};
     use clap::{Parser, Subcommand};
     use serde::{Deserialize, Serialize};
 
@@ -196,7 +196,7 @@ pub(crate) mod breakpoint {
                     #[cfg(not(feature = "web_api"))]
                     context.schedule_debugger(*time, None, Box::new(enter_debugger));
 
-                    info!("Breakpoint set at t={time}");
+                    trace!("Breakpoint set at t={time}");
                     Ok(Retval::Ok)
                 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -97,6 +97,7 @@ pub use crate::hashing::{HashMap, HashMapExt, HashSet, HashSetExt};
 
 // Preludes
 pub mod prelude;
+
 pub mod prelude_for_plugins {
     pub use crate::context::PluginContext;
     pub use crate::define_data_plugin;
@@ -105,6 +106,8 @@ pub mod prelude_for_plugins {
     pub use crate::IxaEvent;
     pub use ixa_derive::IxaEvent;
 }
+
+mod execution_stats;
 
 #[cfg(all(target_arch = "wasm32", feature = "debugger"))]
 compile_error!(

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -67,6 +67,10 @@ pub struct BaseArgs {
     /// Enable the Web API at a given time. Defaults to t=0.0
     #[arg(short, long)]
     pub web: Option<Option<u16>>,
+
+    /// Suppresses the printout of summary statistics at the end of the simulation.
+    #[arg(long)]
+    pub no_stats: bool,
 }
 
 impl BaseArgs {
@@ -80,6 +84,7 @@ impl BaseArgs {
             log_level: None,
             debugger: None,
             web: None,
+            no_stats: false,
         }
     }
 }
@@ -182,7 +187,7 @@ where
                 log_levels.iter().map(|(k, v)| (k, *v)).collect();
             set_module_filters(log_levels_slice.as_slice());
             for (key, value) in log_levels {
-                println!("Logging enabled for {key} at level {value}");
+                info!("Logging enabled for {key} at level {value}");
                 // Here you can set the log level for each key-value pair as needed
             }
         } else {
@@ -226,6 +231,15 @@ where
     #[cfg(not(feature = "web_api"))]
     if args.web.is_some() {
         warn!("Ixa was not compiled with the web_api feature, but a web_api option was provided");
+    }
+
+    if args.no_stats {
+        if cfg!(target_family = "wasm") {
+            warn!("the print-stats option is enabled; some statistics are not supported for the wasm target family")
+        }
+        context.print_execution_statistics = false;
+    } else {
+        context.print_execution_statistics = true;
     }
 
     // Run the provided Fn


### PR DESCRIPTION
Made use of `trace!` and `info!` logging macros more consistent. The execution statistics are printed at simulation end by default if using the runner. The command line argument `--no-stats` disables it.

Questions / Issues:

- Tracking maximum population is tricky. We can use the max of population at start and population at end, or we can track population size dynamically... Do we assume existence of the `People` module (an initilized data container)? 

  **Right now:** if the data container exists, we use `current_population` at simulation end, because this value is monotonically increasing (serves as next `PersonId`). If data container doesn't exist, we just excluding people related stats.

- Polling memory used by current process - at what frequency? It is an expensive system call. **Right now:** 1 Hz.

- The wall and CPU time is *not* paused when the debugger is in use. 

- When using the runner, the stats are printed by default. However, when a `Context` is created, `print_execution_statistics` is false by default. This way stats are not printed when a `Context` is created programmatically, e.g. in tests.

- When `print_execution_statistics` is false, the stats are logged with `info!` instead.

