### PR TITLE
chore: Made in-source references to input files for examples more robust. Fixes #374.

### DIFF
--- a/examples/births-deaths/main.rs
+++ b/examples/births-deaths/main.rs
@@ -3,9 +3,9 @@ use ixa_example_births_deaths::initialize;
 use std::path::Path;
 
 fn main() {
-    let current_dir = Path::new(file!()).parent().unwrap();
+    let source_dir = Path::new(env!("CARGO_MANIFEST_DIR"));
     run_with_args(|context, _, _| {
-        initialize(context, current_dir, current_dir);
+        initialize(context, source_dir);
         Ok(())
     })
     .unwrap();

--- a/examples/births-deaths/src/lib.rs
+++ b/examples/births-deaths/src/lib.rs
@@ -11,18 +11,11 @@ pub mod transmission_manager;
 
 use crate::parameters_loader::Parameters;
 
-pub fn initialize(context: &mut Context, given_parameters_path: &Path, output_path: &Path) {
-    let current_dir = Path::new(file!()).parent().unwrap();
+pub fn initialize(context: &mut Context, output_path: &Path) {
     let output_path_buff = PathBuf::from(&output_path);
 
-    let def_parameters_path = current_dir.join("../input.json");
-    let parameters_path = if given_parameters_path.exists() {
-        given_parameters_path
-    } else {
-        def_parameters_path.as_path()
-    };
-
-    parameters_loader::init_parameters(context, parameters_path).unwrap_or_else(|e| {
+    let parameters_path = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("input.json");
+    parameters_loader::init_parameters(context, &parameters_path).unwrap_or_else(|e| {
         eprintln!("failed to init init_parameters: {}", e);
     });
 

--- a/examples/load-people/population_loader.rs
+++ b/examples/load-people/population_loader.rs
@@ -1,4 +1,4 @@
-use std::path::{Path, PathBuf};
+use std::path::PathBuf;
 
 use crate::vaccine::{ContextVaccineExt, VaccineEfficacy, VaccineType};
 use ixa::prelude::*;

--- a/examples/load-people/population_loader.rs
+++ b/examples/load-people/population_loader.rs
@@ -1,4 +1,4 @@
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 use crate::vaccine::{ContextVaccineExt, VaccineEfficacy, VaccineType};
 use ixa::prelude::*;
@@ -35,8 +35,11 @@ fn create_person_from_record(context: &mut Context, record: &PeopleRecord) -> Pe
 
 pub fn init(context: &mut Context) {
     // Load csv and deserialize records
-    let current_dir = Path::new(file!()).parent().unwrap();
-    let mut reader = csv::Reader::from_path(current_dir.join("people.csv")).unwrap();
+    let data_path = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("examples")
+        .join("load-people")
+        .join("people.csv");
+    let mut reader = csv::Reader::from_path(data_path).unwrap();
 
     for result in reader.deserialize() {
         let record: PeopleRecord = result.expect("Failed to parse record");

--- a/examples/network-hhmodel/loader.rs
+++ b/examples/network-hhmodel/loader.rs
@@ -1,5 +1,4 @@
-use std::path::Path;
-
+use crate::example_dir;
 use csv::Reader;
 use ixa::prelude::*;
 use ixa::PersonId;
@@ -47,7 +46,7 @@ fn create_person_from_record(context: &mut Context, record: &PeopleRecord) -> Pe
 }
 
 pub fn open_csv(file_name: &str) -> Reader<File> {
-    let current_dir = Path::new(file!()).parent().unwrap();
+    let current_dir = example_dir();
     let file_path = current_dir.join(file_name);
     csv::Reader::from_path(file_path).unwrap()
 }

--- a/examples/network-hhmodel/main.rs
+++ b/examples/network-hhmodel/main.rs
@@ -6,7 +6,8 @@ mod loader;
 mod network;
 mod parameters;
 mod seir;
-use std::path::Path;
+use std::path::PathBuf;
+
 define_rng!(MainRng);
 
 fn main() {
@@ -17,6 +18,11 @@ fn main() {
     .unwrap();
 }
 
+fn example_dir() -> PathBuf {
+    let parameters_path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    parameters_path.join("examples").join("network-hhmodel")
+}
+
 fn initialize(context: &mut Context) {
     context.init_random(1);
 
@@ -24,7 +30,7 @@ fn initialize(context: &mut Context) {
     let people = loader::init(context);
 
     // Load parameters from json
-    let file_path = Path::new(file!()).parent().unwrap().join("config.json");
+    let file_path = example_dir().join("config.json");
     context.load_global_properties(&file_path).unwrap();
 
     // Load network

--- a/examples/parameter-loading/main.rs
+++ b/examples/parameter-loading/main.rs
@@ -1,5 +1,5 @@
 use ixa::prelude::*;
-use std::path::Path;
+use std::path::PathBuf;
 
 mod incidence_report;
 mod infection_manager;
@@ -22,11 +22,14 @@ define_person_property_with_default!(
     InfectionStatusValue::S
 );
 
+fn example_dir() -> PathBuf {
+    let parameters_path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    parameters_path.join("examples").join("parameter-loading")
+}
+
 fn initialize() -> Result<Context, IxaError> {
     let mut context = Context::new();
-    let file_path = Path::new("examples")
-        .join("parameter-loading")
-        .join("input.json");
+    let file_path = example_dir().join("input.json");
 
     parameters_loader::init_parameters(&mut context, &file_path)?;
 

--- a/examples/reports-multi-threaded/main.rs
+++ b/examples/reports-multi-threaded/main.rs
@@ -14,6 +14,13 @@ struct Incidence {
 
 create_report_trait!(Incidence);
 
+fn example_dir() -> PathBuf {
+    let parameters_path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    parameters_path
+        .join("examples")
+        .join("reports-multi-threaded")
+}
+
 #[allow(unexpected_cfgs)]
 fn main() {
     let scenarios = vec!["Illinois", "Wisconsin", "Arizona", "California"];
@@ -26,7 +33,7 @@ fn main() {
 
             context
                 .report_options()
-                .directory(PathBuf::from("./examples/reports-multi-threaded"))
+                .directory(example_dir())
                 .file_prefix(format!("{scenario}_"))
                 .overwrite(true); // Not recommended for production. See `basic-infection/incidence-report`.;
             context

--- a/ixa-bench/example_births_deaths/example_births_deaths.rs
+++ b/ixa-bench/example_births_deaths/example_births_deaths.rs
@@ -1,19 +1,15 @@
 use criterion::{criterion_group, criterion_main, Criterion};
 use ixa::prelude::*;
 use ixa_example_births_deaths::initialize;
-use std::fs;
-use std::path::Path;
 use tempfile::tempdir;
 
 pub fn criterion_benchmark(c: &mut Criterion) {
-    let parameters_path =
-        fs::canonicalize(Path::new(".").join("../examples/births-deaths/input.json")).unwrap();
     let output_dir = tempdir().unwrap();
 
     c.bench_function("example births-deaths", |bencher| {
         bencher.iter_with_large_drop(|| {
             let mut context = Context::new();
-            initialize(&mut context, parameters_path.as_path(), output_dir.path());
+            initialize(&mut context, output_dir.path());
             context.execute();
             context
         });


### PR DESCRIPTION
Changed in-source references to use `env!("CARGO_MANIFEST_DIR")`, an absolute path, instead of the `file!` macro, which is relative. This appears to be a little more robust for certain edge cases (`births-deaths`).