### PR TITLE
fix: Don't empty `cli-usage.md` on `just clean-docs`.

### DIFF
--- a/justfile
+++ b/justfile
@@ -114,8 +114,6 @@ fix-md-file filename: install-markdownlint install-prettier
 [group('Ixa Book & Docs')]
 [group('Clean')]
 clean-docs:
-    rm -rf docs/cli-usage.md
-    touch docs/cli-usage.md
     rm -rf website/doc website/debug
     rm -f website/.rustc_info.json website/.rustdoc_fingerprint.json
 


### PR DESCRIPTION
We decided to commit the generated `cli-usage.md` file after all, but we forgot to modify the `clean-docs` recipe in the `justfile` so that it doesn't clear its contents. This PR fixes `clean-docs` so that it leaves `cli-usage.md` alone.