### PR TITLE
chore: Add MSRV to Cargo.toml. Fixes #430.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -74,6 +74,7 @@ ouroboros = "^0.18.5"
 [package]
 name = "ixa"
 version = "0.4.4"
+rust-version = "1.88.0"
 description = "A framework for building agent-based models"
 repository.workspace = true
 license.workspace = true


### PR DESCRIPTION
This PR adds a minimum supported Rust version to the `ixa` crate:

```toml
[package]
name = "ixa"
version = "0.4.4"
rust-version = "1.88.0"
# ...
```

Using the `cargo-msrv` tool...

... to find the MSRV of all (transitive) dependencies:

```bash
cargo msrv list
```

The output lists the MSRV's explicitly specified by dependencies in descending order. The `sysinfo` (direct) and `home` (transitive of `rustyline`) crates have the same latest MSRV, 1.88.0.

Setting this version in `Cargo.toml`, we can verify with `cargo-msrv`:

```bash
cargo msrv verify
```

Verifies as compatible.