### PR TITLE
Proposal: explicit entity id alias

### DIFF
--- a/examples/basic-infection/src/people.rs
+++ b/examples/basic-infection/src/people.rs
@@ -3,7 +3,7 @@ use ixa::trace;
 
 use crate::POPULATION;
 
-define_entity!(Person);
+define_entity!(Person, PersonId);
 
 // In this model, people only have a single property, their infection status.
 define_property!(

--- a/examples/births-deaths/src/population_manager.rs
+++ b/examples/births-deaths/src/population_manager.rs
@@ -10,7 +10,7 @@ define_rng!(PeopleRng);
 
 static MAX_AGE: u8 = 100;
 
-define_entity!(Person);
+define_entity!(Person, PersonId);
 
 define_property!(
     enum InfectionStatus {

--- a/ixa-bench/src/reference_sir/sir_ixa/entities.rs
+++ b/ixa-bench/src/reference_sir/sir_ixa/entities.rs
@@ -7,7 +7,7 @@ use crate::reference_sir::sir_ixa::{
 };
 use crate::reference_sir::{ModelStats, Parameters};
 
-define_entity!(Person);
+define_entity!(Person, PersonId);
 define_property!(
     enum InfectionStatus {
         Susceptible,

--- a/src/entity/context_extension.rs
+++ b/src/entity/context_extension.rs
@@ -347,10 +347,10 @@ mod tests {
     use crate::prelude::PropertyChangeEvent;
     use crate::{define_derived_property, define_entity, define_multi_property, define_property};
 
-    define_entity!(Animal);
+    define_entity!(Animal, AnimalId);
     define_property!(struct Legs(u8), Animal, default_const = Legs(4));
 
-    define_entity!(Person);
+    define_entity!(Person, PersonId);
 
     define_property!(struct Age(u8), Person);
 

--- a/src/entity/entity.rs
+++ b/src/entity/entity.rs
@@ -195,7 +195,7 @@ mod tests {
     use super::*;
     use crate::define_entity;
 
-    define_entity!(DummyEntity);
+    define_entity!(DummyEntity, DummyEntityId);
 
     #[test]
     fn entity_id_debug_display() {

--- a/src/entity/entity_impl.rs
+++ b/src/entity/entity_impl.rs
@@ -5,11 +5,11 @@
 #[macro_export]
 macro_rules! define_entity {
     ($entity_name:ident $(,)? $($id_alias: ident)?) => {
-        
+
         #[allow(unused)]
         #[derive(Default, Debug, PartialEq, Eq, Clone, Copy)]
         pub struct $entity_name;
-        
+
         impl $entity_name {
             #[allow(unused)]
             pub fn new() -> Self {

--- a/src/entity/query/mod.rs
+++ b/src/entity/query/mod.rs
@@ -68,7 +68,7 @@ mod tests {
         HashSetExt,
     };
 
-    define_entity!(Person);
+    define_entity!(Person, PersonId);
 
     define_property!(struct Age(u8), Person, default_const = Age(0));
     define_property!(struct County(u32), Person, default_const = County(0));


### PR DESCRIPTION
I'd like to propose that we have people define an explicit entity id alias instead of auto-generating it with paste. Given that most people won't be declaring entities / it doesn't happen often, I personally think this is:
* more explicit, doesn't require looking up docs to check what the generated type is called
* more searchable:

Change: 
```rs
define_entity!(Mosquito, MosquitoId);
```

Old: 
```rs
define_entity!(Mosquito);
// MosquitoId is generated automatically 
```

Right now in the PR the behaviour is optional, but I'd slightly be in favour of making `define_entity` non-optional (to prevent people forgetting) and leaving `impl_entity` to be optional in case you don't want the alias for some reason. Thoughts?

Still TODO in the PR: update docs. 

