### PR TITLE
feat: Removed RefCell from indexes

### DIFF
--- a/docs/book/src/topics/indexing.md
+++ b/docs/book/src/topics/indexing.md
@@ -29,8 +29,9 @@ Best practices:
   can put all of your `Context::index_property` calls together in a main
   initialization function if you prefer.
 - It is not an error to call `Context::index_property` in the middle of a
-  running simulation or to call it twice for the same property, but it makes
-  little sense to do so.
+  running simulation or to call it twice for the same property.
+- Calling `Context::index_property` enables indexing and catches the index up to
+  the current population at the time of the call.
 
 ## Property Value Storage in Ixa
 
@@ -112,17 +113,6 @@ An index in Ixa is just a map between a property _value_ and the list of all
 property value is (almost) as fast as looking up the property value for a given
 `PersonId`.
 
-> [!INFO] Ixa's Intelligent Indexing Strategy
->
-> The picture we have painted of how Ixa implements indexing is necessarily a
-> simplification. Ixa uses a lazy indexing strategy, which means if a property
-> is never queried, then Ixa never actually does the work of computing the
-> index. Ixa also keeps track of whether new people have been added to the
-> simulation since the last time a query was run, so that it only has to update
-> its index for those newly added people. These and other optimizations make
-> Ixa's indexing very fast and memory efficient compared to the simplistic
-> version described in this section.
-
 ## The Costs of Creating an Index
 
 There are two costs you have to pay for indexing:
@@ -145,10 +135,6 @@ There are two costs you have to pay for indexing:
 > it all at once doesn't matter: the sum of all the small efforts to update the
 > index every time a person is added is equal to the cost of creating the index
 > from scratch for an existing set of data.
->
-> We can, however, save the effort of updating the index when property values
-> _change_ if we wait until we actually run a query that needs to use the index
-> before we construct the index. This is why Ixa uses a lazy indexing strategy.
 
 Usually scanning through the whole property column is so slow relative to
 maintaining an index that the extra computational cost of maintaining the index

--- a/src/entity/context_extension.rs
+++ b/src/entity/context_extension.rs
@@ -34,12 +34,12 @@ pub trait ContextEntitiesExt {
         property_value: P,
     );
 
-    /// Enables indexing of property values for the property `P`.
+    /// Enables full indexing of property values for the property `P`.
     ///
     /// This method is called with the turbo-fish syntax:
     ///     `context.index_property::<Person, Age>()`
-    /// The actual computation of the index is done lazily as needed upon execution of queries,
-    /// not when this method is called.
+    ///
+    /// This method both enables the index and catches it up to the current population.
     fn index_property<E: Entity, P: Property<E>>(&mut self);
 
     /// Enables value-count indexing of property values for the property `P`.
@@ -145,8 +145,19 @@ impl ContextEntitiesExt for Context {
 
         // Assign the properties in the list to the new entity.
         // This does not generate a property change event.
-        property_list
-            .set_values_for_entity(new_entity_id, self.entity_store.get_property_store::<E>());
+        property_list.set_values_for_new_entity(
+            new_entity_id,
+            self.entity_store.get_property_store_mut::<E>(),
+        );
+
+        // Keep all enabled indexes caught up as entities are created.
+        let context_ptr: *const Context = self;
+        let property_store = self.entity_store.get_property_store_mut::<E>();
+        // SAFETY: We create a shared `&Context` for read-only property access while mutably
+        // borrowing the property store to update index internals.
+        unsafe {
+            property_store.index_unindexed_entities_for_all_properties(&*context_ptr);
+        }
 
         // Emit an `EntityCreatedEvent<Entity>`.
         self.emit_event(EntityCreatedEvent::<E>::new(new_entity_id));
@@ -170,24 +181,12 @@ impl ContextEntitiesExt for Context {
     ) {
         debug_assert!(!P::is_derived(), "cannot set a derived property");
 
-        // The algorithm is as follows
-        // 1. Get the previous value of the property.
-        //    1.1 If it's the same as `property_value`, exit.
-        //    1.2 Otherwise, create a `PartialPropertyChangeEvent<E, P>`.
-        // 2. Remove the `entity_id` from the index bucket corresponding to its old value.
-        // 3. For each dependent of the property, do the analog of steps 1 & 2:
-        //    3.1 Compute the previous value of the dependent property `Q`, creating a
-        //        `PartialPropertyChangeEvent<E, Q>` instance if necessary.
-        //    3.2 Remove the `entity_id` from the index bucket corresponding to the old value of `Q`.
-        // 4. Set the new value of the (main) property in the property store.
-        // 5. Update the property index: Insert the `entity_id` into the index bucket corresponding to the new value.
-        // 6. Emit the property change event: convert the `PartialPropertyChangeEvent<E, P>` into a
-        //    `event: PropertyChangeEvent<E, P>` and call `Context::emit_event(event)`.
-        // 7. For each dependent of the property, do the analog of steps 4-6:
-        //    7.1 Compute the new value of the dependent property
-        //    7.2 Add `entity_id` to the index bucket corresponding to the new value.
-        //    7.3 convert the `PartialPropertyChangeEvent<E, Q>` into a
-        //        `event: PropertyChangeEvent<E, Q>` and call `Context::emit_event(event)`.
+        // The algorithm is as follows:
+        // 1. Snapshot previous values for the main property and its dependents by creating
+        //    `PartialPropertyChangeEvent` instances.
+        // 2. Set the new value of the main property in the property store.
+        // 3. Emit each partial event; during emission each event computes the current value,
+        //    updates its index (remove old/add new), and emits a `PropertyChangeEvent`.
 
         // We need two passes over the dependents: one pass to compute all the old values and
         // another to compute all the new values. We group the steps for each dependent (and, it
@@ -211,32 +210,48 @@ impl ContextEntitiesExt for Context {
         // - There may be use cases for listening to "writes" that don't actually change values.
 
         let mut dependents: Vec<Box<dyn PartialPropertyChangeEvent>> = vec![];
-        let property_store = self.entity_store.get_property_store::<E>();
 
-        // Create the partial property change for this value.
-        dependents.push(property_store.create_partial_property_change(P::id(), entity_id, self));
-        // Now create partial property change events for each dependent.
-        for dependent_idx in P::dependents() {
+        // Immutable: Collect the previous value to create partial property change events
+        {
+            let property_store = self.entity_store.get_property_store::<E>();
+
+            // Create the partial property change for this value.
             dependents.push(property_store.create_partial_property_change(
-                *dependent_idx,
+                P::id(),
                 entity_id,
                 self,
             ));
+            // Now create partial property change events for each dependent.
+            for dependent_idx in P::dependents() {
+                dependents.push(property_store.create_partial_property_change(
+                    *dependent_idx,
+                    entity_id,
+                    self,
+                ));
+            }
         }
 
         // Update the value
         let property_value_store = self.get_property_value_store::<E, P>();
         property_value_store.set(entity_id, property_value);
 
-        // After updating the value
+        // Mutable: After updating the value, we update its dependents, removing old values and
+        // storing the new values in their respective indexes, and emit the property change event.
         for dependent in dependents.into_iter() {
             dependent.emit_in_context(self)
         }
     }
 
     fn index_property<E: Entity, P: Property<E>>(&mut self) {
+        let property_id = P::index_id();
+        let context_ptr: *const Context = self;
         let property_store = self.entity_store.get_property_store_mut::<E>();
         property_store.set_property_indexed::<P>(PropertyIndexType::FullIndex);
+        // SAFETY: This only creates a shared reference to `Context` while mutably borrowing
+        // the property store to update index internals.
+        unsafe {
+            property_store.index_unindexed_entities_for_property_id(&*context_ptr, property_id);
+        }
     }
 
     fn index_property_counts<E: Entity, P: Property<E>>(&mut self) {
@@ -265,7 +280,6 @@ impl ContextEntitiesExt for Context {
         if let Some(multi_property_id) = query.multi_property_id() {
             let property_store = self.entity_store.get_property_store::<E>();
             match property_store.get_index_set_with_hash_for_property_id(
-                self,
                 multi_property_id,
                 query.multi_property_value_hash(),
             ) {
@@ -305,7 +319,6 @@ impl ContextEntitiesExt for Context {
         if let Some(multi_property_id) = query.multi_property_id() {
             let property_store = self.entity_store.get_property_store::<E>();
             match property_store.get_index_count_with_hash_for_property_id(
-                self,
                 multi_property_id,
                 query.multi_property_value_hash(),
             ) {
@@ -422,7 +435,7 @@ impl ContextEntitiesExt for Context {
 
 #[cfg(test)]
 mod tests {
-    use std::cell::{Ref, RefCell};
+    use std::cell::RefCell;
     use std::rc::Rc;
 
     use super::*;
@@ -568,7 +581,7 @@ mod tests {
     }
 
     // Helper for index tests
-    #[derive(Copy, Clone)]
+    #[derive(Copy, Clone, Debug)]
     enum IndexMode {
         Unindexed,
         FullIndex,
@@ -608,7 +621,7 @@ mod tests {
             context.with_query_results((existing_value,), &mut |people_set| {
                 existing_len = people_set.into_iter().count();
             });
-            assert_eq!(existing_len, 2);
+            assert_eq!(existing_len, 2, "Wrong length for {mode:?}");
 
             let mut missing_len = 0;
             context.with_query_results((missing_value,), &mut |people_set| {
@@ -926,7 +939,7 @@ mod tests {
 
         let property_store = context.entity_store.get_property_store::<Person>();
         let property_value_store = property_store.get_with_id(index_id);
-        let bucket: Ref<IndexSet<EntityId<Person>>> = property_value_store
+        let bucket: &IndexSet<EntityId<Person>> = property_value_store
             .get_index_set_with_hash(
                 (InfectionStatus::Susceptible, Vaccinated(true)).multi_property_value_hash(),
             )

--- a/src/entity/entity_set/entity_set.rs
+++ b/src/entity/entity_set/entity_set.rs
@@ -312,8 +312,6 @@ impl<'a, E: Entity> IntoIterator for EntitySet<'a, E> {
 
 #[cfg(test)]
 mod tests {
-    use std::cell::RefCell;
-
     use super::*;
     use crate::entity::ContextEntitiesExt;
     use crate::hashing::IndexSet;
@@ -322,17 +320,15 @@ mod tests {
     define_entity!(Person);
     define_property!(struct Age(u8), Person);
 
-    fn finite_set(ids: &[usize]) -> RefCell<IndexSet<EntityId<Person>>> {
-        RefCell::new(
-            ids.iter()
-                .copied()
-                .map(EntityId::<Person>::new)
-                .collect::<IndexSet<_>>(),
-        )
+    fn finite_set(ids: &[usize]) -> IndexSet<EntityId<Person>> {
+        ids.iter()
+            .copied()
+            .map(EntityId::<Person>::new)
+            .collect::<IndexSet<_>>()
     }
 
-    fn as_entity_set(set: &RefCell<IndexSet<EntityId<Person>>>) -> EntitySet<Person> {
-        EntitySet::from_source(SourceSet::IndexSet(set.borrow()))
+    fn as_entity_set(set: &IndexSet<EntityId<Person>>) -> EntitySet<Person> {
+        EntitySet::from_source(SourceSet::IndexSet(set))
     }
 
     #[test]
@@ -470,16 +466,13 @@ mod tests {
         let b = finite_set(&[2, 3, 4]);
 
         let union = as_entity_set(&a).union(as_entity_set(&b));
-        assert_eq!(union.sort_key(), (a.borrow().len() + b.borrow().len(), 3));
+        assert_eq!(union.sort_key(), (a.len() + b.len(), 3));
 
         let intersection = as_entity_set(&a).intersection(as_entity_set(&b));
-        assert_eq!(
-            intersection.sort_key(),
-            (a.borrow().len().min(b.borrow().len()), 6)
-        );
+        assert_eq!(intersection.sort_key(), (a.len().min(b.len()), 6));
 
         let difference = as_entity_set(&a).difference(as_entity_set(&b));
-        assert_eq!(difference.sort_key(), (a.borrow().len(), 6));
+        assert_eq!(difference.sort_key(), (a.len(), 6));
     }
 
     #[test]
@@ -525,12 +518,10 @@ mod tests {
         let population = EntitySet::<Person>::from_source(SourceSet::Population(5));
         assert_eq!(population.try_len(), Some(5));
 
-        let index_data = RefCell::new(
-            [EntityId::new(1), EntityId::new(2), EntityId::new(3)]
-                .into_iter()
-                .collect::<IndexSet<_>>(),
-        );
-        let indexed = EntitySet::<Person>::from_source(SourceSet::IndexSet(index_data.borrow()));
+        let index_data = [EntityId::new(1), EntityId::new(2), EntityId::new(3)]
+            .into_iter()
+            .collect::<IndexSet<_>>();
+        let indexed = EntitySet::<Person>::from_source(SourceSet::IndexSet(&index_data));
         assert_eq!(indexed.try_len(), Some(3));
 
         let mut context = Context::new();

--- a/src/entity/entity_set/entity_set_iterator.rs
+++ b/src/entity/entity_set/entity_set_iterator.rs
@@ -10,8 +10,6 @@
 //!
 //! The iterator is created through `EntitySet::into_iter()`.
 
-use std::cell::Ref;
-
 use log::warn;
 use rand::Rng;
 
@@ -260,7 +258,7 @@ impl<'c, E: Entity> EntitySetIterator<'c, E> {
         }
     }
 
-    pub(crate) fn from_index_set(set: Ref<'c, IndexSet<EntityId<E>>>) -> EntitySetIterator<'c, E> {
+    pub(crate) fn from_index_set(set: &'c IndexSet<EntityId<E>>) -> EntitySetIterator<'c, E> {
         EntitySetIterator {
             inner: EntitySetIteratorInner::Source(SourceSet::IndexSet(set).into_iter()),
         }
@@ -448,8 +446,6 @@ mod tests {
     is indexed with fewer results to ensure it becomes the "smallest source
     set", making the tested property NOT the initial source position.
     */
-
-    use std::cell::RefCell;
 
     use indexmap::IndexSet;
 
@@ -1053,17 +1049,15 @@ mod tests {
         assert_eq!(remaining, 2);
     }
 
-    fn finite_set(ids: &[usize]) -> RefCell<FxIndexSet<EntityId<Person>>> {
-        RefCell::new(
-            ids.iter()
-                .copied()
-                .map(EntityId::new)
-                .collect::<FxIndexSet<_>>(),
-        )
+    fn finite_set(ids: &[usize]) -> FxIndexSet<EntityId<Person>> {
+        ids.iter()
+            .copied()
+            .map(EntityId::new)
+            .collect::<FxIndexSet<_>>()
     }
 
-    fn as_entity_set(set: &RefCell<FxIndexSet<EntityId<Person>>>) -> EntitySet<Person> {
-        EntitySet::from_source(SourceSet::IndexSet(set.borrow()))
+    fn as_entity_set(set: &FxIndexSet<EntityId<Person>>) -> EntitySet<Person> {
+        EntitySet::from_source(SourceSet::IndexSet(set))
     }
 
     #[test]

--- a/src/entity/entity_set/source_iterator.rs
+++ b/src/entity/entity_set/source_iterator.rs
@@ -15,7 +15,6 @@
 //!   (`ConcretePropertySource` and `DerivedPropertySource`), which serve as both
 //!   set-facing wrappers and iterators.
 
-use std::cell::Ref;
 use std::fmt::{Debug, Formatter};
 
 use ouroboros::self_referencing;
@@ -29,14 +28,14 @@ use crate::hashing::{IndexSet, IndexSetIter};
 /// iterator in the `Iterator` implementation on `SourceIterator`.
 #[self_referencing]
 pub(super) struct IndexSetIterator<'a, E: Entity> {
-    index_set: Ref<'a, IndexSet<EntityId<E>>>,
+    index_set: &'a IndexSet<EntityId<E>>,
     #[borrows(index_set)]
     #[covariant]
     iter: IndexSetIter<'this, EntityId<E>>,
 }
 
 impl<'a, E: Entity> IndexSetIterator<'a, E> {
-    pub fn from_index_set(index_set: Ref<'a, IndexSet<EntityId<E>>>) -> Self {
+    pub fn from_index_set(index_set: &'a IndexSet<EntityId<E>>) -> Self {
         IndexSetIteratorBuilder {
             index_set,
             iter_builder: |index_set| index_set.iter(),
@@ -226,8 +225,6 @@ impl<'c, E: Entity> std::iter::FusedIterator for SourceIterator<'c, E> {}
 
 #[cfg(test)]
 mod tests {
-    use std::cell::RefCell;
-
     use super::super::source_set::{ConcretePropertySource, SourceSet};
     use crate::entity::property_value_store_core::RawPropertyValueVec;
     use crate::entity::EntityId;
@@ -247,8 +244,7 @@ mod tests {
             EntityId::new(3),
             EntityId::new(6),
         ]);
-        let people_set = RefCell::new(people_set);
-        let people_set_ref = people_set.borrow();
+        let people_set_ref = &people_set;
 
         let mut iter = SourceSet::IndexSet(people_set_ref).into_iter();
         assert_eq!(iter.next(), Some(EntityId::new(0)));

--- a/src/entity/entity_set/source_set.rs
+++ b/src/entity/entity_set/source_set.rs
@@ -44,7 +44,6 @@
 //! | `ConcretePropertySource`     | `5`         |
 //! | `DerivedPropertySource`      | `6`         |
 
-use std::cell::Ref;
 use std::marker::PhantomData;
 
 use super::source_iterator::{IndexSetIterator, SourceIterator};
@@ -258,7 +257,7 @@ pub(crate) enum SourceSet<'a, E: Entity> {
     Population(usize),
     #[allow(dead_code)]
     Entity(EntityId<E>),
-    IndexSet(Ref<'a, IndexSet<EntityId<E>>>),
+    IndexSet(&'a IndexSet<EntityId<E>>),
     PropertySet(BxPropertySource<'a, E>),
 }
 
@@ -311,7 +310,6 @@ impl<'a, E: Entity> SourceSet<'a, E> {
         // Check for an index.
         {
             match property_store.get_index_set_with_hash_for_property_id(
-                context,
                 P::index_id(),
                 P::hash_property_value(&value.make_canonical()),
             ) {
@@ -379,8 +377,6 @@ impl<'a, E: Entity> SourceSet<'a, E> {
 
 #[cfg(test)]
 mod tests {
-    use std::cell::RefCell;
-
     use super::*;
     use crate::{define_derived_property, define_entity, define_property};
 
@@ -417,12 +413,10 @@ mod tests {
             .collect::<Vec<_>>();
         assert_eq!(singleton_ids, vec![EntityId::new(9)]);
 
-        let ids = RefCell::new(
-            [EntityId::new(1), EntityId::new(4), EntityId::new(8)]
-                .into_iter()
-                .collect::<IndexSet<_>>(),
-        );
-        let ids_ref = ids.borrow();
+        let ids = [EntityId::new(1), EntityId::new(4), EntityId::new(8)]
+            .into_iter()
+            .collect::<IndexSet<_>>();
+        let ids_ref = &ids;
         let indexed = SourceSet::<Person>::IndexSet(ids_ref);
         assert_eq!(indexed.sort_key(), (3, 3));
         assert!(indexed.contains(EntityId::new(4)));

--- a/src/entity/index/mod.rs
+++ b/src/entity/index/mod.rs
@@ -1,7 +1,5 @@
 //! Index types for property-value lookups.
 
-use std::cell::{Ref, RefCell};
-
 use crate::entity::{Entity, EntityId, HashValueType};
 use crate::hashing::IndexSet;
 use crate::prelude::Property;
@@ -19,7 +17,7 @@ pub enum IndexSetResult<'a, E: Entity> {
     /// The set is empty.
     Empty,
     /// A reference to the index set.
-    Set(Ref<'a, IndexSet<EntityId<E>>>),
+    Set(&'a IndexSet<EntityId<E>>),
 }
 
 #[derive(PartialEq, Eq, Debug)]
@@ -39,8 +37,8 @@ pub enum PropertyIndexType {
 
 pub enum PropertyIndex<E: Entity, P: Property<E>> {
     Unindexed,
-    FullIndex(RefCell<FullIndex<E, P>>),
-    ValueCountIndex(RefCell<ValueCountIndex<E, P>>),
+    FullIndex(FullIndex<E, P>),
+    ValueCountIndex(ValueCountIndex<E, P>),
 }
 
 impl<E: Entity, P: Property<E>> PropertyIndex<E, P> {
@@ -52,36 +50,30 @@ impl<E: Entity, P: Property<E>> PropertyIndex<E, P> {
         }
     }
 
-    pub fn add_entity_with_hash(&self, hash: HashValueType, entity_id: EntityId<E>) {
+    pub fn add_entity_with_hash(&mut self, hash: HashValueType, entity_id: EntityId<E>) {
         match self {
             Self::Unindexed => {}
-            Self::FullIndex(index) => index.borrow_mut().add_entity_with_hash(hash, entity_id),
+            Self::FullIndex(index) => index.add_entity_with_hash(hash, entity_id),
             Self::ValueCountIndex(index) => {
-                index.borrow_mut().add_entity_with_hash(hash, entity_id);
+                index.add_entity_with_hash(hash, entity_id);
             }
         }
     }
 
-    pub fn remove_entity_with_hash(&self, hash: HashValueType, entity_id: EntityId<E>) {
+    pub fn remove_entity_with_hash(&mut self, hash: HashValueType, entity_id: EntityId<E>) {
         match self {
             Self::Unindexed => {}
-            Self::FullIndex(index) => index.borrow_mut().remove_entity_with_hash(hash, entity_id),
+            Self::FullIndex(index) => index.remove_entity_with_hash(hash, entity_id),
             Self::ValueCountIndex(index) => {
-                index.borrow_mut().remove_entity_with_hash(hash, entity_id);
+                index.remove_entity_with_hash(hash, entity_id);
             }
         }
     }
 
-    pub fn get_index_set_with_hash(
-        &self,
-        hash: HashValueType,
-    ) -> Option<Ref<IndexSet<EntityId<E>>>> {
+    pub fn get_index_set_with_hash(&self, hash: HashValueType) -> Option<&IndexSet<EntityId<E>>> {
         match self {
             Self::Unindexed => None,
-            Self::FullIndex(index) => {
-                let index = index.borrow();
-                Ref::filter_map(index, |idx| idx.get_with_hash(hash)).ok()
-            }
+            Self::FullIndex(index) => index.get_with_hash(hash),
             Self::ValueCountIndex(_) => None,
         }
     }
@@ -89,13 +81,10 @@ impl<E: Entity, P: Property<E>> PropertyIndex<E, P> {
     pub fn get_index_set_with_hash_result(&self, hash: HashValueType) -> IndexSetResult<'_, E> {
         match self {
             Self::Unindexed => IndexSetResult::<'_, E>::Unsupported,
-            Self::FullIndex(index) => {
-                let index = index.borrow();
-                match Ref::filter_map(index, |idx| idx.get_with_hash(hash)) {
-                    Ok(set) => IndexSetResult::Set(set),
-                    Err(_) => IndexSetResult::Empty,
-                }
-            }
+            Self::FullIndex(index) => match index.get_with_hash(hash) {
+                Some(set) => IndexSetResult::Set(set),
+                None => IndexSetResult::Empty,
+            },
             Self::ValueCountIndex(_) => IndexSetResult::<'_, E>::Unsupported,
         }
     }
@@ -104,33 +93,31 @@ impl<E: Entity, P: Property<E>> PropertyIndex<E, P> {
         match self {
             Self::Unindexed => IndexCountResult::Unsupported,
             Self::FullIndex(index) => {
-                let index = index.borrow();
                 let count = index.get_with_hash(hash).map_or(0, |set| set.len());
                 IndexCountResult::Count(count)
             }
             Self::ValueCountIndex(index) => {
-                let index = index.borrow();
                 IndexCountResult::Count(index.get_with_hash(hash).unwrap_or(0))
             }
         }
     }
 
-    pub fn remove_entity(&self, value: &P::CanonicalValue, entity_id: EntityId<E>) {
+    pub fn remove_entity(&mut self, value: &P::CanonicalValue, entity_id: EntityId<E>) {
         match self {
             Self::Unindexed => {}
-            Self::FullIndex(index) => index.borrow_mut().remove_entity(value, entity_id),
-            Self::ValueCountIndex(index) => index.borrow_mut().remove_entity(value, entity_id),
+            Self::FullIndex(index) => index.remove_entity(value, entity_id),
+            Self::ValueCountIndex(index) => index.remove_entity(value, entity_id),
         }
     }
 
-    pub fn add_entity(&self, value: &P::CanonicalValue, entity_id: EntityId<E>) {
+    pub fn add_entity(&mut self, value: &P::CanonicalValue, entity_id: EntityId<E>) {
         match self {
             Self::Unindexed => {}
             Self::FullIndex(index) => {
-                index.borrow_mut().add_entity(value, entity_id);
+                index.add_entity(value, entity_id);
             }
             Self::ValueCountIndex(index) => {
-                index.borrow_mut().add_entity(value, entity_id);
+                index.add_entity(value, entity_id);
             }
         }
     }
@@ -139,16 +126,16 @@ impl<E: Entity, P: Property<E>> PropertyIndex<E, P> {
     pub fn max_indexed(&self) -> Option<usize> {
         match self {
             Self::Unindexed => None,
-            Self::FullIndex(index) => Some(index.borrow().max_indexed),
-            Self::ValueCountIndex(index) => Some(index.borrow().max_indexed),
+            Self::FullIndex(index) => Some(index.max_indexed),
+            Self::ValueCountIndex(index) => Some(index.max_indexed),
         }
     }
 
-    pub fn set_max_indexed(&self, max_indexed: usize) {
+    pub fn set_max_indexed(&mut self, max_indexed: usize) {
         match self {
             Self::Unindexed => {}
-            Self::FullIndex(index) => index.borrow_mut().max_indexed = max_indexed,
-            Self::ValueCountIndex(index) => index.borrow_mut().max_indexed = max_indexed,
+            Self::FullIndex(index) => index.max_indexed = max_indexed,
+            Self::ValueCountIndex(index) => index.max_indexed = max_indexed,
         }
     }
 }

--- a/src/entity/property_store.rs
+++ b/src/entity/property_store.rs
@@ -352,28 +352,36 @@ impl<E: Entity> PropertyStore<E> {
     }
 
     /// Updates the index of the property having the given ID for any entities that have been added to the context
-    /// since the last time the index was updated. As a convenience, returns `false` if this property is not indexed,
-    /// `true` otherwise.
-    pub fn index_unindexed_entities_for_property_id(&self, context: &Context, property_id: usize) {
+    /// since the last time the index was updated.
+    pub fn index_unindexed_entities_for_property_id(
+        &mut self,
+        context: &Context,
+        property_id: usize,
+    ) {
         self.items[property_id].index_unindexed_entities(context)
+    }
+
+    /// Updates all indexed properties for any entities that have been added since the last update.
+    pub fn index_unindexed_entities_for_all_properties(&mut self, context: &Context) {
+        for store in &mut self.items {
+            store.index_unindexed_entities(context);
+        }
     }
 
     pub fn get_index_set_with_hash_for_property_id(
         &self,
-        context: &Context,
         property_id: usize,
         hash: HashValueType,
     ) -> IndexSetResult<'_, E> {
-        self.items[property_id].get_index_set_with_hash_result(context, hash)
+        self.items[property_id].get_index_set_with_hash_result(hash)
     }
 
     pub fn get_index_count_with_hash_for_property_id(
         &self,
-        context: &Context,
         property_id: usize,
         hash: HashValueType,
     ) -> IndexCountResult {
-        self.items[property_id].get_index_count_with_hash_result(context, hash)
+        self.items[property_id].get_index_count_with_hash_result(hash)
     }
 }
 
@@ -476,34 +484,23 @@ mod tests {
 
         // FullIndex + count
         assert_eq!(
-            property_store.get_index_count_with_hash_for_property_id(
-                &context,
-                Age::index_id(),
-                missing_hash,
-            ),
+            property_store
+                .get_index_count_with_hash_for_property_id(Age::index_id(), missing_hash,),
             IndexCountResult::Count(0)
         );
         assert_eq!(
-            property_store.get_index_count_with_hash_for_property_id(
-                &context,
-                Age::index_id(),
-                existing_hash,
-            ),
+            property_store
+                .get_index_count_with_hash_for_property_id(Age::index_id(), existing_hash,),
             IndexCountResult::Count(2)
         );
 
         // FullIndex + set
         assert!(matches!(
-            property_store.get_index_set_with_hash_for_property_id(
-                &context,
-                Age::index_id(),
-                missing_hash,
-            ),
+            property_store.get_index_set_with_hash_for_property_id(Age::index_id(), missing_hash,),
             IndexSetResult::Empty
         ));
         assert!(matches!(
             property_store.get_index_set_with_hash_for_property_id(
-                &context,
                 Age::index_id(),
                 existing_hash,
             ),
@@ -528,37 +525,23 @@ mod tests {
 
         // ValueCountIndex + count
         assert_eq!(
-            property_store.get_index_count_with_hash_for_property_id(
-                &context,
-                Age::index_id(),
-                missing_hash,
-            ),
+            property_store
+                .get_index_count_with_hash_for_property_id(Age::index_id(), missing_hash,),
             IndexCountResult::Count(0)
         );
         assert_eq!(
-            property_store.get_index_count_with_hash_for_property_id(
-                &context,
-                Age::index_id(),
-                existing_hash,
-            ),
+            property_store
+                .get_index_count_with_hash_for_property_id(Age::index_id(), existing_hash,),
             IndexCountResult::Count(2)
         );
 
         // ValueCountIndex + set (unsupported)
         assert!(matches!(
-            property_store.get_index_set_with_hash_for_property_id(
-                &context,
-                Age::index_id(),
-                missing_hash,
-            ),
+            property_store.get_index_set_with_hash_for_property_id(Age::index_id(), missing_hash,),
             IndexSetResult::Unsupported
         ));
         assert!(matches!(
-            property_store.get_index_set_with_hash_for_property_id(
-                &context,
-                Age::index_id(),
-                existing_hash,
-            ),
+            property_store.get_index_set_with_hash_for_property_id(Age::index_id(), existing_hash,),
             IndexSetResult::Unsupported
         ));
     }
@@ -578,37 +561,23 @@ mod tests {
 
         // Unindexed + count
         assert_eq!(
-            property_store.get_index_count_with_hash_for_property_id(
-                &context,
-                Age::index_id(),
-                missing_hash,
-            ),
+            property_store
+                .get_index_count_with_hash_for_property_id(Age::index_id(), missing_hash,),
             IndexCountResult::Unsupported
         );
         assert_eq!(
-            property_store.get_index_count_with_hash_for_property_id(
-                &context,
-                Age::index_id(),
-                existing_hash,
-            ),
+            property_store
+                .get_index_count_with_hash_for_property_id(Age::index_id(), existing_hash,),
             IndexCountResult::Unsupported
         );
 
         // Unindexed + set
         assert!(matches!(
-            property_store.get_index_set_with_hash_for_property_id(
-                &context,
-                Age::index_id(),
-                missing_hash,
-            ),
+            property_store.get_index_set_with_hash_for_property_id(Age::index_id(), missing_hash,),
             IndexSetResult::Unsupported
         ));
         assert!(matches!(
-            property_store.get_index_set_with_hash_for_property_id(
-                &context,
-                Age::index_id(),
-                existing_hash,
-            ),
+            property_store.get_index_set_with_hash_for_property_id(Age::index_id(), existing_hash,),
             IndexSetResult::Unsupported
         ));
     }

--- a/src/entity/property_value_store.rs
+++ b/src/entity/property_value_store.rs
@@ -11,7 +11,6 @@ Responsibilities:
 */
 
 use std::any::Any;
-use std::cell::{Ref, RefCell};
 
 use log::{error, trace};
 
@@ -21,9 +20,9 @@ use crate::entity::index::{
 };
 use crate::entity::property::Property;
 use crate::entity::property_value_store_core::PropertyValueStoreCore;
-use crate::entity::{ContextEntitiesExt, Entity, EntityId, HashValueType};
+use crate::entity::{Entity, EntityId, HashValueType};
 use crate::hashing::IndexSet;
-use crate::Context;
+use crate::{Context, ContextEntitiesExt};
 
 /// The `PropertyValueStore` trait defines the type-erased interface to the concrete property value storage.
 pub(crate) trait PropertyValueStore<E: Entity>: Any {
@@ -31,9 +30,8 @@ pub(crate) trait PropertyValueStore<E: Entity>: Any {
     fn as_any(&self) -> &dyn Any;
 
     // Methods related to updating a value of a dependency
-    /// Fetch the existing value of the property for the given `entity_id`, remove the `entity_id`
-    /// from the corresponding index bucket, and return a `PartialPropertyChangeEvent` object
-    /// wrapping the previous value and `entity_id` that can be used to emit a property change event.
+    /// Fetches the existing value of the property for the given `entity_id` and returns a
+    /// `PartialPropertyChangeEvent` object wrapping the previous value and `entity_id`.
     fn create_partial_property_change(
         &self,
         // The entity_id has been type-erased but is guaranteed by the caller to be an `EntityId<E>`.
@@ -48,23 +46,15 @@ pub(crate) trait PropertyValueStore<E: Entity>: Any {
 
     /// Fetches the hash bucket corresponding to the provided hash value. Returns `None` if either the
     /// property is not indexed or there is no bucket corresponding to the hash value.
-    fn get_index_set_with_hash(&self, hash: HashValueType) -> Option<Ref<IndexSet<EntityId<E>>>>;
+    fn get_index_set_with_hash(&self, hash: HashValueType) -> Option<&IndexSet<EntityId<E>>>;
 
     /// Fetches the hash bucket corresponding to the provided hash value.
     /// Returns `Unsupported` if there is no index or the index cannot return sets.
-    fn get_index_set_with_hash_result(
-        &self,
-        context: &Context,
-        hash: HashValueType,
-    ) -> IndexSetResult<'_, E>;
+    fn get_index_set_with_hash_result(&self, hash: HashValueType) -> IndexSetResult<'_, E>;
 
     /// Fetches the count corresponding to the provided hash value.
     /// Returns `Unsupported` if there is no index or the index cannot return counts.
-    fn get_index_count_with_hash_result(
-        &self,
-        context: &Context,
-        hash: HashValueType,
-    ) -> IndexCountResult;
+    fn get_index_count_with_hash_result(&self, hash: HashValueType) -> IndexCountResult;
 
     /// Returns the index type used by this `PropertyValueStore` instance.
     fn index_type(&self) -> PropertyIndexType;
@@ -74,7 +64,7 @@ pub(crate) trait PropertyValueStore<E: Entity>: Any {
 
     /// Updates the index for any entities that have been added to the context since the last time the index was
     /// updated.
-    fn index_unindexed_entities(&self, context: &Context);
+    fn index_unindexed_entities(&mut self, context: &Context);
 }
 
 impl<E: Entity, P: Property<E>> PropertyValueStore<E> for PropertyValueStoreCore<E, P> {
@@ -91,17 +81,15 @@ impl<E: Entity, P: Property<E>> PropertyValueStore<E> for PropertyValueStoreCore
         entity_id: EntityId<E>,
         context: &Context,
     ) -> Box<dyn PartialPropertyChangeEvent> {
-        // 1. Compute the existing value of the property for the given `entity_id`
-        // 2. Remove the `entity_id` from the corresponding index bucket (if its indexed)
-        // 3. Return a `PartialPropertyChangeEvent` object wrapping the previous value and `entity_id`.
+        // Compute the existing value of the property for the given `entity_id` and return a
+        // `PartialPropertyChangeEvent` object wrapping the previous value and `entity_id`.
 
         let previous_value = if P::is_derived() {
             P::compute_derived(context, entity_id)
         } else {
             self.get(entity_id)
         };
-        self.index
-            .remove_entity(&previous_value.make_canonical(), entity_id);
+
         Box::new(PartialPropertyChangeEventCore::<E, P>::new(
             entity_id,
             previous_value,
@@ -124,25 +112,15 @@ impl<E: Entity, P: Property<E>> PropertyValueStore<E> for PropertyValueStoreCore
         }
     }
 
-    fn get_index_set_with_hash(&self, hash: HashValueType) -> Option<Ref<IndexSet<EntityId<E>>>> {
+    fn get_index_set_with_hash(&self, hash: HashValueType) -> Option<&IndexSet<EntityId<E>>> {
         self.index.get_index_set_with_hash(hash)
     }
 
-    fn get_index_set_with_hash_result(
-        &self,
-        context: &Context,
-        hash: HashValueType,
-    ) -> IndexSetResult<'_, E> {
-        self.index_unindexed_entities(context);
+    fn get_index_set_with_hash_result(&self, hash: HashValueType) -> IndexSetResult<'_, E> {
         self.index.get_index_set_with_hash_result(hash)
     }
 
-    fn get_index_count_with_hash_result(
-        &self,
-        context: &Context,
-        hash: HashValueType,
-    ) -> IndexCountResult {
-        self.index_unindexed_entities(context);
+    fn get_index_count_with_hash_result(&self, hash: HashValueType) -> IndexCountResult {
         self.index.get_index_count_with_hash_result(hash)
     }
 
@@ -157,21 +135,18 @@ impl<E: Entity, P: Property<E>> PropertyValueStore<E> for PropertyValueStoreCore
             }
             PropertyIndexType::FullIndex => {
                 if self.index.index_type() != PropertyIndexType::FullIndex {
-                    self.index = PropertyIndex::FullIndex(RefCell::new(FullIndex::new()));
+                    self.index = PropertyIndex::FullIndex(FullIndex::new());
                 }
             }
             PropertyIndexType::ValueCountIndex => {
                 if self.index.index_type() != PropertyIndexType::ValueCountIndex {
-                    self.index =
-                        PropertyIndex::ValueCountIndex(
-                            RefCell::new(ValueCountIndex::<E, P>::new()),
-                        );
+                    self.index = PropertyIndex::ValueCountIndex(ValueCountIndex::<E, P>::new());
                 }
             }
         }
     }
 
-    fn index_unindexed_entities(&self, context: &Context) {
+    fn index_unindexed_entities(&mut self, context: &Context) {
         let current_pop = context.get_entity_count::<E>();
         let max_indexed = match self.index.max_indexed() {
             None => return,
@@ -187,7 +162,11 @@ impl<E: Entity, P: Property<E>> PropertyValueStore<E> for PropertyValueStoreCore
 
         for id in max_indexed..current_pop {
             let entity_id = EntityId::new(id);
-            let value = context.get_property::<E, P>(entity_id);
+            let value = if P::is_derived() {
+                P::compute_derived(context, entity_id)
+            } else {
+                self.get(entity_id)
+            };
             self.index.add_entity(&P::make_canonical(value), entity_id);
         }
         self.index.set_max_indexed(current_pop);

--- a/src/entity/query/mod.rs
+++ b/src/entity/query/mod.rs
@@ -114,8 +114,15 @@ impl<E: Entity, T: PropertyList<E>> PropertyList<E> for EntityPropertyTuple<E, T
         T::contains_properties(property_type_ids)
     }
 
-    fn set_values_for_entity(&self, entity_id: EntityId<E>, property_store: &PropertyStore<E>) {
-        self.inner.set_values_for_entity(entity_id, property_store)
+    fn set_values_for_new_entity(
+        &self,
+        entity_id: EntityId<E>,
+        property_store: &mut PropertyStore<E>,
+    ) {
+        let tuple = *self;
+        tuple
+            .into_inner()
+            .set_values_for_new_entity(entity_id, property_store)
     }
 }
 

--- a/src/entity/query/query_impls.rs
+++ b/src/entity/query/query_impls.rs
@@ -114,7 +114,6 @@ impl<E: Entity, P1: Property<E>> Query<E> for (P1,) {
         // rather than wrapping a `DerivedPropertySource`.
         if let Some(multi_property_id) = self.multi_property_id() {
             match property_store.get_index_set_with_hash_for_property_id(
-                context,
                 multi_property_id,
                 self.multi_property_value_hash(),
             ) {
@@ -149,7 +148,6 @@ impl<E: Entity, P1: Property<E>> Query<E> for (P1,) {
 
         if let Some(multi_property_id) = self.multi_property_id() {
             match property_store.get_index_set_with_hash_for_property_id(
-                context,
                 multi_property_id,
                 self.multi_property_value_hash(),
             ) {
@@ -258,7 +256,6 @@ macro_rules! impl_query {
                     if let Some(multi_property_id) = self.multi_property_id() {
                         let property_store = context.entity_store.get_property_store::<E>();
                         match property_store.get_index_set_with_hash_for_property_id(
-                            context,
                             multi_property_id,
                             self.multi_property_value_hash(),
                         ) {
@@ -294,7 +291,6 @@ macro_rules! impl_query {
                     if let Some(multi_property_id) = self.multi_property_id() {
                         let property_store = context.entity_store.get_property_store::<E>();
                         match property_store.get_index_set_with_hash_for_property_id(
-                            context,
                             multi_property_id,
                             self.multi_property_value_hash(),
                         ) {
@@ -338,7 +334,6 @@ macro_rules! impl_query {
                     if let Some(multi_property_id) = self.multi_property_id() {
                         let property_store = context.entity_store.get_property_store::<E>();
                         match property_store.get_index_set_with_hash_for_property_id(
-                            context,
                             multi_property_id,
                             self.multi_property_value_hash(),
                         ) {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -87,11 +87,15 @@ pub mod hashing;
 pub mod numeric;
 
 // Re-export for macros
+pub use bincode;
+pub use csv;
+pub use ctor;
 pub use ixa_derive::{
     impl_make_canonical, impl_people_make_canonical, reorder_closure, sorted_tag,
     sorted_value_type, unreorder_closure,
 };
-pub use {bincode, csv, ctor, paste, rand};
+pub use paste;
+pub use rand;
 
 // Deterministic hashing data structures
 pub use crate::hashing::{HashMap, HashMapExt, HashSet, HashSetExt};


### PR DESCRIPTION
This branch reworks entity-property indexing by removing interior mutability from index storage and switching from lazy (query-time) to eager (write-time) index maintenance.

## The advantages

### Performance

It turns out that lazy indexing wasn't the performance advantage we thought it was. In fact, this refactor shows a consistent but very small performance improvement by indexing eagerly. This alone is probably not good enough justification for the change. I am posting my local benchmark results separately.

### Simpler code

Removing `RefCell` from `PropertyIndex` makes indexing explicit: reads take shared references, writes take mutable references, and the compiler enforces the distinction — no more runtime borrow guards or interior-mutable control flow. For example, there is less API noise from lazy-era plumbing: we can remove now-unused `context` passthrough parameters. Index maintenance is also consolidated: old/new value updates now happen in one place rather than being split across partial-event creation and emission. The result is code that's simpler to follow, review, and maintain.

### `EntitySet` and `EntitySetIterator` can be `Clone`

In the current (lazy/`RefCell`) implementation of `EntitySet` and `EntitySetIterator` , the two types cannot implement `Clone`, because some source set types wrap a `Ref` holding a reference to an index set, which cannot be `Clone`. (See #786.) Removing indexes from `RefCell` allow these types to hold a `&IndexSet` instead, which is trivially `Copy`.

## The Price: Unfortunate use of `unsafe`

The cost of removing `RefCell` is the introduction of two uses of `unsafe`:

1. `ContextEntitiesExt::add_entity`
2. `ContextEntitiesExt::index_property`

In both cases, `unsafe` is used to call `property_store.index_unindexed_entities_for_all_properties(&*context_ptr)`. The problem boils down to the fact that we want to mutate the index in the property value store while also supplying an immutable reference to `context` so that we can compute derived properties with `P::compute_derived(context, entity_id)`.  Rust actually allows a version of this, "partial borrows," for the simple case of a multi-field struct:

```rust
struct Player {
    health: i32,
    name: String,
    scores: Vec<i32>,
}

fn main() {
    let mut p = Player {
      health: 100,
      name: "Alice".to_string(),
      scores: vec![10, 20]
  };

    let name = &p.name;          // immutable borrow of `name`
    let scores = &mut p.scores;  // mutable borrow of `scores` — OK!
    scores.push(30);
    println!("{}", name);        // still valid
}
```

This doesn't work across method boundaries: methods borrow the entire struct, even though in our case we are mutating a different part of `context` than what is being read.

## Implementation

`FullIndex` and `ValueCountIndex` are removed from `RefCell` in `PropertyIndex`, so index mutation now requires `&mut self` and index access returns plain references instead of `Ref` guards. This eliminates runtime borrow checks and simplifies reference types through query iteration.

Index consistency is now maintained at write time rather than via lazy catch-up during queries. Entity creation writes initial values and immediately syncs all enabled indexes for that type. Property updates use a two-phase flow: snapshot previous values, write the new value, then update indexes (remove old / add new) during partial-event emission.

Cleanup:

- stale comments/docs, including the `set_property` algorithm notes
- dropped unused `context: &Context` parameters from index set/count lookup helpers and updated all call sites
- maintenance of indexes upon property change is now done in a single clean step (remove old, insert new) instead of spread out across `property_store.create_partial_property_change` and `partial_property_change.emit_in_context`
- updated description of indexing in the Ixa Book

