### PR TITLE
docs: Remove "SIR" terminology from Ixa book

### DIFF
--- a/docs/book/models/disease_model/Cargo.toml
+++ b/docs/book/models/disease_model/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "disease_model"
-description = "A basic SIR disease model using the Ixa agent-based modeling framework"
+description = "A basic disease model using the Ixa agent-based modeling framework"
 authors = ["John Doe <jdoe@example.com>"]
 version = "0.1.0"
 edition = "2024"

--- a/docs/book/src/first_model/next-steps.md
+++ b/docs/book/src/first_model/next-steps.md
@@ -9,6 +9,6 @@ We have created several new modules. We need to make sure they are each initiali
 
 Exercises:
 
-1. Currently the simulation runs until `MAX_TIME` even if every single person has been infected and has recovered. Add a check somewhere that calls `context.shutdown()` if there is no more work for the simulation to do. Where should this check live? Hint: take a look at the methods available to through `ContextPeopleExt`.
+1. Currently the simulation runs until `MAX_TIME` even if every single person has been infected and has recovered. Add a check somewhere that calls `context.shutdown()` if there is no more work for the simulation to do. Where should this check live? Hint: take a look at the methods available through `ContextPeopleExt`.
 2. Analyze the data output by the incident reporter. Plot the number of people with each `InfectionStatus` on the same axis to see how they change over the course of the simulation. Are the curves what we expect to see given our abstract model?
 3. Add another person property that moderates the risk of infection of the individual. (Imagine, for example, people wearing face masks for an airborne illness.) Give a randomly sampled subpopulation that intervention, and add a check to the transmission module to see if the person that we are attempting to infect has that property. Change the probability of infection accordingly.

--- a/docs/book/src/first_model/people.md
+++ b/docs/book/src/first_model/people.md
@@ -17,9 +17,9 @@ To each person we will associate a value of the enum (short for “enumeration�
 
 - **S**: Represents someone who is susceptible to infection.
 - **I**: Represents someone who is currently infected.
-- **R**: Represents someone who has recovered (or is otherwise no longer infectious).
+- **R**: Represents someone who has recovered.
 
-Each value in the enum corresponds to a stage in our simple SIR (Susceptible, Infected, Recovered) model. The enum value for a person's `InfectionStatus` property will refer to an individual’s health status in our simulation.
+Each value in the enum corresponds to a stage in our simple model. The enum value for a person's `InfectionStatus` property will refer to an individual’s health status in our simulation.
 
 The attributes written above the enum declaration, such as `#[derive(Debug, Hash, Eq, PartialEq, Clone, Copy, Serialize, Deserialize)]`, automatically add useful functionality to the enum:
 

--- a/docs/book/src/first_model/your-first-model.md
+++ b/docs/book/src/first_model/your-first-model.md
@@ -1,17 +1,17 @@
 # Your First Model
 
-In this section we will get acquainted with the basic features of Ixa by implementing a simple [SIR (Susceptible, Infected, Recovered) model](https://en.wikipedia.org/wiki/Compartmental_models_in_epidemiology#The_SIR_model). This section is just a starting point. It is _not_ intended to be:
+In this section we will get acquainted with the basic features of Ixa by implementing a simple infectious disease transmission model. This section is just a starting point. It is _not_ intended to be:
 
 - An introduction to the [Rust programming language](https://www.rust-lang.org/learn) (or [crash course](https://stevedonovan.github.io/rust-gentle-intro/readme.html)) or software engineering topics like [source control with Git](https://git-scm.com/book/ms/v2/Getting-Started-About-Version-Control)
 - A tutorial on using a Unix-flavored command line
-- An overview or survey of either [disease modeling](https://en.wikipedia.org/wiki/Mathematical_modelling_of_infectious_diseases) in general or [agent-based modeling](https://en.wikipedia.org/wiki/Agent-based_model) specifically
+- An overview or survey of either [disease modeling](https://en.wikipedia.org/wiki/Mathematical_modelling_of_infectious_diseases) or [agent-based modeling](https://en.wikipedia.org/wiki/Agent-based_model)
 - An exhaustive treatment of all of the features of Ixa
 
 ## Our Abstract Model
 
-We introduce modeling in Ixa by implementing a simple SIR model for a food-borne illness where infection events follow a **Poisson process**. We assume that each susceptible person has a constant risk of becoming infected over time, independent of past infections. The Poisson process describes events (infections) occurring randomly in time but with a constant rate.
+We introduce modeling in Ixa by implementing a simple model for a food-borne illness where infection events follow a **Poisson process**. We assume that each susceptible person has a constant risk of becoming infected over time, independent of past infections. The Poisson process describes events (infections) occurring randomly in time but with a constant rate.
 
-In this model, each individual susceptible person has an exponentially distributed time until they are infected. This means the time between successive infection events follows an exponential distribution. The rate of infection is typically expressed as a **force of infection**, which is a measure of the risk of a susceptible individual contracting the disease. In the case of a food-borne illness, this force is constant, meaning each susceptible individual faces a fixed probability per unit time of becoming infected, independent of the number of people already infected.
+In this model, each individual susceptible person has an exponentially distributed time until they are infected. This means the time between successive infection events follows an exponential distribution. The rate of infection is typically expressed as a **force of infection**, which is a measure of the risk of a susceptible individual contracting the disease. In the case of a food-borne illness, this force is constant, meaning each susceptible individual faces a fixed probability per unit time of becoming infected, independent of the number of people already infected. Infected individuals subsequently recovery and cannot be re-infected. (Note that while this model has S, I, and R compartments, it is different from the [canonical "SIR" model](https://en.wikipedia.org/wiki/Compartmental_models_(epidemiology)#The_SIR_model). In our simple model, the force of infection does not depend on the prevalence of infected persons. Put another way, our "I" compartment consists merely of _infected_ persons; they are not _infectious_.)
 
 ## High-level view of how Ixa functions
 
@@ -43,8 +43,8 @@ The single responsibility principle in software engineering is a key idea behind
 In the context of our disease transmission model:
 
 - The **population loader** is solely responsible for setting up the initial state of the simulation by importing and structuring the data about people.
-- The **transmission manager** focuses exclusively on modeling how the disease spreads from one person to another.
-- The **infection manager** takes care of the progression of the disease within an individual until recovery.
+- The **transmission manager** focuses exclusively on modeling the process by which persons get infected.
+- The **infection manager** takes care of the progression of the disease within an infected individual until recovery.
 - The **reporting module** handles data collection and output, ensuring that results are recorded accurately.
 
 By organizing the model into these distinct modules, each with a single responsibility, we ensure that our simulation remains organized and manageable—even as the complexity of the model grows.


### PR DESCRIPTION
[The Ixa Book](https://ixa.rs/book) guides readers through a simple transmission model with a constant force of infection. Because this model has susceptible, infected, and recovered compartments, it is referred to as an SIR model. However, I would suggest that we drop this terminology and explain parenthetically how this model is in fact different from the canonical SIR model (i.e., the Kermack-McKendrick model). I believe these changes would help make the text clearer for persons with a prior background infectious disease modeling. This PR is entirely about documentation and does not include any substantive changes to the example model or code.