### PR TITLE
fix: Fixed mangled callout formatting. Fixes #641.

### DIFF
--- a/docs/book/src/first_model/people.md
+++ b/docs/book/src/first_model/people.md
@@ -3,10 +3,10 @@
 In Ixa we organize our models into _modules_ each of which is responsible for a
 single aspect of the model.
 
-> [!INFO] Modules 
-> 
-> In fact, the code of Ixa itself is organized into modules in
-> just the same way models are.
+> [!INFO] Modules
+>
+> In fact, the code of Ixa itself is organized into modules in just the same way
+> models are.
 
 Ixa is a framework for developing _agent_-based models. In most of our models,
 the agents will represent people. So let's create a module that is responsible
@@ -54,13 +54,13 @@ is not enough to define this enum. We have to tell Ixa that it will be a
 {{#rustdoc_include ../../models/disease_model/src/people.rs:define_person_property}}
 ```
 
-> [!NOTE] Name Tags and Values 
-> 
-> Notice that there are two types associated with
-> infection status, `InfectionStatus` and `InfectionStatusValue`. The first,
-> `InfectionStatus`, is a tag that we will use to fetch and store values of the
-> property, while `InfectionStatusValue` is the type of the values themselves.
-> [!INFO] Default or No Default
+> [!NOTE] Name Tags and Values
+>
+> Notice that there are two types associated with infection status,
+> `InfectionStatus` and `InfectionStatusValue`. The first, `InfectionStatus`, is
+> a tag that we will use to fetch and store values of the property, while
+> `InfectionStatusValue` is the type of the values themselves. [!INFO] Default
+> or No Default
 
 ## The module's `init()` function
 

--- a/docs/book/src/first_model/setup.md
+++ b/docs/book/src/first_model/setup.md
@@ -31,20 +31,21 @@ Open the newly created `disease_model` directory in your favorite IDE, like
         └── 📄 Cargo.toml
 ```
 
-> [!INFO] Source Control 
-> 
-> The `.gitignore` file lists all the files and
-> directories you don't want to include in source control. For a Rust project
-> you should at least have `target` and `Cargo.lock` listed in the `.gitignore`.
-> I also make a habit of listing `.vscode` and `.idea`, the directories VS Code
-> and JetBrains respectively store IDE project settings.
+> [!INFO] Source Control
+>
+> The `.gitignore` file lists all the files and directories you don't want to
+> include in source control. For a Rust project you should at least have
+> `target` and `Cargo.lock` listed in the `.gitignore`. I also make a habit of
+> listing `.vscode` and `.idea`, the directories VS Code and JetBrains
+> respectively store IDE project settings.
 
+<!-- markdownlint-disable-next-line MD028 -->
 
-> [!INFO] Cargo 
-> 
-> Cargo is Rust's package manager and build system. It is a single tool that plays
-> the role of the multiple different tools you would use in other languages, such
-> as `pip` and `poetry` in the Python ecosystem. We use Cargo to
+> [!INFO] Cargo
+>
+> Cargo is Rust's package manager and build system. It is a single tool that
+> plays the role of the multiple different tools you would use in other
+> languages, such as `pip` and `poetry` in the Python ecosystem. We use Cargo to
 >
 > - install tools like ripgrep (`cargo install`)
 > - initialize new projects (`cargo new` and `cargo init`)
@@ -116,14 +117,13 @@ before the simulation is kicked off if necessary. The only setup we do is
 schedule a plan at time 1.0. The plan is itself another closure that prints the
 current simulation time.
 
-> [!INFO] Closures 
-> 
-> A _closure_ is a small, self-contained block of code that can
-> be passed around and executed later. It can capture and use variables from its
-> surrounding environment, which makes it useful for things like callbacks,
-> event handlers, or any situation where you want to define some logic on the
-> fly and run it at a later time. In simple terms, a closure is like a mini
-> anonymous function.
+> [!INFO] Closures
+>
+> A _closure_ is a small, self-contained block of code that can be passed around
+> and executed later. It can capture and use variables from its surrounding
+> environment, which makes it useful for things like callbacks, event handlers,
+> or any situation where you want to define some logic on the fly and run it at
+> a later time. In simple terms, a closure is like a mini anonymous function.
 
 The `run_with_args()` function does the following:
 
@@ -168,11 +168,11 @@ the log level:
 cargo run -- --log-level disease_model=trace
 ```
 
-> [!INFO] Logging 
-> 
-> The `trace!`, `info!`, and `error!` logging macros allow us to
-> print messages to the console, but they are much more powerful than a simple
-> print statement. With log messages, you can:
+> [!INFO] Logging
+>
+> The `trace!`, `info!`, and `error!` logging macros allow us to print messages
+> to the console, but they are much more powerful than a simple print statement.
+> With log messages, you can:
 >
 > - Turn log messages on and off as needed.
 > - Enable only messages with a specified priority (for example, only warnings
@@ -182,13 +182,14 @@ cargo run -- --log-level disease_model=trace
 >
 > See the logging documentation for more details.
 
+<!-- markdownlint-disable-next-line MD028 -->
 
 > [!INFO] Command Line Arguments
-> 
+>
 > The `run_with_args()` function takes care of handling any command line
 > arguments for us, which is why we don't just create a `Context` object and
 > call `context.execute()` ourselves. There are many arguments we can pass to
-> our model that affects what is output and where, debugging options,
+> our model that affect what is output and where, debugging options,
 > configuration input, and so forth. See the command line documentation for more
 > details.
 

--- a/docs/book/src/first_model/transmission.md
+++ b/docs/book/src/first_model/transmission.md
@@ -92,14 +92,13 @@ accomplishes the three tasks above. A few observations:
   `InfectionStatus` and `InfectionStatusValue`) or the infection manager we are
   about to write.
 
-> [!INFO] Random Number Generators 
-> 
-> Each module generally defines its own random
-> number source with `define_rng!`, avoiding interfering with the random number
-> sources used elsewhere in the simulation in order to preserve determinism. In
-> Monte Carlo simulations, _deterministic_ pseudorandom number sequences are
-> desirable because they ensure reproducibility, improve efficiency, provide
-> control over randomness, enable consistent statistical testing, and reduce the
-> likelihood of bias or error. These qualities are critical in scientific
-> computing, optimization problems, and simulations that require precise and
-> _verifiable_ results.
+> [!INFO] Random Number Generators
+>
+> Each module generally defines its own random number source with `define_rng!`,
+> avoiding interfering with the random number sources used elsewhere in the
+> simulation in order to preserve determinism. In Monte Carlo simulations,
+> _deterministic_ pseudorandom number sequences are desirable because they
+> ensure reproducibility, improve efficiency, provide control over randomness,
+> enable consistent statistical testing, and reduce the likelihood of bias or
+> error. These qualities are critical in scientific computing, optimization
+> problems, and simulations that require precise and _verifiable_ results.

--- a/docs/book/src/topics/indexing.md
+++ b/docs/book/src/topics/indexing.md
@@ -106,16 +106,16 @@ An index in Ixa is just a map between a property _value_ and the list of all
 property value is (almost) as fast as looking up the property value for a given
 `PersonId`.
 
-> [!INFO] Ixa's Intelligent Indexing Strategy 
-> 
-> The picture we have painted of how
-> Ixa implements indexing is necessarily a simplification. Ixa uses a lazy
-> indexing strategy, which means if a property is never queried, then Ixa never
-> actually does the work of computing the index. Ixa also keeps track of whether
-> new people have been added to the simulation since the last time a query was
-> run, so that it only has to update its index for those newly added people.
-> These and other optimizations make Ixa's indexing very fast and memory
-> efficient compared to the simplistic version described in this section.
+> [!INFO] Ixa's Intelligent Indexing Strategy
+>
+> The picture we have painted of how Ixa implements indexing is necessarily a
+> simplification. Ixa uses a lazy indexing strategy, which means if a property
+> is never queried, then Ixa never actually does the work of computing the
+> index. Ixa also keeps track of whether new people have been added to the
+> simulation since the last time a query was run, so that it only has to update
+> its index for those newly added people. These and other optimizations make
+> Ixa's indexing very fast and memory efficient compared to the simplistic
+> version described in this section.
 
 ## The Costs of Creating an Index
 
@@ -131,14 +131,14 @@ There are two costs you have to pay for indexing:
    example) _and_ the `PersonId` values, while the original column only stores
    the `InfectionStatus` (the `PersonId`'s were implicitly the row numbers).
 
-> [!INFO] Creating vs. Maintaining an Index 
-> 
-> Suspiciously missing from this list
-> of costs is the initial cost of scanning through the property column to create
-> the index in the first place, but actually whether you maintain the index from
-> the very beginning or you index it all at once doesn't matter: the sum of all
-> the small efforts to update the index every time a person is added is equal to
-> the cost of creating the index from scratch for an existing set of data.
+> [!INFO] Creating vs. Maintaining an Index
+>
+> Suspiciously missing from this list of costs is the initial cost of scanning
+> through the property column to create the index in the first place, but
+> actually whether you maintain the index from the very beginning or you index
+> it all at once doesn't matter: the sum of all the small efforts to update the
+> index every time a person is added is equal to the cost of creating the index
+> from scratch for an existing set of data.
 >
 > We can, however, save the effort of updating the index when property values
 > _change_ if we wait until we actually run a query that needs to use the index
@@ -160,10 +160,10 @@ production recommend that we have a feel for whether we really need the
 resources we are using.
 
 > [!TIP] A query might be the wrong tool for the job
-> 
-> Sometimes, the best way to address a slow query in your model isn’t to
-> add indexes, but to remove the query entirely. A common scenario is when you
-> want to report on some aggregate statistics, for example, the total number of
+>
+> Sometimes, the best way to address a slow query in your model isn’t to add
+> indexes, but to remove the query entirely. A common scenario is when you want
+> to report on some aggregate statistics, for example, the total number of
 > people having each infectiousness status. It might be much better to just
 > track the aggregate value directly than to run a query for it every time you
 > want to write it to a report. As usual, when it comes to performance issues,

--- a/docs/book/src/topics/random-module.md
+++ b/docs/book/src/topics/random-module.md
@@ -6,19 +6,19 @@ Random sampling is a fundamental capability for most simulations. The
 requirement that experiments also need to be _deterministic_ makes randomness a
 subtle issue.
 
-> [!NOTE] Randomness vs. Determinism 
-> 
-> A _truly random_ number source produces
-> numbers in a sequence that cannot be predicted even in principle. A
-> _pseudorandom_ number source produces numbers in a sequence according to a
-> completely deterministic algorithm, so if you know the algorithm, you can
-> predict the next number in the sequence exactly. However, good pseudorandom
-> number generators can produce sequences that appear indistinguishable from a
-> truly random sequence according to a battery of rigorous statistical tests. We
-> sometimes use the word random when we actually mean _pseudorandom_. Because we
-> want simulations to be reproducible, we want them to be deterministic. But we
-> also want statistical randomness within the simulation. Pseudorandom number
-> generators give us both determinism and statistical randomness.
+> [!NOTE] Randomness vs. Determinism
+>
+> A _truly random_ number source produces numbers in a sequence that cannot be
+> predicted even in principle. A _pseudorandom_ number source produces numbers
+> in a sequence according to a completely deterministic algorithm, so if you
+> know the algorithm, you can predict the next number in the sequence exactly.
+> However, good pseudorandom number generators can produce sequences that appear
+> indistinguishable from a truly random sequence according to a battery of
+> rigorous statistical tests. We sometimes use the word random when we actually
+> mean _pseudorandom_. Because we want simulations to be reproducible, we want
+> them to be deterministic. But we also want statistical randomness within the
+> simulation. Pseudorandom number generators give us both determinism and
+> statistical randomness.
 
 Here are the primary ways we handle this challenge in Ixa:
 
@@ -53,14 +53,14 @@ giving each module its own RNG, you ensure that changes in one module's random
 behavior don't cascade through the entire simulation, enabling precise scenario
 comparisons and reproducible debugging.
 
-> [!NOTE] Requirements for Determinism 
-> 
-> The determinism guarantee applies to
-> repeated execution of the same model compiled with the same version of Ixa.
-> However, you should not expect identical results between different versions of
-> Ixa. When you make changes to your own code, it is very easy to change the
-> simulation behavior even if you don't intend to. Do not be surprised if you
-> get different results if you make changes to your own code.
+> [!NOTE] Requirements for Determinism
+>
+> The determinism guarantee applies to repeated execution of the same model
+> compiled with the same version of Ixa. However, you should not expect
+> identical results between different versions of Ixa. When you make changes to
+> your own code, it is very easy to change the simulation behavior even if you
+> don't intend to. Do not be surprised if you get different results if you make
+> changes to your own code.
 
 ## How to make and use a random number source
 
@@ -165,15 +165,14 @@ provide many more.
 let value = context.sample_distr(MyRng, Uniform::new(2.0, 10.0).unwrap());
 ```
 
-> [!WARNING] `rand` Crate Version Compatibility 
-> 
-> As of this writing, the latest
-> version of the `rand` crate is v0.9.2, but some popular crates in the Rust
-> ecosystem still use `rand@0.8.*`, which is incompatible. Using an incompatible
-> version in your code can result in confusing errors that end with the
-> tell-tale line, "Note: there are multiple different versions of crate `rand`
-> in the dependency graph". Always using `rand` that Ixa re-exports at
-> `ixa::rand` will help you avoid this trap.
+> [!WARNING] `rand` Crate Version Compatibility
+>
+> As of this writing, the latest version of the `rand` crate is v0.9.2, but some
+> popular crates in the Rust ecosystem still use `rand@0.8.*`, which is
+> incompatible. Using an incompatible version in your code can result in
+> confusing errors that end with the tell-tale line, "Note: there are multiple
+> different versions of crate `rand` in the dependency graph". Always using
+> `rand` that Ixa re-exports at `ixa::rand` will help you avoid this trap.
 
 ### Custom Random Generation
 

--- a/docs/book/src/topics/reports.md
+++ b/docs/book/src/topics/reports.md
@@ -356,11 +356,11 @@ pub fn init(context: &mut Context) {
 
 That is everything needed for the bookkeeping.
 
-> [!INFO] Aggregation Inside The Model 
-> 
-> The aggregation step often doesn't look
-> like aggregation inside the model, because we can accumulate values _as events
-> occur_ instead of aggregating values after the fact.
+> [!INFO] Aggregation Inside The Model
+>
+> The aggregation step often doesn't look like aggregation inside the model,
+> because we can accumulate values _as events occur_ instead of aggregating
+> values after the fact.
 
 ### Reporting
 


### PR DESCRIPTION
At some point we must have run an autoformatting tool on our markdown in the ixa book that mangled the syntax we use for callouts, and we didn't catch it. This results in callouts being rendered incorrectly. This PR fixes the callout syntax.