### PR TITLE
chore: Disable pedantic and add ignore mismatched_lifetime_syntaxes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -145,17 +145,14 @@ roots.workspace = true
 ixa_example_basic_infection = { path = "examples/basic-infection" }
 ixa_example_births_deaths = { path = "examples/births-deaths" }
 
+[workspace.lints.rust]
+mismatched_lifetime_syntaxes = "allow"
+
+# https://rust-lang.github.io/rust-clippy/master/index.html
 [workspace.lints.clippy]
-pedantic = { level = "warn", priority = -1 }
 module-name-repetitions = "allow"
-implicit_hasher = "allow"
-missing_panics_doc = "allow"
-missing_errors_doc = "allow"
-uninlined_format_args = "allow"
 result_unit_err = "allow"
-struct_field_names = "allow"
-unnecessary_debug_formatting = "allow"
-struct_excessive_bools = "allow"
+mismatched_lifetime_syntaxes = "allow"
 
 [lints]
 workspace = true

--- a/examples/births-deaths/src/population_manager.rs
+++ b/examples/births-deaths/src/population_manager.rs
@@ -219,7 +219,7 @@ mod test {
         let mut context = Context::new();
         let age_vec = vec![0, 5, 62, 80];
         let years = 5.0;
-        let age_groups = vec![
+        let age_groups = [
             AgeGroupRisk::NewBorn,
             AgeGroupRisk::General,
             AgeGroupRisk::General,
@@ -243,7 +243,7 @@ mod test {
         }
 
         // Plan to check in 5 years
-        let future_age_groups = vec![
+        let future_age_groups = [
             AgeGroupRisk::General,
             AgeGroupRisk::General,
             AgeGroupRisk::OldAdult,

--- a/src/log/wasm_logger.rs
+++ b/src/log/wasm_logger.rs
@@ -48,11 +48,9 @@ impl LogConfiguration {
         let mut longest_match = None;
         for (prefix, config) in &self.module_configurations {
             if target.starts_with(prefix)
-                && longest_match
-                    .as_ref()
-                    .map_or(true, |(m, _): &(&String, &ModuleLogConfiguration)| {
-                        m.len() < prefix.len()
-                    })
+                && longest_match.as_ref().is_none_or(
+                    |(m, _): &(&String, &ModuleLogConfiguration)| m.len() < prefix.len(),
+                )
             {
                 longest_match = Some((prefix, config));
             }

--- a/src/people/context_extension.rs
+++ b/src/people/context_extension.rs
@@ -666,15 +666,6 @@ mod tests {
         age >= threshold
     });
 
-    // This isn't used, it's just testing for a compile error.
-    define_derived_property!(
-        NotUsed,
-        bool,
-        [Age],
-        [ThresholdP, ThresholdP],
-        |age, threshold, threshold2| { age >= threshold && age <= threshold2 }
-    );
-
     define_derived_property!(AgeGroup, AgeGroupValue, [Age], |age| {
         if age < 18 {
             AgeGroupValue::Child

--- a/src/people/event.rs
+++ b/src/people/event.rs
@@ -49,9 +49,6 @@ mod tests {
         Adult,
     }
     define_global_property!(Threshold, u8);
-    define_derived_property!(IsEligible, bool, [Age], [Threshold], |age, threshold| {
-        age >= threshold
-    });
 
     define_derived_property!(AgeGroup, AgeGroupValue, [Age], |age| {
         if age < 18 {

--- a/src/people/query.rs
+++ b/src/people/query.rs
@@ -136,7 +136,6 @@ mod tests {
     define_person_property!(Age, u8);
     define_person_property!(County, u32);
     define_person_property!(Height, u32);
-    define_derived_property!(AgeGroup, u8, [Age], |age| (age / 5));
 
     #[derive(Serialize, Copy, Clone, PartialEq, Eq, Debug)]
     pub enum RiskCategoryValue {

--- a/src/tabulator.rs
+++ b/src/tabulator.rs
@@ -93,8 +93,7 @@ impl Tabulator for Vec<(TypeId, String)> {
 mod tests {
     use super::Tabulator;
     use crate::{
-        define_derived_property, define_person_property, define_person_property_with_default,
-        Context, ContextPeopleExt,
+        define_person_property, define_person_property_with_default, Context, ContextPeopleExt,
     };
     use crate::{HashSet, HashSetExt};
     use std::any::TypeId;
@@ -105,9 +104,6 @@ mod tests {
     define_person_property!(RiskCategory, RiskCategoryValue);
     define_person_property_with_default!(IsRunner, bool, false);
     define_person_property_with_default!(IsSwimmer, bool, false);
-    define_derived_property!(AdultSwimmer, bool, [IsSwimmer, Age], |is_swimmer, age| {
-        is_swimmer && age >= 18
-    });
 
     #[test]
     fn test_tabulator() {


### PR DESCRIPTION
This PR removes pedantic + pedantic-specific `allow`s in Cargo.toml and disables the new rule we discussed.

I am not sure why some lint errors showed up that didn't before 

Fixes #504 