### PR TITLE
Build system ergonomics

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -38,12 +38,13 @@ run = '''
   mdbook build docs/book -d ../../website/book
 '''
 
-[tasks.test]
+[tasks.test-all]
 description = "Run all tests"
-depends = [
-  "test:unit",
-  "test:wasm"
-]
+depends = ["test:unit", "test:wasm"]
+
+[tasks.test]
+description = "Run rust tests. Faster than test-all"
+alias = "test:unit"
 
 [tasks.'test:unit']
 description = "Run all unit tests"
@@ -56,10 +57,7 @@ run = "cargo test -p ixa"
 [tasks.'test:wasm']
 description = "Run wasm integration tests"
 dir = "integration-tests/ixa-wasm-tests"
-depends = [
-  "wasm:pnpm",
-  "wasm:compile"
-  ]
+depends = ["wasm:pnpm", "wasm:compile"]
 run = "pnpm exec playwright test"
 
 [tasks.'test:features']
@@ -68,33 +66,20 @@ run = "cargo test --no-default-features --features 'web_api'"
 
 [tasks.'wasm:pnpm']
 dir = "integration-tests/ixa-wasm-tests"
-run = [
-  "pnpm install",
-  "pnpm exec playwright install"
-  ]
-sources = [
-  'package.json',
-  'pnpm-lock.yaml',
-  'mise.toml'
-  ]
+run = ["pnpm install", "pnpm exec playwright install"]
+sources = ['package.json', 'pnpm-lock.yaml', 'mise.toml']
 outputs = 'node_modules/.pnpm/lock.yaml'
 
 [tasks.'wasm:compile']
 env.RUSTFLAGS = '--cfg getrandom_backend="wasm_js"'
 dir = "integration-tests/ixa-wasm-tests"
 run = "wasm-pack build --target web"
-sources = [
-  "src/*.rs",
-  "Cargo.toml"
-  ]
+sources = ["src/*.rs", "Cargo.toml"]
 outputs = "pkg"
 
 [tasks.'bench']
 description = "Run all benchmarks"
-run = [
-  "mise run bench:hyperfine",
-  "mise run bench:criterion"
-]
+run = ["mise run bench:hyperfine", "mise run bench:criterion"]
 
 [tasks.'bench:criterion']
 description = "Run all Criterion benchmarks (optionally pass a specific name)"
@@ -107,17 +92,14 @@ run = "cargo bench -p ixa-bench {{arg(name='name', default='')}} -- --save-basel
 [tasks.'bench:compare']
 description = "Compare benchmarks against a Criterion baseline"
 run = [
-    "cargo bench -p ixa-bench {{arg(name='name', default='')}} -- --baseline {{arg(name='baseline')}}",
-    "cargo run -q -p ixa-bench --bin check_criterion_regressions"
-  ]
+  "cargo bench -p ixa-bench {{arg(name='name', default='')}} -- --baseline {{arg(name='baseline')}}",
+  "cargo run -q -p ixa-bench --bin check_criterion_regressions",
+]
 
 [tasks.'build:hyperfine']
 description = "Build the benchmark utilities binaries"
 run = "cargo build -p ixa-bench --release"
-sources = [
-  "ixa-bench/src/**/*.rs", 'Cargo.toml',
-  "ixa-bench/Cargo.toml"
-  ]
+sources = ["ixa-bench/src/**/*.rs", 'Cargo.toml', "ixa-bench/Cargo.toml"]
 outputs = "target/release/hyperfine"
 
 [tasks.'test:hyperfine']
@@ -128,9 +110,13 @@ run = "mise bench:hyperfine --warmup=0 --runs=1"
 depends = "build:hyperfine"
 run = './target/release/hyperfine'
 
-[tasks.check]
+[tasks.check-all]
 description = "Formatting and linting"
 depends = "check:*"
+
+[tasks.check]
+description = "Run rust checks. Faster than check-all"
+alias = "check:rust"
 
 [tasks.'check:rust']
 run = [
@@ -139,7 +125,7 @@ run = [
   "cargo check --all-targets --workspace --all-features",
   "rustup component add --toolchain nightly-x86_64-unknown-linux-gnu rustfmt",
   "cargo +nightly fmt --check",
-  "cargo clippy --workspace --all-targets --all-features -- -D warnings"
+  "cargo clippy --workspace --all-targets --all-features -- -D warnings",
 ]
 
 [tasks.prettier]
@@ -150,14 +136,15 @@ run = '''prettier --{{arg(name='action', default='check')}} "**/*.{md,json,yml,y
 '''
 
 [tasks.'check:markdown']
-run = [
-  "markdownlint '**/*.md'",
-  "mise prettier check"
-  ]
+run = ["markdownlint '**/*.md'", "mise prettier check"]
 
-[tasks.fix]
+[tasks.fix-all]
 description = "Auto-fix formatting and linting issues"
 depends = "fix:*"
+
+[tasks.fix]
+description = "Fix rust code. Faster than fix-all"
+alias = "fix:rust"
 
 [tasks.'fix:prettier']
 run = "mise prettier write"
@@ -166,7 +153,7 @@ run = "mise prettier write"
 run = [
   "cargo clippy --fix --workspace --all-targets --allow-dirty --all-features -- -D warnings",
   "rustup component add --toolchain nightly-x86_64-unknown-linux-gnu rustfmt",
-  "cargo +nightly fmt"
+  "cargo +nightly fmt",
 ]
 
 [tasks.'fix:markdown']
@@ -184,17 +171,12 @@ run = '''
 
 [tasks.precommit]
 description = "This is used by pre-commit (which installs git hooks)"
-depends = "check"
+depends = "check-all"
 
 [tasks.prepush]
 description = "Check everything before pushing"
 env.RUSTFLAGS = "-D warnings"
-run = [
-  "mise precommit",
-  "mise examples",
-  "mise docs",
-  "mise test"
-  ]
+run = ["mise precommit", "mise examples", "mise docs", "mise test-all"]
 
 [tasks.'docker:build']
 run = "docker build -t ixa-bench ."


### PR DESCRIPTION
In practice the "all" case is handled by precommit/CI/prepush so I'd propose that we make the default workflow `mise check` and `mise test`and `mise fix` rust-specific since it covers the majority of cases and is much faster. I found myself mostly running `mise test:unit` all the time. Thoughts? 

