### PR TITLE
feat: Publicly exposed `Context::get_execution_statistics`. Fixes #488.

### DIFF
--- a/examples/basic-infection/src/incidence_report.rs
+++ b/examples/basic-infection/src/incidence_report.rs
@@ -2,10 +2,10 @@ use crate::infection_manager::InfectionStatusEvent;
 use crate::people::InfectionStatusValue;
 use ixa::prelude::*;
 use ixa::{trace, PersonId};
-use serde::{Deserialize, Serialize};
+use serde::Serialize;
 use std::path::PathBuf;
 
-#[derive(Serialize, Deserialize, Clone)]
+#[derive(Serialize)]
 struct IncidenceReportItem {
     time: f64,
     person_id: PersonId,

--- a/src/context.rs
+++ b/src/context.rs
@@ -5,6 +5,7 @@
 use crate::data_plugin::DataPlugin;
 use crate::execution_stats::{
     log_execution_statistics, print_execution_statistics, ExecutionProfilingCollector,
+    ExecutionStatistics,
 };
 use crate::plan::{PlanId, Queue};
 #[cfg(feature = "progress_bar")]
@@ -441,8 +442,7 @@ impl Context {
             }
         }
 
-        let population = self.get_current_population();
-        let stats = self.execution_profiler.compute_final_statistics(population);
+        let stats = self.get_execution_statistics();
         if self.print_execution_statistics {
             print_execution_statistics(&stats);
         } else {
@@ -501,6 +501,11 @@ impl Context {
             self.shutdown_requested = true;
         }
     }
+
+    pub fn get_execution_statistics(&mut self) -> ExecutionStatistics {
+        let population = self.get_current_population();
+        self.execution_profiler.compute_final_statistics(population)
+    }
 }
 
 /// A supertrait that exposes useful methods from `Context`
@@ -543,6 +548,7 @@ pub trait PluginContext: Sized {
     fn get_data_mut<T: DataPlugin>(&mut self, plugin: T) -> &mut T::DataContainer;
     fn get_data<T: DataPlugin>(&self, plugin: T) -> &T::DataContainer;
     fn get_current_time(&self) -> f64;
+    fn get_execution_statistics(&mut self) -> ExecutionStatistics;
 }
 impl PluginContext for Context {
     delegate::delegate! {
@@ -557,6 +563,7 @@ impl PluginContext for Context {
             fn get_data_mut<T: DataPlugin>(&mut self, plugin: T) -> &mut T::DataContainer;
             fn get_data<T: DataPlugin>(&self, plugin: T) -> &T::DataContainer;
             fn get_current_time(&self) -> f64;
+            fn get_execution_statistics(&mut self) -> ExecutionStatistics;
         }
     }
 }

--- a/src/execution_stats.rs
+++ b/src/execution_stats.rs
@@ -4,6 +4,7 @@
 use bytesize::ByteSize;
 use humantime::format_duration;
 use log::{debug, error, info};
+use serde_derive::Serialize;
 use std::time::Duration;
 #[cfg(not(target_arch = "wasm32"))]
 use std::time::Instant;
@@ -27,6 +28,7 @@ pub fn get_high_res_time() -> f64 {
 
 /// A container struct for computed final statistics. Note that if population size
 /// is zero, then the per person statistics are also zero, as they are meaningless.
+#[derive(Serialize)]
 pub struct ExecutionStatistics {
     max_memory_usage: u64,
     cpu_time: Duration,
@@ -40,7 +42,7 @@ pub struct ExecutionStatistics {
 }
 
 #[cfg_attr(target_arch = "wasm32", allow(dead_code))]
-pub struct ExecutionProfilingCollector {
+pub(crate) struct ExecutionProfilingCollector {
     /// Simulation start time, used to compute elapsed wall time for the simulation execution
     #[cfg(not(target_arch = "wasm32"))]
     start_time: Instant,
@@ -96,9 +98,9 @@ impl ExecutionProfilingCollector {
         new_stats
     }
 
-    /// If at least 1 second has passed since the previous refresh, memory usage is polled and
-    /// updated. Call this method as frequently as you like, as it takes care of limiting polling
-    /// frequency itself.
+    /// If at least `REFRESH_INTERVAL` (1 second) has passed since the previous
+    /// refresh, memory usage is polled and updated. Call this method as frequently
+    /// as you like, as it takes care of limiting polling frequency itself.
     #[inline]
     pub fn refresh(&mut self) {
         #[cfg(not(target_arch = "wasm32"))]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -111,7 +111,7 @@ pub mod prelude_for_plugins {
     pub use ixa_derive::IxaEvent;
 }
 
-mod execution_stats;
+pub mod execution_stats;
 
 #[cfg(all(target_arch = "wasm32", feature = "debugger"))]
 compile_error!(


### PR DESCRIPTION
This PR adds `Context::get_execution_statistics(&mut self) -> ExecutionStatistics` and also a method on `PluginContext` that delegates to it. The purpose is to expose the collected statistics for consumption by profiling modules like the one proposed for epi-isolation. 

**Future Direction**
If/when the profiling module is ported back to ixa core, displaying or logging a context's`ExecutionStatistics` can be moved into that module. (Right now it's a free function in `execution_stats.rs`.) We can convert the execution statistics collector into a data plugin in which the mechanism used to refresh the execution stats is a periodic plan.