### PR TITLE
fix: `Query` for tuples of size up to 20

### DIFF
--- a/src/people/query.rs
+++ b/src/people/query.rs
@@ -193,8 +193,8 @@ macro_rules! impl_query {
     }
 }
 
-// Implement the versions with 2..10 parameters. (The 1 case is implemented above.)
-seq!(Z in 2..10 {
+// Implement the versions with 2..20 parameters. (The 1 case is implemented above.)
+seq!(Z in 2..20 {
     impl_query!(Z);
 });
 


### PR DESCRIPTION
A version of #789 for the v1.0 branch. 

Is this the right target branch for v1.0 fixes?