### PR TITLE
feat: Use bump allocator for allocations during querying

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,6 +61,7 @@ sysinfo = "^0.37.0"
 humantime = "^2.2.0"
 bytesize = "^2.0.1"
 polonius-the-crab = "^0.4.2"
+bumpalo = { version = "3.19.0", features = ["collections", "boxed"] }
 
 [package]
 name = "ixa"
@@ -100,6 +101,7 @@ sysinfo.workspace = true
 humantime.workspace = true
 bytesize.workspace = true
 polonius-the-crab.workspace = true
+bumpalo.workspace = true
 
 # Non-WASM targets
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]

--- a/src/people/data.rs
+++ b/src/people/data.rs
@@ -4,6 +4,7 @@ use crate::people::methods::Methods;
 use crate::people::InitializationList;
 use crate::{Context, IxaError, PersonId, PersonProperty, PersonPropertyChangeEvent};
 use crate::{HashMap, HashSet, HashSetExt};
+use bumpalo::Bump;
 use std::any::{Any, TypeId};
 use std::cell::{Ref, RefCell, RefMut};
 
@@ -35,6 +36,7 @@ pub(super) struct PeopleData {
     pub(super) dependency_map: RefCell<HashMap<TypeId, Vec<Box<dyn PersonPropertyHolder>>>>,
     pub(super) property_indexes: RefCell<HashMap<TypeId, Index>>,
     pub(super) people_types: RefCell<HashMap<String, TypeId>>,
+    pub(super) allocator: RefCell<Bump>,
 }
 
 // The purpose of this trait is to enable storing a Vec of different

--- a/src/people/mod.rs
+++ b/src/people/mod.rs
@@ -108,6 +108,7 @@ define_data_plugin!(
         dependency_map: RefCell::new(HashMap::new()),
         property_indexes: RefCell::new(HashMap::new()),
         people_types: RefCell::new(HashMap::new()),
+        allocator: RefCell::new(bumpalo::Bump::new()),
     }
 );
 


### PR DESCRIPTION
Allocations are made during querying that are difficult to avoid without major changes. We can speed things up quite a bit by using a bump allocator during querying that we then reset.

**EDIT:** The benchmarks from github-actions suggest a much more modest improvement than my own benchmark. Maybe try it on your machine(s) to see if the added complexity is worth it.

```bash
just baseline-create bump
just baseline-compare bump
```