### PR TITLE
chore: Reverted to `PropertyChangeEvent::current`

### DIFF
--- a/examples/basic-infection/src/incidence_report.rs
+++ b/examples/basic-infection/src/incidence_report.rs
@@ -19,14 +19,14 @@ define_report!(IncidenceReportItem);
 fn handle_infection_status_change(context: &mut Context, event: InfectionStatusEvent) {
     trace!(
         "Handling infection status change from {:?} to {:?} for {:?}",
-        event.previous_value,
-        event.current_value,
+        event.previous,
+        event.current,
         event.entity_id
     );
     context.send_report(IncidenceReportItem {
         time: context.get_current_time(),
         person_id: event.entity_id,
-        infection_status: event.current_value,
+        infection_status: event.current,
     });
 }
 

--- a/examples/basic-infection/src/infection_manager.rs
+++ b/examples/basic-infection/src/infection_manager.rs
@@ -24,11 +24,11 @@ fn schedule_recovery(context: &mut Context, person_id: PersonId) {
 fn handle_infection_status_change(context: &mut Context, event: InfectionStatusEvent) {
     trace!(
         "Handling infection status change from {:?} to {:?} for {:?}",
-        event.previous_value,
-        event.current_value,
+        event.previous,
+        event.current,
         event.entity_id
     );
-    if event.current_value == InfectionStatus::I {
+    if event.current == InfectionStatus::I {
         schedule_recovery(context, event.entity_id);
     }
 }
@@ -50,7 +50,7 @@ mod test {
     define_data_plugin!(RecoveryPlugin, usize, 0);
 
     fn handle_recovery_event(context: &mut Context, event: InfectionStatusEvent) {
-        if event.current_value == InfectionStatus::R {
+        if event.current == InfectionStatus::R {
             *context.get_data_mut(RecoveryPlugin) += 1;
         }
     }

--- a/examples/births-deaths/src/demographics_report.rs
+++ b/examples/births-deaths/src/demographics_report.rs
@@ -40,13 +40,13 @@ fn handle_person_aging(context: &mut Context, event: PropertyChangeEvent<Person,
         person_id: format!("{person}"),
         age_group: age_group_person,
         property: "Age".to_string(),
-        property_prev: format!("{:?}", event.previous_value),
-        property_current: format!("{:?}", event.current_value),
+        property_prev: format!("{:?}", event.previous),
+        property_current: format!("{:?}", event.current),
     });
 }
 
 fn handle_death_events(context: &mut Context, event: PropertyChangeEvent<Person, Alive>) {
-    if !event.current_value.0 {
+    if !event.current.0 {
         let person = event.entity_id;
         let age_group_person: AgeGroupRisk = context.get_property(person);
         context.send_report(PersonReportItem {
@@ -54,8 +54,8 @@ fn handle_death_events(context: &mut Context, event: PropertyChangeEvent<Person,
             person_id: format!("{person}"),
             age_group: age_group_person,
             property: "Alive".to_string(),
-            property_prev: format!("{:?}", event.previous_value),
-            property_current: format!("{:?}", event.current_value),
+            property_prev: format!("{:?}", event.previous),
+            property_current: format!("{:?}", event.current),
         });
     }
 }

--- a/examples/births-deaths/src/incidence_report.rs
+++ b/examples/births-deaths/src/incidence_report.rs
@@ -29,7 +29,7 @@ fn handle_infection_status_change(
         person_id: format!("{}", event.entity_id),
         age_group: age_group_person,
         age: age_person.0,
-        infection_status: event.current_value,
+        infection_status: event.current,
     });
 }
 

--- a/examples/births-deaths/src/infection_manager.rs
+++ b/examples/births-deaths/src/infection_manager.rs
@@ -68,7 +68,7 @@ fn handle_infection_status_change(
     context: &mut Context,
     event: PropertyChangeEvent<Person, InfectionStatus>,
 ) {
-    match event.current_value {
+    match event.current {
         InfectionStatus::I => {
             schedule_recovery(context, event.entity_id);
         }
@@ -80,7 +80,7 @@ fn handle_infection_status_change(
 }
 
 fn handle_person_removal(context: &mut Context, event: PropertyChangeEvent<Person, Alive>) {
-    if !event.current_value.0 {
+    if !event.current.0 {
         cancel_recovery_plans(context, event.entity_id);
     }
 }
@@ -133,7 +133,7 @@ mod test {
 
         context.subscribe_to_event(
             move |context, event: PropertyChangeEvent<Person, InfectionStatus>| {
-                if event.current_value == InfectionStatus::R {
+                if event.current == InfectionStatus::R {
                     *context.get_data_mut(RecoveryPlugin) += 1;
                 }
             },

--- a/src/entity/context_extension.rs
+++ b/src/entity/context_extension.rs
@@ -604,8 +604,8 @@ mod tests {
         context.subscribe_to_event(
             move |_context, event: PropertyChangeEvent<Person, RiskLevel>| {
                 assert_eq!(event.entity_id, expected_high_id);
-                assert_eq!(event.previous_value, Some(RiskLevel::High));
-                assert_eq!(event.current_value, RiskLevel::Medium);
+                assert_eq!(event.previous, RiskLevel::High);
+                assert_eq!(event.current, RiskLevel::Medium);
                 *risk_flag_clone.borrow_mut() += 1;
             },
         );
@@ -615,8 +615,8 @@ mod tests {
         context.subscribe_to_event(
             move |_context, event: PropertyChangeEvent<Person, AgeGroup>| {
                 assert_eq!(event.entity_id, expected_high_id);
-                assert_eq!(event.previous_value, Some(AgeGroup::Senior));
-                assert_eq!(event.current_value, AgeGroup::Adult);
+                assert_eq!(event.previous, AgeGroup::Senior);
+                assert_eq!(event.current, AgeGroup::Adult);
                 *age_group_flag_clone.borrow_mut() += 1;
             },
         );
@@ -668,8 +668,8 @@ mod tests {
         context.subscribe_to_event(
             move |_context, event: PropertyChangeEvent<Person, AdultAthlete>| {
                 assert_eq!(event.entity_id, person);
-                assert_eq!(event.previous_value, Some(AdultAthlete(false)));
-                assert_eq!(event.current_value, AdultAthlete(true));
+                assert_eq!(event.previous, AdultAthlete(false));
+                assert_eq!(event.current, AdultAthlete(true));
                 *flag_clone.borrow_mut() += 1;
             },
         );


### PR DESCRIPTION
In the implementation of Entities, the `PropertyChangeEvent`'s fields `previous` and `current` were renamed `previous_value` and `current_value`. It turns out it's really annoying to port previous code to entities with this change. This PR reverts the field names to `previous` and `current`. 

Also, previously it was possible for a property to not have a value, in which case there is no meaningful value of `previous`, so it had type `Option<P>`. However, now every property must have a value, so `previous` is now a `P`.