### PR TITLE
fix: Implement `PropertyList` and `Query` for tuples of size up to 20

### DIFF
--- a/src/entity/property_list.rs
+++ b/src/entity/property_list.rs
@@ -131,7 +131,7 @@ macro_rules! impl_property_list {
     };
 }
 
-// Generate impls for tuple lengths 2 through 10.
-seq!(Z in 2..=5 {
+// Generate impls for tuple lengths 2 through 20. (The 0 and 1 case are implemented above.)
+seq!(Z in 2..=20 {
     impl_property_list!(Z);
 });

--- a/src/entity/query/query_impls.rs
+++ b/src/entity/query/query_impls.rs
@@ -266,7 +266,7 @@ macro_rules! impl_query {
     }
 }
 
-// Implement the versions with 2..10 parameters. (The 1 case is implemented above.)
-seq!(Z in 2..10 {
+// Implement the versions with 2..20 parameters. (The 0 and 1 case are implemented above.)
+seq!(Z in 2..20 {
     impl_query!(Z);
 });


### PR DESCRIPTION
At some point some knucklehead changed the bounds on the macro invocation that generates the trait impls for `PropertyList` and `Query` for tuples up to size 20 for completely mysterious reasons. This is the fix.