### PR TITLE
fix: Pinned MDBook to version 0.4.52, removed unused key in book.toml. Fixes #643.

### DIFF
--- a/docs/book/book.toml
+++ b/docs/book/book.toml
@@ -1,7 +1,6 @@
 [book]
 authors = ["The Ixa Developers"]
 language = "en"
-multilingual = false
 src = "src"
 title = "The Ixa Book"
 

--- a/mise.toml
+++ b/mise.toml
@@ -6,7 +6,7 @@ pnpm = "latest"
 "npm:markdownlint-cli" = "0.45.0"
 "cargo:wasm-pack" = "latest"
 "cargo:hyperfine" = "latest"
-"cargo:mdbook" = "latest"
+"cargo:mdbook" = "0.4.52"
 "cargo:mdbook-callouts" = "latest"
 "cargo:mdbook-inline-highlighting" = "latest"
 


### PR DESCRIPTION
Pinned MDBook to version 0.4.52 for compatibility with the callouts plugin we use.

Removed unused "multilingual" key in `book.toml`. (Using this key will be a hard error in `mdbook@0.5.*`.)