### PR TITLE
feat: Add all! macro to replace tuples

### DIFF
--- a/src/entity/mod.rs
+++ b/src/entity/mod.rs
@@ -47,6 +47,7 @@ pub mod query;
 // Flatten the module hierarchy.
 pub use context_extension::ContextEntitiesExt;
 pub use entity::*;
+pub use query::EntityPropertyTuple;
 pub(crate) use query::Query;
 
 /// The type used in the indexing infrastructure. This type alias is

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -120,7 +120,7 @@ pub mod prelude_for_plugins {
 }
 
 pub mod entity;
-pub use entity::ContextEntitiesExt;
+pub use entity::{ContextEntitiesExt, EntityPropertyTuple};
 
 pub mod execution_stats;
 pub mod profiling;

--- a/src/macros/all.rs
+++ b/src/macros/all.rs
@@ -1,0 +1,124 @@
+/// Creates a query matching all entities of a given type, optionally filtered by properties.
+///
+/// # Examples
+///
+/// ```ignore
+/// // Add an entity with default properties
+/// let query = all!(Person);
+/// context.add_entity(query)?;
+///
+/// // An inline query matching a single property
+/// let person = context.sample_entity(MyRng, all!(Person, Age(12)))?;
+///
+/// // A query matching multiple properties
+/// let query = all!(Person, Age(12), RiskCategory::High);
+/// let count = context.count_entities(query);
+/// ```
+#[macro_export]
+macro_rules! all {
+    // No properties - generates empty tuple query
+    ($entity:ty) => {
+        $crate::EntityPropertyTuple::<$entity, _>::new(())
+    };
+    // One or more properties
+    ($entity:ty, $($prop:expr),+ $(,)?) => {
+        $crate::EntityPropertyTuple::<$entity, _>::new(($($prop,)+))
+    };
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::context::Context;
+    use crate::entity::ContextEntitiesExt;
+    use crate::random::ContextRandomExt;
+    use crate::{define_entity, define_property, define_rng, impl_property};
+
+    define_entity!(TestPerson);
+    define_property!(struct Age(u8), TestPerson, default_const = Age(0));
+    define_property!(
+        enum Risk {
+            High,
+            Low,
+        },
+        TestPerson
+    );
+    define_rng!(AllMacroTestRng);
+
+    #[test]
+    fn all_macro_with_add_entity() {
+        let mut context = Context::new();
+
+        // Use all! macro to add an entity
+        let person = context
+            .add_entity(all!(TestPerson, Age(42), Risk::High))
+            .unwrap();
+
+        // Verify properties were set correctly
+        assert_eq!(context.get_property::<TestPerson, Age>(person), Age(42));
+        assert_eq!(context.get_property::<TestPerson, Risk>(person), Risk::High);
+    }
+
+    #[test]
+    fn all_macro_with_sample_entity() {
+        let mut context = Context::new();
+        context.init_random(42);
+
+        // Add some entities
+        let p1 = context
+            .add_entity(all!(TestPerson, Age(30), Risk::High))
+            .unwrap();
+        let _ = context
+            .add_entity(all!(TestPerson, Age(30), Risk::Low))
+            .unwrap();
+        let _ = context
+            .add_entity(all!(TestPerson, Age(25), Risk::High))
+            .unwrap();
+
+        // Sample from entities matching the query
+        let sampled = context.sample_entity(AllMacroTestRng, all!(TestPerson, Age(30), Risk::High));
+        assert_eq!(sampled, Some(p1));
+    }
+
+    #[test]
+    fn all_macro_with_sample_entity_no_match() {
+        let mut context = Context::new();
+        context.init_random(42);
+
+        // Add some entities that don't match the query
+        let _ = context
+            .add_entity(all!(TestPerson, Age(30), Risk::Low))
+            .unwrap();
+
+        // Sample should return None when no entities match
+        let sampled = context.sample_entity(AllMacroTestRng, all!(TestPerson, Age(30), Risk::High));
+        assert_eq!(sampled, None);
+    }
+
+    // Demonstrate that `all!` can disambiguate entities in otherwise ambiguous cases.
+    use crate::entity::EntityId;
+    define_entity!(TestMammal);
+    define_entity!(TestAvian);
+    define_property!(struct IsBipedal(bool), TestMammal, default_const = IsBipedal(false));
+    impl_property!(IsBipedal, TestAvian, default_const = IsBipedal(true));
+
+    #[test]
+    fn all_macro_disambiguates_entities() {
+        let mut context = Context::new();
+
+        context
+            .add_entity(all!(TestAvian, IsBipedal(true)))
+            .unwrap();
+        context
+            .add_entity(all!(TestMammal, IsBipedal(true)))
+            .unwrap();
+
+        let result = context.query_result_iterator(all!(TestMammal, IsBipedal(true)));
+        assert_eq!(result.count(), 1);
+
+        let sampled_id = context
+            .sample_entity(AllMacroTestRng, all!(TestAvian, IsBipedal(true)))
+            .unwrap();
+        let expected_id: EntityId<TestAvian> = EntityId::new(0);
+        assert_eq!(sampled_id, expected_id);
+    }
+}

--- a/src/macros/mod.rs
+++ b/src/macros/mod.rs
@@ -1,3 +1,4 @@
+mod all;
 mod assert_almost_eq;
 mod define_data_plugin;
 mod define_edge_type;


### PR DESCRIPTION
This implementation leaves tuples in place (for now – I think if we like it, we might want to consider removing the tuples) but adds a new api via an `all!` macro.

Example:

```js
// Empty
let person = context.add_entity::<Person>(())
let person = context.add_entity(all!(Person))

// With properties
let person = context.add_entity(all!(Person, Age(17), Risk::Low))

// Also for queries
let person = context.sample_entity(SampleRng, all!(Person, InfectionStatus::Infected);

```