### PR TITLE
fix: mise `docs` task to use regular `target` directory

### DIFF
--- a/.rumdl.toml
+++ b/.rumdl.toml
@@ -3,4 +3,4 @@ disable = [
   "MD013", # line-length
   "MD033", # no-inline-html
 ]
-exclude = ["CHANGELOG.md"]
+exclude = ["CHANGELOG.md", "docs/book/src/cli-usage.md"]

--- a/docs/book/src/cli-usage.md
+++ b/docs/book/src/cli-usage.md
@@ -8,7 +8,7 @@ Default cli arguments for ixa runner
 
 **Usage:** `ixa [OPTIONS]`
 
-### **Options:**
+###### **Options:**
 
 * `-r`, `--random-seed <RANDOM_SEED>` — Random seed
 
@@ -26,7 +26,6 @@ Default cli arguments for ixa runner
    | -v      |   ✓   |  ✓   |  ✓   |       |       |
    | -vv     |   ✓   |  ✓   |  ✓   |   ✓   |       |
    | -vvv    |   ✓   |  ✓   |  ✓   |   ✓   |   ✓   |
-
 * `--warn` — Set logging to WARN level. Shortcut for `--log-level warn`
 * `--debug` — Set logging to DEBUG level. Shortcut for `--log-level DEBUG`
 * `--trace` — Set logging to TRACE level. Shortcut for `--log-level TRACE`
@@ -34,3 +33,6 @@ Default cli arguments for ixa runner
 * `-w`, `--web <WEB>` — Enable the Web API at a given time. Defaults to t=0.0
 * `-t`, `--timeline-progress-max <TIMELINE_PROGRESS_MAX>` — Enable the timeline progress bar with a maximum time
 * `--no-stats` — Suppresses the printout of summary statistics at the end of the simulation
+
+
+

--- a/docs/book/src/first_model/people.md
+++ b/docs/book/src/first_model/people.md
@@ -22,7 +22,7 @@ a new file in the `src` directory called `people.rs`.
 We have to define the `Person` entity before we can associate properties with
 it. The `define_entity!(Person)` macro invocation automatically defines the
 `Person` type, implements the `Entity` trait for `Person`, and creates the type
-alias `PersonId = EntityId<Person>`, which is the type we can use to represent
+alias `PersonId = EntityId\<Person>`, which is the type we can use to represent
 specific instances of our entity, a single person, in our simulation.
 
 To each person we will associate a value of the enum (short for “enumeration”)

--- a/docs/book/src/migration_guide.md
+++ b/docs/book/src/migration_guide.md
@@ -64,7 +64,7 @@ pub enum InfectionStatus {
     Recovered,
 }
 
-// Implements `Property<Person>` for an existing type.
+// Implements `Property\<Person>` for an existing type.
 impl_property!(
     InfectionStatus,
     Person,
@@ -77,7 +77,7 @@ traits and `pub` visibility to the type definition and then call
 `impl_property!` as above.)
 
 The crucial thing to understand is that the value type _is_ the property type.
-The `impl Property<Person> for InfectionStatus`, which the macros give you, is
+The `impl Property\<Person> for InfectionStatus`, which the macros give you, is
 the thing that ties the `InfectionStatus` type to the `Person` entity.
 
 For details about defining properties, see the `property_impl` module-level docs
@@ -90,9 +90,9 @@ and API docs for the macros `define_property!`, `impl_property!`,
 | Concept                     | Old System                                                                                                                     | New System                                                                                                           | Notes / Implications                                                                |
 | --------------------------- | ------------------------------------------------------------------------------------------------------------------------------ | -------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------- |
 | **Property Type Structure** | Two separate types: (1) value type, and (2) property-identifier ZST.                                                           | A single type represents both the value and identifies the property.                                                 | Simplified to a single type                                                         |
-| **Defining Properties**     | Define a normal Rust type (or use an existing primitive, e.g. `u8`), then use a macro to define the identifying property type. | Define a normal Rust type, then use `impl_property` to declare it a `Property<E>` for a particular `Entity` `E`.     |                                                                                     |
+| **Defining Properties**     | Define a normal Rust type (or use an existing primitive, e.g. `u8`), then use a macro to define the identifying property type. | Define a normal Rust type, then use `impl_property` to declare it a `Property\<E>` for a particular `Entity` `E`.     |                                                                                     |
 | **Entity Association**      | Implicit—only one entity ("person")                                                                                            | Every property must explicitly specify the `Entity` it belongs to (e.g., `Person`); Entities are defined separately. |                                                                                     |
-| **Default Values**          | Provided in the macro creating the property-identifier type.                                                                   | Same but with updated syntax; default values are per `Property<E>` implementation.                                   |                                                                                     |
+| **Default Values**          | Provided in the macro creating the property-identifier type.                                                                   | Same but with updated syntax; default values are per `Property\<E>` implementation.                                   |                                                                                     |
 | **Using Existing Types**    | A single _value_ type can be used in multiple properties—including primitive types like `u8`                                   | Only one property per type (per `Entity`); primitive types must be wrapped in a newtype.                             | Both systems require that the existing type implement the required property traits. |
 | **Macro Behavior**          | Macros define the property’s ZST and connect it to the value type via trait impls.                                             | Macros define "is a property of entity `E`" relationship via trait impl. No additional synthesized types.            | Both enforce correctness via macro                                                  |
 
@@ -121,8 +121,8 @@ impl_entity!(Person);
 ```
 
 These macros automatically create a type alias of the form
-`MyEntityId = EntityId<MyEntity>`. In our case, it defines the type alias
-`PersonId = EntityId<Person>`.
+`MyEntityId = EntityId\<MyEntity>`. In our case, it defines the type alias
+`PersonId = EntityId\<Person>`.
 
 ### Adding a new entity (e.g. a new person)
 
@@ -158,11 +158,11 @@ let person_id = context.add_entity((Age(25), )).unwrap();
 Adding a new entity with only default property values:
 
 ```rust
-// If you specify the `EntityId<E>` return type, the compiler uses it to infer which entity to add.
+// If you specify the `EntityId\<E>` return type, the compiler uses it to infer which entity to add.
 // This is a good practice and avoids the special "turbo fish" syntax.
 let person_id: PersonId = context.add_entity(()).unwrap();
 
-// If we don't specify the `EntityId<E>` type, we have to explicitly tell the compiler *which* entity
+// If we don't specify the `EntityId\<E>` type, we have to explicitly tell the compiler *which* entity
 // type we are adding, as there is nothing from which to infer the entity type.
 let person_id = context.add_entity::<Person, _>(()).unwrap();
 ```

--- a/docs/book/src/topics/indexing.md
+++ b/docs/book/src/topics/indexing.md
@@ -24,7 +24,7 @@ Best practices:
 - The cost of creating indexes is increased memory use, which can be significant
   for large populations. So it is best to only create indexes / multi-indexes
   that actually improve model performance.
-- It may be best to call `context.index_property::<Entity, Property<Entity>>()`
+- It may be best to call `context.index_property::\<Entity, Property<Entity>>()`
   in the `init()` method of the module in which the property is defined, or you
   can put all of your `Context::index_property` calls together in a main
   initialization function if you prefer.

--- a/docs/book/src/topics/profiling-module.md
+++ b/docs/book/src/topics/profiling-module.md
@@ -161,7 +161,7 @@ some span.
 
 You can register custom, derived metrics over collected `ProfilingData` using
 `add_computed_statistic(label, description, computer, printer)`. The "computer"
-returns an `Option<T>` (for conditionally defined statistics), and the "printer"
+returns an `Option\<T>` (for conditionally defined statistics), and the "printer"
 prints the computed value.
 
 Computed statistics are printed by `print_computed_statistics()` and included in

--- a/mise.toml
+++ b/mise.toml
@@ -43,7 +43,9 @@ done
 description = "Build the Rust cli docs, API docs and Ixa website"
 run = '''
   cargo run --features write_cli_usage --example basic-infection -- --markdown-help
-  cargo doc --all-features --no-deps --target-dir website/
+  cargo doc --all-features --no-deps
+  rm -rf website/doc
+  cp -r target/doc website
   mdbook build docs/book -d ../../website/book
 '''
 


### PR DESCRIPTION
Also fixed:

- Excluded the machine-generated `cli-usage.md` from rumdl checks
- Escaped a bunch of `<` characters in inline code in the docs, which cause problems if unescaped.