### PR TITLE
feat: `match_entity` and `filter_entities`. Fixes #690.

### DIFF
--- a/src/entity/context_extension.rs
+++ b/src/entity/context_extension.rs
@@ -96,6 +96,12 @@ pub trait ContextEntitiesExt {
 
     /// Generates an iterator over the results of the query.
     fn query_result_iterator<E: Entity, Q: Query<E>>(&self, query: Q) -> QueryResultIterator<E>;
+
+    /// Determines if the given person matches this query.
+    fn match_entity<E: Entity, Q: Query<E>>(&self, entity_id: EntityId<E>, query: Q) -> bool;
+
+    /// Removes all `EntityId`s from the given vector that do not match the given query.
+    fn filter_entities<E: Entity, Q: Query<E>>(&self, entities: &mut Vec<EntityId<E>>, query: Q);
 }
 
 impl ContextEntitiesExt for Context {
@@ -318,8 +324,17 @@ impl ContextEntitiesExt for Context {
     fn get_entity_iterator<E: Entity>(&self) -> EntityIterator<E> {
         self.entity_store.get_entity_iterator::<E>()
     }
+
     fn query_result_iterator<E: Entity, Q: Query<E>>(&self, query: Q) -> QueryResultIterator<E> {
         query.new_query_result_iterator(self)
+    }
+
+    fn match_entity<E: Entity, Q: Query<E>>(&self, entity_id: EntityId<E>, query: Q) -> bool {
+        query.match_entity(entity_id, self)
+    }
+
+    fn filter_entities<E: Entity, Q: Query<E>>(&self, entities: &mut Vec<EntityId<E>>, query: Q) {
+        query.filter_entities(entities, self);
     }
 }
 


### PR DESCRIPTION
Implemented `match_entity` and `filter_entities`, the entity analog of `match_people` and `filter_people`.

Benchmark comparisons with the legacy `people` implementation is very favorable.

<img width="627" height="310" alt="Screenshot 2026-02-01 at 2 03 36 PM" src="https://github.com/user-attachments/assets/a23705a9-a991-4779-90ca-66c23ff2a4cd" />
