### PR TITLE
chore: Rename `QueryResultIterator` to `EntitySetIterator`

### DIFF
--- a/src/entity/context_extension.rs
+++ b/src/entity/context_extension.rs
@@ -1,10 +1,11 @@
 use std::any::{Any, TypeId};
 
+use crate::entity::entity_set::EntitySetIterator;
 use crate::entity::events::{EntityCreatedEvent, PartialPropertyChangeEvent};
 use crate::entity::property::Property;
 use crate::entity::property_list::PropertyList;
-use crate::entity::query::{Query, QueryResultIterator};
-use crate::entity::{Entity, EntityId, EntityIterator};
+use crate::entity::query::Query;
+use crate::entity::{Entity, EntityId, PopulationIterator};
 use crate::hashing::IndexSet;
 use crate::rand::Rng;
 use crate::{warn, Context, ContextRandomExt, RngId};
@@ -93,10 +94,10 @@ pub trait ContextEntitiesExt {
     fn get_entity_count<E: Entity>(&self) -> usize;
 
     /// Returns an iterator over all created entities of type `E`.
-    fn get_entity_iterator<E: Entity>(&self) -> EntityIterator<E>;
+    fn get_entity_iterator<E: Entity>(&self) -> PopulationIterator<E>;
 
     /// Generates an iterator over the results of the query.
-    fn query_result_iterator<E: Entity, Q: Query<E>>(&self, query: Q) -> QueryResultIterator<E>;
+    fn query_result_iterator<E: Entity, Q: Query<E>>(&self, query: Q) -> EntitySetIterator<E>;
 
     /// Determines if the given person matches this query.
     fn match_entity<E: Entity, Q: Query<E>>(&self, entity_id: EntityId<E>, query: Q) -> bool;
@@ -264,7 +265,7 @@ impl ContextEntitiesExt for Context {
         // The slow path of computing the full query set.
         warn!("Called Context::with_query_results() with an unindexed query. It's almost always better to use Context::query_result_iterator() for unindexed queries.");
 
-        // Fall back to `QueryResultIterator`.
+        // Fall back to `EntitySetIterator`.
         let people_set = query
             .new_query_result_iterator(self)
             .collect::<IndexSet<_>>();
@@ -322,11 +323,11 @@ impl ContextEntitiesExt for Context {
         self.entity_store.get_entity_count::<E>()
     }
 
-    fn get_entity_iterator<E: Entity>(&self) -> EntityIterator<E> {
+    fn get_entity_iterator<E: Entity>(&self) -> PopulationIterator<E> {
         self.entity_store.get_entity_iterator::<E>()
     }
 
-    fn query_result_iterator<E: Entity, Q: Query<E>>(&self, query: Q) -> QueryResultIterator<E> {
+    fn query_result_iterator<E: Entity, Q: Query<E>>(&self, query: Q) -> EntitySetIterator<E> {
         query.new_query_result_iterator(self)
     }
 

--- a/src/entity/entity.rs
+++ b/src/entity/entity.rs
@@ -127,7 +127,7 @@ pub type BxEntity = Box<dyn Entity>;
 /// If entities are added _after_ this iterator has been created, this iterator will _not_ produce the `EntityId<E>`s
 /// of the newly added entities.
 #[derive(Copy, Clone)]
-pub struct EntityIterator<E: Entity> {
+pub struct PopulationIterator<E: Entity> {
     /// The total count of all entities of this type at the time this iterator was created
     population: usize,
     /// The next `EntityId<E>` this iterator will produce (assuming `entity_id < population`)
@@ -136,11 +136,11 @@ pub struct EntityIterator<E: Entity> {
     _phantom: PhantomData<E>,
 }
 
-impl<E: Entity> EntityIterator<E> {
-    // Only internal ixa code can create a new `EntityIterator<E>` in order to guarantee only valid
+impl<E: Entity> PopulationIterator<E> {
+    // Only internal ixa code can create a new `PopulationIterator<E>` in order to guarantee only valid
     // `EntityId<E>` values are ever created.
     pub(crate) fn new(population: usize) -> Self {
-        EntityIterator::<E> {
+        PopulationIterator::<E> {
             population,
             entity_id: 0,
             _phantom: PhantomData,
@@ -148,7 +148,7 @@ impl<E: Entity> EntityIterator<E> {
     }
 }
 
-impl<E: Entity> Iterator for EntityIterator<E> {
+impl<E: Entity> Iterator for PopulationIterator<E> {
     type Item = EntityId<E>;
 
     fn next(&mut self) -> Option<Self::Item> {
@@ -181,14 +181,14 @@ impl<E: Entity> Iterator for EntityIterator<E> {
     }
 }
 
-impl<E: Entity> ExactSizeIterator for EntityIterator<E> {
+impl<E: Entity> ExactSizeIterator for PopulationIterator<E> {
     fn len(&self) -> usize {
         // Safety: Since `self.entity_id` saturates to `self.population`, we do not need `saturating_sub` here.
         self.population - self.entity_id
     }
 }
-// Once `EntityIterator<E>` returns `None`, it will always return `None`.
-impl<E: Entity> std::iter::FusedIterator for EntityIterator<E> {}
+// Once `PopulationIterator<E>` returns `None`, it will always return `None`.
+impl<E: Entity> std::iter::FusedIterator for PopulationIterator<E> {}
 
 #[cfg(test)]
 mod tests {
@@ -206,7 +206,7 @@ mod tests {
 
     #[test]
     fn test_entity_iterator_basic() {
-        let mut iter = EntityIterator::<DummyEntity>::new(3);
+        let mut iter = PopulationIterator::<DummyEntity>::new(3);
 
         assert_eq!(iter.len(), 3);
         assert_eq!(iter.next(), Some(EntityId::new(0)));
@@ -222,7 +222,7 @@ mod tests {
 
     #[test]
     fn test_entity_iterator_nth() {
-        let mut iter = EntityIterator::<DummyEntity>::new(10);
+        let mut iter = PopulationIterator::<DummyEntity>::new(10);
 
         // Seek to 3rd element (index 2)
         assert_eq!(iter.nth(2), Some(EntityId::new(2)));
@@ -239,7 +239,7 @@ mod tests {
 
     #[test]
     fn test_entity_iterator_size_hint() {
-        let mut iter = EntityIterator::<DummyEntity>::new(5);
+        let mut iter = PopulationIterator::<DummyEntity>::new(5);
         assert_eq!(iter.size_hint(), (5, Some(5)));
 
         iter.next();
@@ -252,7 +252,7 @@ mod tests {
 
     #[test]
     fn test_entity_iterator_clonable() {
-        let mut iter = EntityIterator::<DummyEntity>::new(5);
+        let mut iter = PopulationIterator::<DummyEntity>::new(5);
         iter.next();
 
         let mut cloned = iter;

--- a/src/entity/entity_set/mod.rs
+++ b/src/entity/entity_set/mod.rs
@@ -1,0 +1,5 @@
+mod entity_set_iterator;
+mod source_set;
+
+pub use entity_set_iterator::EntitySetIterator;
+pub(crate) use source_set::SourceSet;

--- a/src/entity/entity_store.rs
+++ b/src/entity/entity_store.rs
@@ -17,7 +17,7 @@ use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::{LazyLock, Mutex, OnceLock};
 
 use crate::entity::property_store::PropertyStore;
-use crate::entity::{Entity, EntityId, EntityIterator};
+use crate::entity::{Entity, EntityId, PopulationIterator};
 use crate::HashMap;
 
 /// Global entity index counter; keeps track of the index that will be assigned to the next entity that
@@ -260,9 +260,9 @@ impl EntityStore {
     }
 
     /// Returns an iterator over all valid `EntityId<E>`s
-    pub fn get_entity_iterator<E: Entity>(&self) -> EntityIterator<E> {
+    pub fn get_entity_iterator<E: Entity>(&self) -> PopulationIterator<E> {
         let count = self.get_entity_count::<E>();
-        EntityIterator::new(count)
+        PopulationIterator::new(count)
     }
 
     pub fn get_property_store<E: Entity>(&self) -> &PropertyStore<E> {

--- a/src/entity/mod.rs
+++ b/src/entity/mod.rs
@@ -33,6 +33,7 @@ static variable `index`. Each concrete `Entity` type is thus assigned a unique i
 
 pub mod context_extension;
 mod entity;
+pub mod entity_set;
 pub mod entity_store;
 pub mod events;
 mod index;
@@ -47,6 +48,7 @@ pub mod query;
 // Flatten the module hierarchy.
 pub use context_extension::ContextEntitiesExt;
 pub use entity::*;
+pub use entity_set::EntitySetIterator;
 pub use query::EntityPropertyTuple;
 pub(crate) use query::Query;
 

--- a/src/entity/query/mod.rs
+++ b/src/entity/query/mod.rs
@@ -1,13 +1,10 @@
 mod query_impls;
-mod query_result_iterator;
-mod source_set;
 
 use std::any::TypeId;
 use std::marker::PhantomData;
 use std::sync::{Mutex, OnceLock};
 
-pub use query_result_iterator::QueryResultIterator;
-
+use crate::entity::entity_set::EntitySetIterator;
 use crate::entity::multi_property::type_ids_to_multi_property_index;
 use crate::entity::property_list::PropertyList;
 use crate::entity::property_store::PropertyStore;
@@ -95,7 +92,7 @@ impl<E: Entity, T: Query<E>> Query<E> for EntityPropertyTuple<E, T> {
         self.inner.multi_property_value_hash()
     }
 
-    fn new_query_result_iterator<'c>(&self, context: &'c Context) -> QueryResultIterator<'c, E> {
+    fn new_query_result_iterator<'c>(&self, context: &'c Context) -> EntitySetIterator<'c, E> {
         self.inner.new_query_result_iterator(context)
     }
 
@@ -158,8 +155,8 @@ pub trait Query<E: Entity>: Copy + 'static {
     /// multi-property value.
     fn multi_property_value_hash(&self) -> HashValueType;
 
-    /// Creates a new `QueryResultIterator`
-    fn new_query_result_iterator<'c>(&self, context: &'c Context) -> QueryResultIterator<'c, E>;
+    /// Creates a new `EntitySetIterator`.
+    fn new_query_result_iterator<'c>(&self, context: &'c Context) -> EntitySetIterator<'c, E>;
 
     /// Determines if the given person matches this query.
     fn match_entity(&self, entity_id: EntityId<E>, context: &Context) -> bool;


### PR DESCRIPTION
This change to the public API looks ahead to a future `EntitySet` feature that can be used to implement conjunction and disjunction in queries, among other things. All this PR does is
- rename `QueryResultIterator` to `EntitySetIterator`
- moves `QueryResultIterator` / `EntitySetIterator` and `SourceSet` / `SourceSetIterator` to a new `entity::entity_set` module.
- Renames `EntityIterator` to `PopulationIterator` (to avoid confusion with `EntitySetIterator`)