### PR TITLE
feat: `with_query_results` API. Fixes #540.

### DIFF
--- a/examples/network-hhmodel/network.rs
+++ b/examples/network-hhmodel/network.rs
@@ -18,7 +18,10 @@ fn create_household_networks(context: &mut Context, people: &[PersonId]) {
     for person_id in people {
         let household_id = context.get_person_property(*person_id, HouseholdId);
         if households.insert(household_id) {
-            let mut members = context.query_people((HouseholdId, household_id));
+            let mut members: Vec<PersonId> = Vec::new();
+            context.with_query_results((HouseholdId, household_id), &mut |results| {
+                members = results.iter().copied().collect()
+            });
             // create a dense network
             while let Some(person) = members.pop() {
                 for other_person in &members {
@@ -36,10 +39,16 @@ fn load_edge_list<T: EdgeType + 'static>(context: &mut Context, file_name: &str,
 
     for result in reader.deserialize() {
         let record: EdgeRecord = result.expect("Failed to parse edge");
-        let p1_vec = context.query_people((Id, record.v1));
+        let mut p1_vec = Vec::new();
+        context.with_query_results((Id, record.v1), &mut |people| {
+            p1_vec = people.to_owned_vec()
+        });
         assert_eq!(p1_vec.len(), 1);
         let p1 = p1_vec[0];
-        let p2_vec = context.query_people((Id, record.v2));
+        let mut p2_vec = Vec::new();
+        context.with_query_results((Id, record.v2), &mut |people| {
+            p2_vec = people.to_owned_vec()
+        });
         assert_eq!(p2_vec.len(), 1);
         let p2 = p2_vec[0];
         context.add_edge_bidi::<T>(p1, p2, 1.0, value).unwrap();

--- a/examples/network-hhmodel/network.rs
+++ b/examples/network-hhmodel/network.rs
@@ -20,7 +20,7 @@ fn create_household_networks(context: &mut Context, people: &[PersonId]) {
         if households.insert(household_id) {
             let mut members: Vec<PersonId> = Vec::new();
             context.with_query_results((HouseholdId, household_id), &mut |results| {
-                members = results.iter().copied().collect()
+                members = results.to_owned_vec()
             });
             // create a dense network
             while let Some(person) = members.pop() {

--- a/examples/network-hhmodel/seir.rs
+++ b/examples/network-hhmodel/seir.rs
@@ -34,14 +34,15 @@ fn calculate_waiting_time(context: &Context, shape: f64, mean_period: f64) -> f6
 }
 
 pub fn get_i_s_edges<T: EdgeType + 'static>(context: &Context) -> Vec<Edge<T::Value>> {
-    let infected = context.query_people((DiseaseStatus, DiseaseStatusValue::I));
     let mut edges = Vec::new();
 
-    for i in infected {
-        edges.extend(context.get_matching_edges::<T>(i, |context, edge| {
-            context.match_person(edge.neighbor, (DiseaseStatus, DiseaseStatusValue::S))
-        }));
-    }
+    context.with_query_results((DiseaseStatus, DiseaseStatusValue::I), &mut |infected| {
+        for i in infected {
+            edges.extend(context.get_matching_edges::<T>(*i, |context, edge| {
+                context.match_person(edge.neighbor, (DiseaseStatus, DiseaseStatusValue::S))
+            }));
+        }
+    });
 
     edges
 }

--- a/ixa-bench/Cargo.toml
+++ b/ixa-bench/Cargo.toml
@@ -74,3 +74,8 @@ harness = false
 name = "sampling"
 path = "criterion/sample_people.rs"
 harness = false
+
+[[bench]]
+name = "indexing"
+path = "criterion/index_benches.rs"
+harness = false

--- a/ixa-bench/Cargo.toml
+++ b/ixa-bench/Cargo.toml
@@ -38,6 +38,7 @@ clap = { workspace = true, features = ["derive"] }
 paste.workspace = true
 anyhow.workspace = true
 ctor.workspace = true
+nohash-hasher = "0.2.0"
 
 [lib]
 bench = false

--- a/ixa-bench/criterion/index_benches.rs
+++ b/ixa-bench/criterion/index_benches.rs
@@ -115,6 +115,7 @@ pub fn criterion_benchmark(criterion: &mut Criterion) {
     criterion.bench_function("query_people_single_indexed_property", |bencher| {
         bencher.iter(|| {
             for number in &numbers {
+                #[allow(deprecated)]
                 black_box(context.query_people(black_box((Property10, number % 10))));
             }
         });
@@ -125,6 +126,7 @@ pub fn criterion_benchmark(criterion: &mut Criterion) {
         |bencher| {
             bencher.iter(|| {
                 for number in &numbers {
+                    #[allow(deprecated)]
                     black_box(context.query_people(black_box((
                         (Property10, number * 3 % 10),
                         (Property100, *number),
@@ -137,6 +139,7 @@ pub fn criterion_benchmark(criterion: &mut Criterion) {
     criterion.bench_function("query_people_indexed_multi-property", |bencher| {
         bencher.iter(|| {
             for number in &numbers {
+                #[allow(deprecated)]
                 black_box(context.query_people(black_box((MProperty, (number * 3 % 10, *number)))));
             }
         });

--- a/ixa-bench/criterion/index_benches.rs
+++ b/ixa-bench/criterion/index_benches.rs
@@ -1,0 +1,109 @@
+use criterion::{criterion_group, criterion_main, Criterion};
+use ixa::prelude::*;
+use ixa::{define_multi_property, PersonId};
+use std::hint::black_box;
+
+define_rng!(IndexBenchRng);
+
+define_person_property!(Property10, u8, |context: &Context, _person: PersonId| {
+    context.sample_range(IndexBenchRng, 0..10)
+});
+define_person_property!(Property100, u8, |context: &Context, _person: PersonId| {
+    context.sample_range(IndexBenchRng, 0..100)
+});
+
+define_person_property!(MProperty10, u8, |context: &Context, _person: PersonId| {
+    context.sample_range(IndexBenchRng, 0..10)
+});
+define_person_property!(MProperty100, u8, |context: &Context, _person: PersonId| {
+    context.sample_range(IndexBenchRng, 0..100)
+});
+
+define_multi_property!(MProperty, (MProperty10, MProperty100));
+
+pub fn criterion_benchmark(criterion: &mut Criterion) {
+    let mut criterion = criterion.benchmark_group("indexing");
+
+    let mut context = Context::new();
+    for _ in 0..100000 {
+        let _ = context.add_person(());
+    }
+
+    let mut numbers: Vec<u8> = Vec::with_capacity(1000);
+    for _ in 0..1000 {
+        numbers.push(context.sample_range(IndexBenchRng, 0..100));
+    }
+
+    context.index_property(Property10);
+    context.index_property(Property100);
+    context.index_property(MProperty);
+
+    criterion.bench_function("query_people_count_single_indexed_property", |bencher| {
+        bencher.iter(|| {
+            for number in &numbers {
+                black_box(context.query_people_count(black_box((Property10, number % 10))));
+            }
+        });
+    });
+
+    criterion.bench_function(
+        "query_people_count_multiple_individually_indexed_properties",
+        |bencher| {
+            bencher.iter(|| {
+                for number in &numbers {
+                    black_box(context.query_people_count(black_box((
+                        (Property10, number * 3 % 10),
+                        (Property100, *number),
+                    ))));
+                }
+            });
+        },
+    );
+
+    criterion.bench_function("query_people_count_indexed_multi-property", |bencher| {
+        bencher.iter(|| {
+            for number in &numbers {
+                black_box(
+                    context.query_people_count(black_box((MProperty, (number * 3 % 10, *number)))),
+                );
+            }
+        });
+    });
+
+    criterion.bench_function("query_people_single_indexed_property", |bencher| {
+        bencher.iter(|| {
+            for number in &numbers {
+                black_box(context.query_people(black_box((Property10, number % 10))));
+            }
+        });
+    });
+
+    criterion.bench_function(
+        "query_people_multiple_individually_indexed_properties",
+        |bencher| {
+            bencher.iter(|| {
+                for number in &numbers {
+                    black_box(context.query_people(black_box((
+                        (Property10, number * 3 % 10),
+                        (Property100, *number),
+                    ))));
+                }
+            });
+        },
+    );
+
+    criterion.bench_function("query_people_indexed_multi-property", |bencher| {
+        bencher.iter(|| {
+            for number in &numbers {
+                black_box(
+                    context.query_people(black_box((MProperty, (number * 3 % 10, *number)))),
+                );
+            }
+        });
+    });
+
+    criterion.finish();
+}
+
+criterion_group!(index_benches, criterion_benchmark);
+criterion_main!(index_benches);

--- a/ixa-bench/criterion/index_benches.rs
+++ b/ixa-bench/criterion/index_benches.rs
@@ -43,9 +43,7 @@ pub fn criterion_benchmark(criterion: &mut Criterion) {
             for number in &numbers {
                 black_box(context.with_query_results(
                     black_box((Property10, number % 10)),
-                    black_box(&mut |people_set| {
-                        black_box(people_set);
-                    }),
+                    black_box(&mut |_| {}),
                 ));
             }
         });

--- a/ixa-bench/src/reference_sir/sir_ixa.rs
+++ b/ixa-bench/src/reference_sir/sir_ixa.rs
@@ -330,8 +330,7 @@ mod test {
             no_queries.ctx.infected_people(),
             no_queries
                 .ctx
-                .query_people((InfectionStatus, InfectionStatusValue::Infectious))
-                .len(),
+                .query_people_count((InfectionStatus, InfectionStatusValue::Infectious)),
             "no queries variant should compute infected people correctly",
         );
 

--- a/ixa-bench/src/reference_sir/sir_ixa.rs
+++ b/ixa-bench/src/reference_sir/sir_ixa.rs
@@ -70,6 +70,7 @@ impl InfectionLoop for Context {
     }
     fn infected_people(&self) -> usize {
         if self.get_options().queries_enabled {
+            #[allow(deprecated)]
             self.query_people((InfectionStatus, InfectionStatusValue::Infectious))
                 .len()
         } else {

--- a/ixa-bench/src/reference_sir/sir_ixa.rs
+++ b/ixa-bench/src/reference_sir/sir_ixa.rs
@@ -71,8 +71,7 @@ impl InfectionLoop for Context {
     fn infected_people(&self) -> usize {
         if self.get_options().queries_enabled {
             #[allow(deprecated)]
-            self.query_people((InfectionStatus, InfectionStatusValue::Infectious))
-                .len()
+            self.query_people_count((InfectionStatus, InfectionStatusValue::Infectious))
         } else {
             self.get_data(NonQueryInfectionTracker).len()
         }

--- a/justfile
+++ b/justfile
@@ -177,7 +177,7 @@ _prehyperfine:
         echo "hyperfine not found. You can install it with:\ncargo install hyperfine"; \
         exit 1; \
     }
-    cargo build --release -p ixa-bench \
+    cargo build --release -p ixa-bench
 
 # List all hyperfine benchmarks
 [group('Hyperfine')]

--- a/src/people/context_extension.rs
+++ b/src/people/context_extension.rs
@@ -742,7 +742,7 @@ mod tests {
     use crate::{
         define_derived_property, define_global_property, define_person_property,
         define_person_property_with_default, Context, ContextGlobalPropertiesExt, ContextPeopleExt,
-        IxaError, PersonId, PersonPropertyChangeEvent,
+        HashSetExt, IxaError, PersonId, PersonPropertyChangeEvent,
     };
     use serde_derive::Serialize;
     use std::cell::RefCell;
@@ -1099,7 +1099,11 @@ mod tests {
         let _ = context.add_person((Age, 40)).unwrap();
         let _ = context.add_person((Age, 42)).unwrap();
         let _ = context.add_person((Age, 42)).unwrap();
-        let mut all_people = context.query_people(());
+        let mut all_people = Vec::new();
+
+        context.with_query_results((), &mut |results| {
+            all_people = results.to_owned_vec();
+        });
 
         let mut result = all_people.clone();
         context.filter_people(&mut result, (Age, 42));

--- a/src/people/data.rs
+++ b/src/people/data.rs
@@ -208,16 +208,16 @@ impl PeopleData {
         &self,
         type_id: TypeId,
         value_hash: HashValueType,
-        function: &mut dyn FnMut(&HashSet<PersonId>),
+        callback: &mut dyn FnMut(&HashSet<PersonId>),
     ) -> Result<(), ()> {
         if let Some(index) = self.property_indexes.borrow().get(&type_id) {
             if let Some(people_set) = index.get_with_hash(value_hash) {
-                (function)(people_set);
+                (callback)(people_set);
             } else {
                 // The `value_hash` is not found. We assume this occurs when no people have that value for the
                 // property, so we pass an empty set to the function. (This is guaranteed not to allocate.)
                 let empty = HashSet::default();
-                (function)(&empty);
+                (callback)(&empty);
             }
             return Ok(());
         }

--- a/src/people/data.rs
+++ b/src/people/data.rs
@@ -200,6 +200,30 @@ where
 }
 
 impl PeopleData {
+    #[allow(unused)]
+    /// This method looks up the index for the given `type_id` and `value_hash` and, if one is found, passes
+    /// an immutable reference to the index's `HashSet` to the given function. If either the index doesn't exist
+    /// or
+    pub(super) fn with_index(
+        &self,
+        type_id: TypeId,
+        value_hash: HashValueType,
+        function: &mut dyn FnMut(&HashSet<PersonId>),
+    ) -> Result<(), ()> {
+        if let Some(index) = self.property_indexes.borrow().get(&type_id) {
+            if let Some(people_set) = index.get_with_hash(value_hash) {
+                (function)(people_set);
+            } else {
+                // The `value_hash` is not found. We assume this occurs when no people have that value for the
+                // property, so we pass an empty set to the function. (This is guaranteed not to allocate.)
+                let empty = HashSet::default();
+                (function)(&empty);
+            }
+            return Ok(());
+        }
+        Err(())
+    }
+
     /// Adds a person and returns a `PersonId` that can be used to reference them.
     /// This will increment the current population by 1.
     pub(super) fn add_person(&mut self) -> PersonId {

--- a/src/people/index.rs
+++ b/src/people/index.rs
@@ -258,10 +258,16 @@ mod test {
             .add_person(((Age, 1u8), (Weight, 2u8), (Height, 3u8)))
             .unwrap();
 
-        let results_a = context.query_people((AWH, (1u8, 2u8, 3u8)));
+        let mut results_a = Default::default();
+        context.with_query_results((AWH, (1u8, 2u8, 3u8)), &mut |results| {
+            results_a = results.clone()
+        });
         assert_eq!(results_a.len(), 1);
 
-        let results_b = context.query_people((WHA, (2u8, 3u8, 1u8)));
+        let mut results_b = Default::default();
+        context.with_query_results((WHA, (2u8, 3u8, 1u8)), &mut |results| {
+            results_b = results.clone()
+        });
         assert_eq!(results_b.len(), 1);
 
         assert_eq!(results_a, results_b);
@@ -271,10 +277,16 @@ mod test {
             .add_person(((Weight, 1u8), (Height, 2u8), (Age, 3u8)))
             .unwrap();
 
-        let results_a = context.query_people((WHA, (1u8, 2u8, 3u8)));
+        let mut results_a = Default::default();
+        context.with_query_results((WHA, (1u8, 2u8, 3u8)), &mut |results| {
+            results_a = results.clone()
+        });
         assert_eq!(results_a.len(), 1);
 
-        let results_b = context.query_people((AWH, (3u8, 1u8, 2u8)));
+        let mut results_b = Default::default();
+        context.with_query_results((AWH, (3u8, 1u8, 2u8)), &mut |results| {
+            results_b = results.clone()
+        });
         assert_eq!(results_b.len(), 1);
 
         assert_eq!(results_a, results_b);

--- a/src/people/property.rs
+++ b/src/people/property.rs
@@ -528,8 +528,9 @@ mod tests {
             );
         }
 
-        let results = context.query_people((ProfileNAW, ("John", 42, 220.5)));
-        assert_eq!(results.len(), 1);
+        context.with_query_results((ProfileNAW, ("John", 42, 220.5)), &mut |results| {
+            assert_eq!(results.len(), 1);
+        });
     }
 
     #[test]

--- a/src/people/query.rs
+++ b/src/people/query.rs
@@ -201,7 +201,7 @@ mod tests {
     use crate::people::PeoplePlugin;
     use crate::{
         define_derived_property, define_multi_property, define_person_property, Context,
-        ContextPeopleExt, PersonProperty,
+        ContextPeopleExt, HashSetExt, PersonProperty,
     };
     use serde_derive::Serialize;
 
@@ -218,22 +218,24 @@ mod tests {
     define_person_property!(RiskCategory, RiskCategoryValue);
 
     #[test]
-    fn query_people() {
+    fn with_query_results() {
         let mut context = Context::new();
         let _ = context
             .add_person((RiskCategory, RiskCategoryValue::High))
             .unwrap();
 
-        let people = context.query_people((RiskCategory, RiskCategoryValue::High));
-        assert_eq!(people.len(), 1);
+        context.with_query_results((RiskCategory, RiskCategoryValue::High), &mut |people| {
+            assert_eq!(people.len(), 1);
+        });
     }
 
     #[test]
-    fn query_people_empty() {
+    fn with_query_results_empty() {
         let context = Context::new();
 
-        let people = context.query_people((RiskCategory, RiskCategoryValue::High));
-        assert_eq!(people.len(), 0);
+        context.with_query_results((RiskCategory, RiskCategoryValue::High), &mut |people| {
+            assert_eq!(people.len(), 0);
+        });
     }
 
     #[test]
@@ -260,15 +262,17 @@ mod tests {
     }
 
     #[test]
-    fn query_people_macro_index_first() {
+    fn with_query_results_macro_index_first() {
         let mut context = Context::new();
         let _ = context
             .add_person((RiskCategory, RiskCategoryValue::High))
             .unwrap();
         context.index_property(RiskCategory);
         assert!(is_property_indexed::<RiskCategory>(&context));
-        let people = context.query_people((RiskCategory, RiskCategoryValue::High));
-        assert_eq!(people.len(), 1);
+
+        context.with_query_results((RiskCategory, RiskCategoryValue::High), &mut |people| {
+            assert_eq!(people.len(), 1);
+        });
     }
 
     fn is_property_indexed<T: PersonProperty>(context: &Context) -> bool {
@@ -282,70 +286,84 @@ mod tests {
     }
 
     #[test]
-    fn query_people_macro_index_second() {
+    fn with_query_results_macro_index_second() {
         let mut context = Context::new();
         let _ = context.add_person((RiskCategory, RiskCategoryValue::High));
-        let people = context.query_people((RiskCategory, RiskCategoryValue::High));
+
+        context.with_query_results((RiskCategory, RiskCategoryValue::High), &mut |people| {
+            assert_eq!(people.len(), 1);
+        });
         assert!(!is_property_indexed::<RiskCategory>(&context));
-        assert_eq!(people.len(), 1);
+
         context.index_property(RiskCategory);
         assert!(is_property_indexed::<RiskCategory>(&context));
-        let people = context.query_people((RiskCategory, RiskCategoryValue::High));
-        assert_eq!(people.len(), 1);
+
+        context.with_query_results((RiskCategory, RiskCategoryValue::High), &mut |people| {
+            assert_eq!(people.len(), 1);
+        });
     }
 
     #[test]
-    fn query_people_macro_change() {
+    fn with_query_results_macro_change() {
         let mut context = Context::new();
         let person1 = context
             .add_person((RiskCategory, RiskCategoryValue::High))
             .unwrap();
 
-        let people = context.query_people((RiskCategory, RiskCategoryValue::High));
-        assert_eq!(people.len(), 1);
-        let people = context.query_people((RiskCategory, RiskCategoryValue::Low));
-        assert_eq!(people.len(), 0);
+        context.with_query_results((RiskCategory, RiskCategoryValue::High), &mut |people| {
+            assert_eq!(people.len(), 1);
+        });
+
+        context.with_query_results((RiskCategory, RiskCategoryValue::Low), &mut |people| {
+            assert_eq!(people.len(), 0);
+        });
 
         context.set_person_property(person1, RiskCategory, RiskCategoryValue::Low);
-        let people = context.query_people((RiskCategory, RiskCategoryValue::High));
-        assert_eq!(people.len(), 0);
-        let people = context.query_people((RiskCategory, RiskCategoryValue::Low));
-        assert_eq!(people.len(), 1);
+        context.with_query_results((RiskCategory, RiskCategoryValue::High), &mut |people| {
+            assert_eq!(people.len(), 0);
+        });
+
+        context.with_query_results((RiskCategory, RiskCategoryValue::Low), &mut |people| {
+            assert_eq!(people.len(), 1);
+        });
     }
 
     #[test]
-    fn query_people_index_after_add() {
+    fn with_query_results_index_after_add() {
         let mut context = Context::new();
         let _ = context
             .add_person((RiskCategory, RiskCategoryValue::High))
             .unwrap();
         context.index_property(RiskCategory);
         assert!(is_property_indexed::<RiskCategory>(&context));
-        let people = context.query_people((RiskCategory, RiskCategoryValue::High));
-        assert_eq!(people.len(), 1);
+        context.with_query_results((RiskCategory, RiskCategoryValue::High), &mut |people| {
+            assert_eq!(people.len(), 1);
+        });
     }
 
     #[test]
-    fn query_people_add_after_index() {
+    fn with_query_results_add_after_index() {
         let mut context = Context::new();
         let _ = context
             .add_person((RiskCategory, RiskCategoryValue::High))
             .unwrap();
         context.index_property(RiskCategory);
         assert!(is_property_indexed::<RiskCategory>(&context));
-        let people = context.query_people((RiskCategory, RiskCategoryValue::High));
-        assert_eq!(people.len(), 1);
+        context.with_query_results((RiskCategory, RiskCategoryValue::High), &mut |people| {
+            assert_eq!(people.len(), 1);
+        });
 
         let _ = context
             .add_person((RiskCategory, RiskCategoryValue::High))
             .unwrap();
-        let people = context.query_people((RiskCategory, RiskCategoryValue::High));
-        assert_eq!(people.len(), 2);
+        context.with_query_results((RiskCategory, RiskCategoryValue::High), &mut |people| {
+            assert_eq!(people.len(), 2);
+        });
     }
 
     #[test]
     // This is safe because we reindex only when someone queries.
-    fn query_people_add_after_index_without_query() {
+    fn add_after_index_without_query() {
         let mut context = Context::new();
         let _ = context.add_person(()).unwrap();
         context.index_property(RiskCategory);
@@ -354,25 +372,26 @@ mod tests {
     #[test]
     #[should_panic(expected = "Property not initialized")]
     // This will panic when we query.
-    fn query_people_add_after_index_panic() {
+    fn with_query_results_add_after_index_panic() {
         let mut context = Context::new();
         context.add_person(()).unwrap();
         context.index_property(RiskCategory);
-        context.query_people((RiskCategory, RiskCategoryValue::High));
+        context.with_query_results((RiskCategory, RiskCategoryValue::High), &mut |_people| {});
     }
 
     #[test]
-    fn query_people_cast_value() {
+    fn with_query_results_cast_value() {
         let mut context = Context::new();
         let _ = context.add_person((Age, 42)).unwrap();
 
         // Age is a u8, by default integer literals are i32; the macro should cast it.
-        let people = context.query_people((Age, 42));
-        assert_eq!(people.len(), 1);
+        context.with_query_results((Age, 42), &mut |people| {
+            assert_eq!(people.len(), 1);
+        });
     }
 
     #[test]
-    fn query_people_intersection() {
+    fn with_query_results_intersection() {
         let mut context = Context::new();
         let _ = context
             .add_person(((Age, 42), (RiskCategory, RiskCategoryValue::High)))
@@ -384,12 +403,16 @@ mod tests {
             .add_person(((Age, 40), (RiskCategory, RiskCategoryValue::Low)))
             .unwrap();
 
-        let people = context.query_people(((Age, 42), (RiskCategory, RiskCategoryValue::High)));
-        assert_eq!(people.len(), 1);
+        context.with_query_results(
+            ((Age, 42), (RiskCategory, RiskCategoryValue::High)),
+            &mut |people| {
+                assert_eq!(people.len(), 1);
+            },
+        );
     }
 
     #[test]
-    fn query_people_intersection_non_macro() {
+    fn with_query_results_intersection_non_macro() {
         let mut context = Context::new();
         let _ = context
             .add_person(((Age, 42), (RiskCategory, RiskCategoryValue::High)))
@@ -401,12 +424,16 @@ mod tests {
             .add_person(((Age, 40), (RiskCategory, RiskCategoryValue::Low)))
             .unwrap();
 
-        let people = context.query_people(((Age, 42), (RiskCategory, RiskCategoryValue::High)));
-        assert_eq!(people.len(), 1);
+        context.with_query_results(
+            ((Age, 42), (RiskCategory, RiskCategoryValue::High)),
+            &mut |people| {
+                assert_eq!(people.len(), 1);
+            },
+        );
     }
 
     #[test]
-    fn query_people_intersection_one_indexed() {
+    fn with_query_results_intersection_one_indexed() {
         let mut context = Context::new();
         let _ = context
             .add_person(((Age, 42), (RiskCategory, RiskCategoryValue::High)))
@@ -419,8 +446,12 @@ mod tests {
             .unwrap();
 
         context.index_property(Age);
-        let people = context.query_people(((Age, 42), (RiskCategory, RiskCategoryValue::High)));
-        assert_eq!(people.len(), 1);
+        context.with_query_results(
+            ((Age, 42), (RiskCategory, RiskCategoryValue::High)),
+            &mut |people| {
+                assert_eq!(people.len(), 1);
+            },
+        );
     }
 
     #[test]
@@ -429,18 +460,27 @@ mod tests {
         define_derived_property!(Senior, bool, [Age], |age| age >= 65);
 
         let person = context.add_person((Age, 64)).unwrap();
-        let _ = context.add_person((Age, 88)).unwrap();
+        let _ = context.add_person((Age, 88));
 
-        // Age is a u8, by default integer literals are i32; the macro should cast it.
-        let not_seniors = context.query_people((Senior, false));
-        let seniors = context.query_people((Senior, true));
+        let mut not_seniors = Vec::new();
+        context.with_query_results((Senior, false), &mut |people| {
+            not_seniors = people.to_owned_vec()
+        });
+        let mut seniors = Vec::new();
+        context.with_query_results((Senior, true), &mut |people| {
+            seniors = people.to_owned_vec();
+        });
         assert_eq!(seniors.len(), 1, "One senior");
         assert_eq!(not_seniors.len(), 1, "One non-senior");
 
         context.set_person_property(person, Age, 65);
 
-        let not_seniors = context.query_people((Senior, false));
-        let seniors = context.query_people((Senior, true));
+        context.with_query_results((Senior, false), &mut |people| {
+            not_seniors = people.to_owned_vec()
+        });
+        context.with_query_results((Senior, true), &mut |people| {
+            seniors = people.to_owned_vec()
+        });
 
         assert_eq!(seniors.len(), 2, "Two seniors");
         assert_eq!(not_seniors.len(), 0, "No non-seniors");
@@ -453,18 +493,28 @@ mod tests {
 
         context.index_property(Senior);
         let person = context.add_person((Age, 64)).unwrap();
-        let _ = context.add_person((Age, 88)).unwrap();
+        let _ = context.add_person((Age, 88));
 
         // Age is a u8, by default integer literals are i32; the macro should cast it.
-        let not_seniors = context.query_people((Senior, false));
-        let seniors = context.query_people((Senior, true));
+        let mut not_seniors = Vec::new();
+        context.with_query_results((Senior, false), &mut |people| {
+            not_seniors = people.to_owned_vec()
+        });
+        let mut seniors = Vec::new();
+        context.with_query_results((Senior, true), &mut |people| {
+            seniors = people.to_owned_vec()
+        });
         assert_eq!(seniors.len(), 1, "One senior");
         assert_eq!(not_seniors.len(), 1, "One non-senior");
 
         context.set_person_property(person, Age, 65);
 
-        let not_seniors = context.query_people((Senior, false));
-        let seniors = context.query_people((Senior, true));
+        context.with_query_results((Senior, false), &mut |people| {
+            not_seniors = people.to_owned_vec()
+        });
+        context.with_query_results((Senior, true), &mut |people| {
+            seniors = people.to_owned_vec()
+        });
 
         assert_eq!(seniors.len(), 2, "Two seniors");
         assert_eq!(not_seniors.len(), 0, "No non-seniors");
@@ -486,12 +536,8 @@ mod tests {
         );
 
         // add some people
-        let _person = context
-            .add_person(((Age, 64), (County, 2), (Height, 120)))
-            .unwrap();
-        let _ = context
-            .add_person(((Age, 88), (County, 2), (Height, 130)))
-            .unwrap();
+        let _ = context.add_person(((Age, 64), (County, 2), (Height, 120)));
+        let _ = context.add_person(((Age, 88), (County, 2), (Height, 130)));
         let p2 = context
             .add_person(((Age, 8), (County, 1), (Height, 140)))
             .unwrap();
@@ -506,44 +552,51 @@ mod tests {
             .unwrap();
 
         // 'regular' derived property
-        let ach_people = context.query_people((Ach, (28, 2, 160)));
-        assert_eq!(ach_people.len(), 2, "Should have 2 matches");
-        assert!(ach_people.contains(&p4));
-        assert!(ach_people.contains(&p5));
+        context.with_query_results((Ach, (28, 2, 160)), &mut |people| {
+            assert_eq!(people.len(), 2, "Should have 2 matches");
+            assert!(people.contains(&p4));
+            assert!(people.contains(&p5));
+        });
 
         // multi-property index
-        let age_county_height2 = context.query_people(((Age, 28), (County, 2), (Height, 160)));
-        assert_eq!(age_county_height2.len(), 2, "Should have 2 matches");
-        assert!(age_county_height2.contains(&p4));
-        assert!(age_county_height2.contains(&p5));
+        context.with_query_results(((Age, 28), (County, 2), (Height, 160)), &mut |people| {
+            assert_eq!(people.len(), 2, "Should have 2 matches");
+            assert!(people.contains(&p4));
+            assert!(people.contains(&p5));
+        });
 
         // multi-property index with different order
-        let age_county_height3 = context.query_people(((County, 2), (Height, 160), (Age, 28)));
-        assert_eq!(age_county_height3.len(), 2, "Should have 2 matches");
-        assert!(age_county_height3.contains(&p4));
-        assert!(age_county_height3.contains(&p5));
+        context.with_query_results(((County, 2), (Height, 160), (Age, 28)), &mut |people| {
+            assert_eq!(people.len(), 2, "Should have 2 matches");
+            assert!(people.contains(&p4));
+            assert!(people.contains(&p5));
+        });
 
         // multi-property index with different order
-        let age_county_height4 = context.query_people(((Height, 160), (County, 2), (Age, 28)));
-        assert_eq!(age_county_height4.len(), 2, "Should have 2 matches");
-        assert!(age_county_height4.contains(&p4));
-        assert!(age_county_height4.contains(&p5));
+        context.with_query_results(((Height, 160), (County, 2), (Age, 28)), &mut |people| {
+            assert_eq!(people.len(), 2, "Should have 2 matches");
+            assert!(people.contains(&p4));
+            assert!(people.contains(&p5));
+        });
 
         // multi-property index with different order and different value
-        let age_county_height5 = context.query_people(((Height, 140), (County, 1), (Age, 28)));
-        assert_eq!(age_county_height5.len(), 1, "Should have 1 matches");
-        assert!(age_county_height5.contains(&p3));
+        context.with_query_results(((Height, 140), (County, 1), (Age, 28)), &mut |people| {
+            assert_eq!(people.len(), 1, "Should have 1 matches");
+            assert!(people.contains(&p3));
+        });
 
         context.set_person_property(p2, Age, 28);
         // multi-property index again after changing the value
-        let age_county_height5 = context.query_people(((Height, 140), (County, 1), (Age, 28)));
-        assert_eq!(age_county_height5.len(), 2, "Should have 2 matches");
-        assert!(age_county_height5.contains(&p2));
-        assert!(age_county_height5.contains(&p3));
+        context.with_query_results(((Height, 140), (County, 1), (Age, 28)), &mut |people| {
+            assert_eq!(people.len(), 2, "Should have 2 matches");
+            assert!(people.contains(&p2));
+            assert!(people.contains(&p3));
+        });
 
-        let age_county_height5 = context.query_people(((Height, 140), (County, 1)));
-        assert_eq!(age_county_height5.len(), 2, "Should have 2 matches");
-        assert!(age_county_height5.contains(&p2));
-        assert!(age_county_height5.contains(&p3));
+        context.with_query_results(((Height, 140), (County, 1)), &mut |people| {
+            assert_eq!(people.len(), 2, "Should have 2 matches");
+            assert!(people.contains(&p2));
+            assert!(people.contains(&p3));
+        });
     }
 }


### PR DESCRIPTION
- Added `index_benches.rs`.
- Added `with_query_results` method.
- Changed tests to use `with_query_results` instead of `query_people`

This PR is stacked on #534, but it doesn't have to be.