### PR TITLE
fix: Made the fields of `ExecutionStatistics` public

### DIFF
--- a/src/execution_stats.rs
+++ b/src/execution_stats.rs
@@ -58,7 +58,7 @@ pub(crate) struct ExecutionProfilingCollector {
     /// to compute the CPU time of the simulation execution
     start_cpu_time: u64,
     /// The maximum amount of real memory used by the process as reported by
-    /// `sysinfo:System::process::memory()`. This value is polled during execution to capture the
+    /// `sysinfo::System::process::memory()`. This value is polled during execution to capture the
     /// max.
     max_memory_usage: u64,
     /// A `sysinfo::System` for polling memory use

--- a/src/execution_stats.rs
+++ b/src/execution_stats.rs
@@ -30,15 +30,15 @@ pub fn get_high_res_time() -> f64 {
 /// is zero, then the per person statistics are also zero, as they are meaningless.
 #[derive(Serialize)]
 pub struct ExecutionStatistics {
-    max_memory_usage: u64,
-    cpu_time: Duration,
-    wall_time: Duration,
+    pub max_memory_usage: u64,
+    pub cpu_time: Duration,
+    pub wall_time: Duration,
 
     // Per person stats
-    population: usize,
-    cpu_time_per_person: Duration,
-    wall_time_per_person: Duration,
-    memory_per_person: u64,
+    pub population: usize,
+    pub cpu_time_per_person: Duration,
+    pub wall_time_per_person: Duration,
+    pub memory_per_person: u64,
 }
 
 #[cfg_attr(target_arch = "wasm32", allow(dead_code))]


### PR DESCRIPTION
In a previous PR (#489) we exposed `ExecutionStatistics` in the public API for client code to use. But we forgot to make the fields public! Oops. This PR just adds `pub` to each field.