### PR TITLE
chore: Remove `pub` from inner property fields in examples, docs

### DIFF
--- a/examples/births-deaths/src/population_manager.rs
+++ b/examples/births-deaths/src/population_manager.rs
@@ -22,11 +22,11 @@ define_property!(
     default_const = InfectionStatus::S
 );
 define_property!(
-    struct Age(pub u8),
+    struct Age(u8),
     Person
 );
 define_property!(
-    struct Alive(pub bool),
+    struct Alive(bool),
     Person,
     default_const = Alive(true)
 );

--- a/examples/load-people/population_loader.rs
+++ b/examples/load-people/population_loader.rs
@@ -20,7 +20,7 @@ struct PeopleRecord {
     risk_category: RiskCategory,
 }
 
-define_property!(struct Age(pub u8), Person);
+define_property!(struct Age(u8), Person);
 
 fn create_person_from_record(context: &mut Context, record: &PeopleRecord) -> PersonId {
     let age = Age(record.age);

--- a/examples/load-people/vaccine.rs
+++ b/examples/load-people/vaccine.rs
@@ -12,8 +12,8 @@ define_property!(
     },
     Person
 );
-define_property!(struct VaccineEfficacy(pub f64), Person);
-define_property!(struct VaccineDoses(pub u8), Person);
+define_property!(struct VaccineEfficacy(f64), Person);
+define_property!(struct VaccineDoses(u8), Person);
 
 pub trait ContextVaccineExt: ContextRandomExt {
     fn get_vaccine_props(&self, risk: RiskCategory) -> (VaccineType, VaccineEfficacy) {

--- a/examples/network-hhmodel/seir.rs
+++ b/examples/network-hhmodel/seir.rs
@@ -22,7 +22,7 @@ define_rng!(SeirRng);
 impl_property!(DiseaseStatus, Person, default_const = DiseaseStatus::S);
 
 define_property!(
-    struct InfectedBy(pub Option<PersonId>),
+    struct InfectedBy(Option<PersonId>),
     Person,
     default_const = InfectedBy(None)
 );

--- a/examples/time-varying-infection/population_loader.rs
+++ b/examples/time-varying-infection/population_loader.rs
@@ -15,7 +15,7 @@ define_property!(
 );
 
 define_property!(
-    struct InfectionTime(pub Option<f64>),
+    struct InfectionTime(Option<f64>),
     Person,
     default_const = InfectionTime(None)
 );

--- a/integration-tests/ixa-runner-tests/tests/macros.rs
+++ b/integration-tests/ixa-runner-tests/tests/macros.rs
@@ -6,15 +6,15 @@ mod tests {
     define_entity!(Person);
 
     // Test entity property / derived / multi-property macros
-    define_property!(struct TestPropU32(pub u32), Person);
-    define_property!(struct TestPropU32b(pub u32), Person);
+    define_property!(struct TestPropU32(u32), Person);
+    define_property!(struct TestPropU32b(u32), Person);
     define_property!(
-        struct TestPropDefault(pub u32),
+        struct TestPropDefault(u32),
         Person,
         default_const = TestPropDefault(7u32)
     );
     define_property!(
-        struct TestPropOpt(pub Option<u8>),
+        struct TestPropOpt(Option<u8>),
         Person,
         default_const = TestPropOpt(None)
     );

--- a/src/entity/index.rs
+++ b/src/entity/index.rs
@@ -139,9 +139,9 @@ mod test {
     use crate::prelude::*;
 
     define_entity!(Person);
-    define_property!(struct Age(pub u8), Person, default_const = Age(0));
-    define_property!(struct Weight(pub u8), Person, default_const = Weight(0));
-    define_property!(struct Height(pub u8), Person, default_const = Height(0));
+    define_property!(struct Age(u8), Person, default_const = Age(0));
+    define_property!(struct Weight(u8), Person, default_const = Weight(0));
+    define_property!(struct Height(u8), Person, default_const = Height(0));
 
     define_multi_property!((Age, Weight, Height), Person);
     define_multi_property!((Weight, Height, Age), Person);

--- a/src/macros/property_impl.rs
+++ b/src/macros/property_impl.rs
@@ -139,7 +139,7 @@ impl_property!(
 /// # use serde::Serialize;
 /// # define_entity!(Person);
 /// #[derive(Debug, PartialEq, Eq, Clone, Copy, Serialize)]
-/// pub struct Age(pub u8);
+/// pub struct Age(u8);
 /// impl_property!(Age, Person);
 /// ```
 ///
@@ -242,7 +242,7 @@ macro_rules! define_property {
         $(, $($extra:tt)+),*
     ) => {
         #[derive(Debug, PartialEq, Clone, Copy, serde::Serialize)]
-        pub struct $name { $($visibility $field_name : $field_ty),* }
+        pub struct $name { $(pub $field_name : $field_ty),* }
         $crate::impl_property!($name, $entity $(, $($extra)+)*);
     };
 


### PR DESCRIPTION
Also inserted `pub` in the case of a struct with named fields in `define_property!`, which case was missed in the previous related PR.