### PR TITLE
feat: Reimplemented Index to be type aware: `Index<T>`.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ csv = "^1.3.1"
 serde = { version = "^1.0.217", features = ["derive"] }
 serde_derive = "^1.0.217"
 serde_json = "^1.0.135"
-bincode = "^1.3.3"
+bincode = { version = "^2.0.1", default-features = false, features = ["std", "serde"] }
 reikna = "^0.12.3"
 ixa-derive = { version = "0.0.2", path = "ixa-derive" }
 seq-macro = "^0.3.5"
@@ -61,6 +61,8 @@ sysinfo = "^0.37.0"
 humantime = "^2.2.0"
 bytesize = "^2.0.1"
 polonius-the-crab = "^0.4.2"
+hashbrown = "^0.15.5"
+twox-hash = { version = "^2.1.1", default-features = false, features = ["xxhash3_128", "std"] }
 
 [package]
 name = "ixa"
@@ -100,6 +102,8 @@ sysinfo.workspace = true
 humantime.workspace = true
 bytesize.workspace = true
 polonius-the-crab.workspace = true
+hashbrown.workspace = true
+twox-hash.workspace = true
 
 # Non-WASM targets
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,7 +40,7 @@ reqwest = { version = "^0.12.12", features = ["blocking", "json"] }
 uuid = "^1.12.1"
 tower-http = { version = "^0.6.2", features = ["full"] }
 mime = "^0.3.17"
-rustc-hash = "^2.1.1"
+gxhash = { version = "3.5.0", features = ["deterministic"] }
 rand_distr = "^0.4.3"
 tempfile = "^3.15.0"
 assert_cmd = "^2.0.16"
@@ -62,7 +62,6 @@ humantime = "^2.2.0"
 bytesize = "^2.0.1"
 polonius-the-crab = "^0.4.2"
 hashbrown = "^0.15.5"
-twox-hash = { version = "^2.1.1", default-features = false, features = ["xxhash3_128", "std"] }
 
 [package]
 name = "ixa"
@@ -92,7 +91,6 @@ ixa-derive.workspace = true
 log.workspace = true
 paste.workspace = true
 rand.workspace = true
-rustc-hash.workspace = true
 seq-macro.workspace = true
 serde.workspace = true
 serde_derive.workspace = true
@@ -103,7 +101,7 @@ humantime.workspace = true
 bytesize.workspace = true
 polonius-the-crab.workspace = true
 hashbrown.workspace = true
-twox-hash.workspace = true
+gxhash.workspace = true
 
 # Non-WASM targets
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]

--- a/src/hashing.rs
+++ b/src/hashing.rs
@@ -14,9 +14,12 @@
 //!
 //! The `hash_usize` free function is a convenience function used in `crate::random::get_rng`.
 
+use bincode::serde::encode_to_vec as serialize_to_vec;
 pub use rustc_hash::FxHashMap as HashMap;
 pub use rustc_hash::FxHashSet as HashSet;
-use std::hash::Hasher;
+use serde::Serialize;
+use std::hash::{Hash, Hasher};
+use twox_hash::XxHash3_128;
 
 /// Provides API parity with `std::collections::HashMap`.
 pub trait HashMapExt {
@@ -47,4 +50,75 @@ pub fn hash_str(data: &str) -> u64 {
     let mut hasher = rustc_hash::FxHasher::default();
     hasher.write(data.as_bytes());
     hasher.finish()
+}
+
+pub struct Xxh3Hasher128(XxHash3_128);
+
+impl Default for Xxh3Hasher128 {
+    fn default() -> Self {
+        Self(XxHash3_128::new())
+        // or Xxh3::with_seed(seed) for domain separation
+    }
+}
+
+impl Hasher for Xxh3Hasher128 {
+    fn write(&mut self, bytes: &[u8]) {
+        self.0.write(bytes); // stream bytes, no allocation
+    }
+    // Hasher requires a u64 result; return the low 64 bits of the 128-bit digest.
+    #[allow(clippy::cast_possible_truncation)]
+    fn finish(&self) -> u64 {
+        self.0.finish_128() as u64
+    }
+}
+
+impl Xxh3Hasher128 {
+    pub fn finish_u128(self) -> u128 {
+        // consume the state to produce the 128-bit digest
+        self.0.finish_128()
+    }
+}
+
+// Helper for any T: Hash
+pub fn one_shot_128<T: Hash>(value: &T) -> u128 {
+    let mut h = Xxh3Hasher128::default();
+    value.hash(&mut h);
+    h.finish_u128()
+}
+
+pub fn hash_serialized_128<T: Serialize>(value: T) -> u128 {
+    let serialized = serialize_to_vec(&value, bincode::config::standard()).unwrap();
+    one_shot_128(&serialized)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn hashes_strings() {
+        let a = one_shot_128(&"hello");
+        let b = one_shot_128(&"hello");
+        let c = one_shot_128(&"world");
+        assert_eq!(a, b);
+        assert_ne!(a, c);
+    }
+
+    #[test]
+    fn hashes_structs() {
+        #[derive(Hash)]
+        struct S {
+            x: u32,
+            y: String,
+        }
+        let h1 = one_shot_128(&S {
+            x: 1,
+            y: "a".into(),
+        });
+        let h2 = one_shot_128(&S {
+            x: 1,
+            y: "a".into(),
+        });
+        assert_eq!(h1, h2);
+    }
 }

--- a/src/people/external_api.rs
+++ b/src/people/external_api.rs
@@ -3,7 +3,6 @@ use crate::people::PeoplePlugin;
 use crate::IxaError;
 use crate::PersonId;
 use crate::{Context, PluginContext};
-use crate::{HashMap, HashMapExt};
 use std::any::TypeId;
 
 #[cfg_attr(not(feature = "web_api"), allow(dead_code))]
@@ -44,8 +43,8 @@ pub(crate) trait ContextPeopleExtCrate: PluginContext + ContextPeopleExt {
         let data_container = self.get_data(PeoplePlugin);
 
         let mut index = data_container.get_index_ref_mut(type_id).unwrap();
-        if index.lookup.is_none() {
-            index.lookup = Some(HashMap::new());
+        if !index.is_indexed() {
+            index.set_indexed(true);
         }
     }
 

--- a/src/people/index.rs
+++ b/src/people/index.rs
@@ -1,122 +1,175 @@
-use super::methods::Methods;
+/*!
+
+Each property type `P: PersonProperty` has a corresponding `Index<P>` type a single
+instance of which is stored in the `PeopleData::property_indexes: RefCell<HashMap<TypeId,
+BxIndex>>` map. The map `PeopleData::property_indexes` is keyed by the `TypeId` of the
+property tag type `P`, _not_ the value type of the property, `PersonProperty::Value`.
+
+`Index<P>::lookup: HashTable<(T, std::collections::HashSet<PersonId>)>` is a hash table,
+_not_ a hash map. The difference is, a hash table is keyed by a `u64`, in our case,
+the 64-bit hash of the property value, and allows for a custom equality check. For
+equality, we compare the 128-bit hash of the property value. This allows us to keep the
+lookup operation completely type-erased. The value associated with the key is a tuple
+of the property value and a set of `PersonId`s. The property value is stored so that
+
+1. we can compute its 128-bit hash to check equality during lookup,
+2. we can iterate over (property value, set of `PersonId`s) pairs in the typed API, and
+3. we can iterate over (serialized property value, set of `PersonId`s) pairs in the type-erased API.
+
+*/
+
 use crate::people::external_api::ContextPeopleExtCrate;
-use crate::{Context, ContextPeopleExt, PersonId, PersonProperty};
-use crate::{HashMap, HashMapExt, HashSet, HashSetExt};
-use bincode::serialize;
-use serde::ser::{Serialize, Serializer};
+use crate::{
+    hashing::one_shot_128, people::HashValueType, Context, ContextPeopleExt, HashMap, HashSet,
+    PersonId, PersonProperty,
+};
+use hashbrown::HashTable;
 use std::any::TypeId;
 use std::cell::RefCell;
-use std::collections::hash_map::DefaultHasher;
-use std::hash::{Hash, Hasher};
-use std::sync::Arc;
-use std::sync::LazyLock;
-use std::sync::Mutex;
+use std::sync::{Arc, LazyLock, Mutex};
 
-#[derive(Clone, Copy, PartialEq, Eq, Hash, Debug)]
-// The lookup key for entries in the index. This is a serialized version of the value.
-// If that serialization fits in 128 bits, we store it in `IndexValue::Fixed`
-// Otherwise, we use a 64 bit hash.
-#[doc(hidden)]
-pub enum IndexValue {
-    Fixed(u128),
-    Hashed(u64),
-}
+pub type BxIndex = Box<dyn TypeErasedIndex>;
 
-impl Serialize for IndexValue {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: Serializer,
-    {
-        match self {
-            IndexValue::Fixed(value) => serializer.serialize_u128(*value),
-            IndexValue::Hashed(value) => serializer.serialize_u64(*value),
-        }
-    }
-}
-
-impl IndexValue {
-    pub fn compute<T: Serialize>(val: &T) -> IndexValue {
-        // Serialize `val` to a `Vec<u8>` using `bincode`
-        let serialized_data = serialize(val).expect("Failed to serialize value");
-
-        // If serialized data fits within 16 bytes...
-        if serialized_data.len() <= 16 {
-            // ...store it as `IndexValue::Fixed`
-            let mut tmp: [u8; 16] = [0; 16];
-            tmp[..serialized_data.len()].copy_from_slice(&serialized_data[..]);
-
-            IndexValue::Fixed(u128::from_le_bytes(tmp))
-        } else {
-            // Otherwise, hash the data and store it as `IndexValue::Hashed`
-            let mut hasher = DefaultHasher::new();
-            serialized_data.hash(&mut hasher);
-            let hash = hasher.finish(); // Produces a 64-bit hash
-            IndexValue::Hashed(hash)
-        }
-    }
-}
-
-// An index for a single property.
-pub struct Index {
+/// The typed index.
+#[derive(Default)]
+pub struct Index<T: PersonProperty> {
     // Primarily for debugging purposes
     #[allow(dead_code)]
     pub(super) name: &'static str,
 
-    // The hash of the property value maps to a list of PersonIds
-    // or None if we're not indexing
-    pub(super) lookup: Option<HashMap<IndexValue, (String, HashSet<PersonId>)>>,
+    // We store a copy of the value here so that we can iterate over
+    // it in the typed API, and so that the type-erased API can
+    // access some serialization of it.
+    lookup: HashTable<(T::Value, HashSet<PersonId>)>,
 
     // The largest person ID that has been indexed. Used so that we
     // can lazily index when a person is added.
     pub(super) max_indexed: usize,
+
+    pub(super) is_indexed: bool,
 }
 
-impl Index {
-    pub(super) fn new<T: PersonProperty>(_context: &Context, _property: T) -> Self {
-        Self {
-            name: std::any::type_name::<T>(),
-            lookup: None,
+/// Implements the typed API
+impl<T: PersonProperty> Index<T> {
+    #[must_use]
+    pub fn new() -> Box<Self> {
+        Box::new(Self {
+            name: T::name(),
+            lookup: HashTable::default(),
             max_indexed: 0,
-        }
+            is_indexed: false,
+        })
     }
 
-    pub(super) fn add_person(&mut self, context: &Context, methods: &Methods, person_id: PersonId) {
-        let hash = (methods.indexer)(context, person_id);
+    /// Inserts an entity into the set associated with `key`, creating a new set if one does not yet exist. Returns a
+    /// `bool` according to whether the `entity_id` already existed in the set.
+    pub fn add_person(&mut self, key: &T::Value, entity_id: PersonId) -> bool {
+        let hash = T::hash_property_value(key);
+
+        // > `hasher` is called if entries need to be moved or copied to a new table.
+        // > This must return the same hash value that each entry was inserted with.
+        #[allow(clippy::cast_possible_truncation)]
+        let hasher = |(stored_value, _stored_set): &_| T::hash_property_value(stored_value) as u64;
+        // Equality is determined by comparing the full 128-bit hashes. We do not expect any collisions before the heat
+        // death of the universe.
+        let hash128_equality = |(stored_value, _): &_| T::hash_property_value(stored_value) == hash;
+        #[allow(clippy::cast_possible_truncation)]
         self.lookup
-            .as_mut()
-            .unwrap()
-            .entry(hash)
-            .or_insert_with(|| ((methods.get_display)(context, person_id), HashSet::new()))
+            .entry(hash as u64, hash128_equality, hasher)
+            .or_insert_with(|| (*key, HashSet::default()))
+            .get_mut()
             .1
-            .insert(person_id);
+            .insert(entity_id)
     }
 
-    pub(super) fn remove_person(
-        &mut self,
-        context: &Context,
-        methods: &Methods,
-        person_id: PersonId,
-    ) {
-        let hash = (methods.indexer)(context, person_id);
-        if let Some(entry) = self.lookup.as_mut().unwrap().get_mut(&hash) {
-            entry.1.remove(&person_id);
+    pub fn remove_person(&mut self, key: &T::Value, entity_id: PersonId) {
+        let hash = T::hash_property_value(key);
+        self.remove_person_with_hash(hash, entity_id);
+    }
+}
+
+/// This trait Encapsulates the type-erased API.
+pub trait TypeErasedIndex {
+    fn as_any_mut(&mut self) -> &mut dyn std::any::Any;
+
+    /// Removing a person only requires the hash.
+    fn remove_person_with_hash(&mut self, hash: HashValueType, entity_id: PersonId);
+
+    /// Fetching a set only requires the hash.
+    fn get_with_hash(&self, hash: HashValueType) -> Option<&HashSet<PersonId>>;
+
+    // /// Fetching a set only requires the hash.
+    // fn get_with_hash_mut(&mut self, hash: HashValueType) -> Option<&mut HashSet<PersonId>>;
+
+    fn is_indexed(&self) -> bool;
+    fn set_indexed(&mut self, is_indexed: bool);
+    fn index_unindexed_people(&mut self, context: &Context);
+
+    /// Produces an iterator over pairs (serialized property value, set of `PersonId`s).
+    fn iter_serialized_values_people(
+        &self,
+    ) -> Box<dyn Iterator<Item = (String, &HashSet<PersonId>)> + '_>;
+}
+
+// Implements the type-erased API for Index<T>.
+impl<T: PersonProperty> TypeErasedIndex for Index<T> {
+    fn as_any_mut(&mut self) -> &mut dyn std::any::Any {
+        self
+    }
+
+    /// Removing a person only requires the hash.
+    fn remove_person_with_hash(&mut self, hash: HashValueType, entity_id: PersonId) {
+        // Equality is determined by comparing the full 128-bit hashes. We do not expect any
+        // collisions before the heat death of the universe.
+        let hash128_equality = |(stored_value, _): &_| T::hash_property_value(stored_value) == hash;
+
+        #[allow(clippy::cast_possible_truncation)]
+        if let Ok(mut entry) = self.lookup.find_entry(hash as u64, hash128_equality) {
+            let (_, set) = entry.get_mut();
+            set.remove(&entity_id);
             // Clean up the entry if there are no people
-            if entry.0.is_empty() {
-                self.lookup.as_mut().unwrap().remove(&hash);
+            if set.is_empty() {
+                entry.remove();
             }
         }
     }
 
-    pub(super) fn index_unindexed_people(&mut self, context: &Context, methods: &Methods) {
-        if self.lookup.is_none() {
+    /// Fetching a set only requires the hash.
+    fn get_with_hash(&self, hash: HashValueType) -> Option<&HashSet<PersonId>> {
+        // Equality is determined by comparing the full 128-bit hashes. We do not expect
+        // any collisions before the heat death of the universe.
+        let hash128_equality = |(stored_value, _): &_| T::hash_property_value(stored_value) == hash;
+        #[allow(clippy::cast_possible_truncation)]
+        self.lookup
+            .find(hash as u64, hash128_equality)
+            .map(|(_, set)| set)
+    }
+
+    fn is_indexed(&self) -> bool {
+        self.is_indexed
+    }
+
+    fn set_indexed(&mut self, is_indexed: bool) {
+        self.is_indexed = is_indexed;
+    }
+
+    fn index_unindexed_people(&mut self, context: &Context) {
+        if !self.is_indexed {
             return;
         }
         let current_pop = context.get_current_population();
         for id in self.max_indexed..current_pop {
             let person_id = PersonId(id);
-            self.add_person(context, methods, person_id);
+            let value = context.get_person_property(person_id, T::get_instance());
+            self.add_person(&value, person_id);
         }
         self.max_indexed = current_pop;
+    }
+
+    fn iter_serialized_values_people(
+        &self,
+    ) -> Box<dyn Iterator<Item = (String, &HashSet<PersonId>)> + '_> {
+        Box::new(self.lookup.iter().map(|(k, v)| (T::get_display(k), v)))
     }
 }
 
@@ -128,58 +181,68 @@ pub struct MultiIndex {
     type_id: TypeId,
 }
 
-// A static map of multi-property indices. This is used to register multi-property property indices
-// when they are first created. The map is keyed by the property IDs of the properties that are
-// indexed. The values are the `MultiIndex` objects that contain the registration function and
-// the type ID of the index.
+/// A static map of multi-property indices. This is used to register multi-property
+/// property indices when they are first created. The map is keyed by the property IDs of
+/// the properties that are indexed. The values are the `MultiIndex` objects that contain
+/// a function which registers and indexes the property and the type ID of the index.
 #[doc(hidden)]
 #[allow(clippy::type_complexity)]
 pub static MULTI_PROPERTY_INDEX_MAP: LazyLock<
-    Mutex<RefCell<HashMap<Vec<TypeId>, Arc<MultiIndex>>>>,
-> = LazyLock::new(|| Mutex::new(RefCell::new(HashMap::new())));
+    Mutex<RefCell<HashMap<HashValueType, Arc<MultiIndex>>>>,
+> = LazyLock::new(|| Mutex::new(RefCell::new(HashMap::default())));
 
+/// Creates a record in `MULTI_PROPERTY_INDEX_MAP` if one doesn't already exist.
+/// Called from the `define_multi_property_index!` macro. The registered `type_id`
+/// for a multi-index is the `type_id` of the first multi-index having that set
+/// of properties to register.
 #[allow(dead_code)]
-pub fn add_multi_property_index<T: PersonProperty>(property_ids: &[TypeId], index_type: TypeId) {
+pub fn add_multi_property_index<T: PersonProperty>(
+    property_type_ids: &mut [TypeId],
+    index_type: TypeId,
+) {
     let current_map = MULTI_PROPERTY_INDEX_MAP.lock().unwrap();
     let mut map = current_map.borrow_mut();
-    let mut ordered_property_ids = property_ids.to_owned();
-    ordered_property_ids.sort();
-    map.entry(ordered_property_ids)
-        .or_insert(Arc::new(MultiIndex {
-            register: Box::new(|context| {
-                context.register_property::<T>();
-                context.index_property_by_id(TypeId::of::<T>());
-            }),
-            type_id: index_type,
-        }));
+    let property_id_hash = get_multi_property_hash(property_type_ids);
+
+    map.entry(property_id_hash).or_insert(Arc::new(MultiIndex {
+        register: Box::new(|context| {
+            context.register_property::<T>();
+            context.index_property_by_id(TypeId::of::<T>());
+        }),
+        type_id: index_type,
+    }));
 }
 
 pub fn get_and_register_multi_property_index(
-    query: &[(TypeId, IndexValue)],
+    query: &[(TypeId, HashValueType)],
     context: &Context,
 ) -> Option<TypeId> {
     let map = MULTI_PROPERTY_INDEX_MAP.lock().unwrap();
     let map = map.borrow();
-    let mut sorted_query = query.to_owned();
-    sorted_query.sort_by(|a, b| a.0.cmp(&b.0));
-    let items = query.iter().map(|(t, _)| *t).collect::<Vec<_>>();
-    if let Some(multi_index) = map.get(&items) {
+    let mut property_type_ids = query.iter().map(|(id, _)| *id).collect::<Vec<_>>();
+    let hash = get_multi_property_hash(&mut property_type_ids);
+
+    if let Some(multi_index) = map.get(&hash) {
         (multi_index.register)(context);
         return Some(multi_index.type_id);
     }
     None
 }
 
-pub fn get_multi_property_hash(query: &[(TypeId, IndexValue)]) -> IndexValue {
-    let mut sorted_query = query.to_owned();
-    sorted_query.sort_by(|a, b| a.0.cmp(&b.0));
-    let items = query.iter().map(|(_, i)| *i).collect::<Vec<_>>();
-    IndexValue::compute(&IndexValue::compute(&items))
+pub fn get_multi_property_value_hash(query: &[(TypeId, HashValueType)]) -> HashValueType {
+    let mut items = query.iter().map(|(_, i)| *i).collect::<Vec<_>>();
+    items.sort_unstable();
+    one_shot_128(&items)
+}
+
+pub fn get_multi_property_hash(property_type_ids: &mut [TypeId]) -> HashValueType {
+    property_type_ids.sort();
+    one_shot_128(&property_type_ids)
 }
 
 pub fn process_indices(
     context: &Context,
-    remaining_indices: &[&Index],
+    remaining_indices: &[&BxIndex],
     property_names: &mut Vec<String>,
     current_matches: &HashSet<PersonId>,
     print_fn: &dyn Fn(&Context, &[String], usize),
@@ -189,17 +252,15 @@ pub fn process_indices(
         return;
     }
 
-    let (next_index, rest_indices) = remaining_indices.split_first().unwrap();
-    let lookup = next_index.lookup.as_ref().unwrap();
-
+    let (&next_index, rest_indices) = remaining_indices.split_first().unwrap();
     // If there is nothing in the index, we don't need to process it
-    if lookup.is_empty() {
+    if !next_index.is_indexed() {
         return;
     }
 
-    for (display, people) in lookup.values() {
+    for (display, people) in next_index.iter_serialized_values_people() {
         let intersect = !property_names.is_empty();
-        property_names.push(display.clone());
+        property_names.push(display);
 
         let matches = if intersect {
             &current_matches.intersection(people).copied().collect()
@@ -216,56 +277,49 @@ pub fn process_indices(
 mod test {
     // Tests in `src/people/query.rs` also exercise indexing code.
 
-    use crate::people::index::{Index, IndexValue};
-    use crate::{define_person_property, Context, ContextPeopleExt};
+    use crate::hashing::{hash_serialized_128, one_shot_128};
+    use crate::people::index::{HashValueType, Index};
+    use crate::prelude::*;
+    use crate::PersonProperty;
     use std::any::TypeId;
 
     define_person_property!(Age, u8);
 
     #[test]
     fn index_name() {
-        let context = Context::new();
-        let index = Index::new(&context, Age);
+        let index = Index::<Age>::new();
         assert!(index.name.contains("Age"));
     }
 
     #[test]
-    fn test_index_value_hasher_finish2_short() {
-        let value = 42;
-        let index = IndexValue::compute(&value);
-        assert!(matches!(index, IndexValue::Fixed(_)));
-    }
-
-    #[test]
-    fn test_index_value_hasher_finish2_long() {
-        let value = "this is a longer string that exceeds 16 bytes";
-        let index = IndexValue::compute(&value);
-        assert!(matches!(index, IndexValue::Hashed(_)));
-    }
-
-    #[test]
     fn test_index_value_compute_same_values() {
-        let value = "test value";
-        let value2 = "test value";
-        assert_eq!(IndexValue::compute(&value), IndexValue::compute(&value2));
+        let value = hash_serialized_128("test value");
+        let value2 = hash_serialized_128("test value");
+        assert_eq!(one_shot_128(&value), one_shot_128(&value2));
     }
 
     #[test]
     fn test_index_value_compute_different_values() {
         let value1 = 42;
         let value2 = 43;
-        assert_ne!(IndexValue::compute(&value1), IndexValue::compute(&value2));
+        assert_ne!(
+            <Age as PersonProperty>::hash_property_value(&value1),
+            <Age as PersonProperty>::hash_property_value(&value2)
+        );
     }
 
     #[test]
     fn test_multi_property_index_map_add_get_and_hash() {
         let mut context = Context::new();
-        let _person = context.add_person((Age, 64)).unwrap();
-        let property_ids = vec![TypeId::of::<Age>()];
-        let index_type = TypeId::of::<IndexValue>();
-        super::add_multi_property_index::<Age>(&property_ids, index_type);
-        let query = vec![(TypeId::of::<Age>(), IndexValue::Fixed(42))];
-        let _ = super::get_multi_property_hash(&query);
+        let _person = context.add_person((Age, 64u8)).unwrap();
+        let mut property_ids = vec![TypeId::of::<Age>()];
+        let index_type = TypeId::of::<HashValueType>();
+        super::add_multi_property_index::<Age>(&mut property_ids, index_type);
+        let query = vec![(
+            TypeId::of::<Age>(),
+            <Age as PersonProperty>::hash_property_value(&42u8),
+        )];
+        let _ = super::get_multi_property_value_hash(&query);
         let registered_index = super::get_and_register_multi_property_index(&query, &context);
         assert!(registered_index.is_some());
     }

--- a/src/people/methods.rs
+++ b/src/people/methods.rs
@@ -1,13 +1,13 @@
 /// Synthesized per-type methods that encapsulate the person
 /// property type.
-use crate::people::index::IndexValue;
+use crate::people::HashValueType;
 use crate::{Context, ContextPeopleExt, PersonId, PersonProperty};
 
 type PersonCallback<T> = dyn Fn(&Context, PersonId) -> T;
 
 pub(crate) struct Methods {
-    // A callback that calculates the IndexValue of a person's current property value
-    pub(super) indexer: Box<PersonCallback<IndexValue>>,
+    // A callback that calculates the 128-bit hash of a person's current property value
+    pub(super) indexer: Box<PersonCallback<HashValueType>>,
 
     // A callback that calculates the display value of a person's current property value
     pub(super) get_display: Box<PersonCallback<String>>,
@@ -18,7 +18,7 @@ impl Methods {
         Self {
             indexer: Box::new(move |context: &Context, person_id: PersonId| {
                 let value = context.get_person_property(person_id, T::get_instance());
-                IndexValue::compute(&value)
+                T::hash_property_value(&value)
             }),
             get_display: Box::new(move |context: &Context, person_id: PersonId| {
                 let value = context.get_person_property(person_id, T::get_instance());

--- a/src/people/mod.rs
+++ b/src/people/mod.rs
@@ -83,7 +83,7 @@ pub use context_extension::ContextPeopleExt;
 use data::PeopleData;
 pub use data::PersonPropertyHolder;
 pub use event::{PersonCreatedEvent, PersonPropertyChangeEvent};
-pub use index::{add_multi_property_index, Index, IndexValue};
+pub use index::{add_multi_property_index, Index};
 pub use property::{
     define_derived_property, define_person_property, define_person_property_with_default,
     PersonProperty,
@@ -95,6 +95,8 @@ use serde::{Deserialize, Serialize};
 use std::cell::RefCell;
 use std::fmt::{Debug, Display, Formatter};
 use std::{any::TypeId, hash::Hash};
+
+pub type HashValueType = u128;
 
 define_data_plugin!(
     PeoplePlugin,


### PR DESCRIPTION
- Separated typed and type-erased indexing API.
- Added `PersonProperty::hash_property_value`. This allows us to have special hashing, say, for multi-properties.
- Added 128-bit hash function for equality test in index hash table.