### PR TITLE
fix: Enable default features of the `syn` dependency, fixing build failure.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,7 +51,7 @@ roots = "0.0.8"
 assert_approx_eq = "^1.1.0"
 strum = { version = "^0.27.1", features = ["derive"] }
 quote = "^1.0.38"
-syn = { version = "^2.0.95",  default-features = false, features = ["derive", "parsing"] }
+syn = { version = "^2.0.95" }
 proc-macro2 = "1.0.93"
 proc-macro-crate = "3.3.0"
 delegate = "^0.13.3"


### PR DESCRIPTION
Enabled the default features on the `syn` dependency, which fixes a build failure in CodeSpaces.