### PR TITLE
fix: Silences a few lints new in the latest Rust release. Fixes #440.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -145,6 +145,12 @@ missing_panics_doc = "allow"
 missing_errors_doc = "allow"
 uninlined_format_args = "allow"
 result_unit_err = "allow"
+struct_field_names = "allow"
+unnecessary_debug_formatting = "allow"
+struct_excessive_bools = "allow"
+
+[lints]
+workspace = true
 
 [lib]
 # Prevent Cargo from implicitly linking `libtest` for Criterion.rs compatibility.

--- a/integration-tests/ixa-wasm-tests/Cargo.toml
+++ b/integration-tests/ixa-wasm-tests/Cargo.toml
@@ -22,3 +22,6 @@ js-sys = "^0.3.77"
 ixa = { path = "../../", default-features = false, features = ["logging"] }
 rand_distr = "^0.4.3"
 serde = { version = "^1.0.217", features = ["derive"] }
+
+[lints]
+workspace = true


### PR DESCRIPTION
Also, a couple of module members did not correctly inherit the lint exceptions from the workspace.

The new lint exceptions are:
 - `struct_field_names` - Says that field names of structs should now have the name of the struct as a prefix.
 - `unnecessary_debug_formatting` - If we instead use `some_path.display()`, "escaped characters will no longer be escaped and surrounding quotes will be removed." But we prefer escape characters and quotes for our use case.
 - `struct_excessive_bools` - Detects when more than three fields of a struct are of type `bool`.