### PR TITLE
fix: global property validation now returns type erased boxed error

### DIFF
--- a/docs/book/src/migration_guide.md
+++ b/docs/book/src/migration_guide.md
@@ -96,6 +96,13 @@ and API docs for the macros `define_property!`, `impl_property!`,
 | **Using Existing Types**    | A single _value_ type can be used in multiple properties—including primitive types like `u8`                                   | Only one property per type (per `Entity`); primitive types must be wrapped in a newtype.                             | Both systems require that the existing type implement the required property traits. |
 | **Macro Behavior**          | Macros define the property’s ZST and connect it to the value type via trait impls.                                             | Macros define "is a property of entity `E`" relationship via trait impl. No additional synthesized types.            | Both enforce correctness via macro                                                  |
 
+## Global property validator errors
+
+Global-property validators are client code, so they should return
+`Result<(), Box<dyn std::error::Error + 'static>>` instead of constructing
+`IxaError` values directly. Ixa wraps any returned validator error in
+`IxaError::IllegalGlobalPropertyValue` when a global property is set or loaded.
+
 ## New Entities API: How Do I...?
 
 We will use `Person` as an example entity, but there is nothing special about

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,4 +1,5 @@
 //! Provides [`IxaError`] and wraps other errors.
+use std::error::Error;
 use std::io;
 
 use thiserror::Error;
@@ -28,8 +29,11 @@ pub enum IxaError {
     #[error("property {name} is not set")]
     PropertyNotSet { name: String },
 
-    #[error("illegal value for `{field}`: {value}")]
-    IllegalGlobalPropertyValue { field: String, value: String },
+    #[error("illegal value for global property `{name}`: {source}")]
+    IllegalGlobalPropertyValue {
+        name: String,
+        source: Box<dyn Error + 'static>,
+    },
 
     #[error(
         "the same property appears in both position {first_index} and {second_index} in the property list"

--- a/src/global_properties.rs
+++ b/src/global_properties.rs
@@ -18,6 +18,7 @@
 use std::any::{Any, TypeId};
 use std::cell::RefCell;
 use std::collections::hash_map::Entry;
+use std::error::Error;
 use std::fmt::Debug;
 use std::fs;
 use std::io::BufReader;
@@ -66,7 +67,12 @@ where
                 setter: Box::new(
                     |context: &mut Context, name, value| -> Result<(), IxaError> {
                         let val: T::Value = serde_json::from_value(value)?;
-                        T::validate(&val)?;
+                        T::validate(&val).map_err(|source| {
+                            IxaError::IllegalGlobalPropertyValue {
+                                name: T::name().to_string(),
+                                source,
+                            }
+                        })?;
                         if context.get_global_property_value(T::new()).is_some() {
                             return Err(IxaError::DuplicateProperty {
                                 name: name.to_string(),
@@ -96,14 +102,27 @@ fn get_global_property_accessor(name: &str) -> Option<Arc<PropertyAccessors>> {
 
 /// The trait representing a global property. Do not use this
 /// directly, but instead define global properties with
-/// [`define_global_property!`](crate::define_global_property!)
+/// [`define_global_property!`](crate::define_global_property!).
+///
+/// Validation errors are produced by client code and should be returned as
+/// `Box<dyn std::error::Error + 'static>`. Ixa wraps those values in
+/// [`IxaError::IllegalGlobalPropertyValue`]
+/// when a global property is set or loaded.
 pub trait GlobalProperty: Any {
-    type Value: Any; // The actual type of the data.
+    /// The actual type of the data stored in the global property
+    type Value: Any;
 
     fn new() -> Self;
-    #[allow(clippy::missing_errors_doc)]
-    // A function which validates the global property.
-    fn validate(value: &Self::Value) -> Result<(), IxaError>;
+
+    fn name() -> &'static str {
+        let full = std::any::type_name::<Self>();
+        full.rsplit("::").next().unwrap()
+    }
+
+    /// A function which validates the global property.
+    ///
+    /// Client code should box any produced error itself.
+    fn validate(value: &Self::Value) -> Result<(), Box<dyn Error + 'static>>;
 }
 
 struct GlobalPropertiesDataContainer {
@@ -157,7 +176,10 @@ pub trait ContextGlobalPropertiesExt: ContextBase {
         property: T,
         value: T::Value,
     ) -> Result<(), IxaError> {
-        T::validate(&value)?;
+        T::validate(&value).map_err(|source| IxaError::IllegalGlobalPropertyValue {
+            name: T::name().to_string(),
+            source,
+        })?;
         let data_container = self.get_data_mut(GlobalPropertiesPlugin);
         data_container.set_global_property_value(&property, value)
     }
@@ -257,6 +279,8 @@ impl ContextGlobalPropertiesExt for Context {
 
 #[cfg(test)]
 mod test {
+    use std::error::Error;
+    use std::fmt;
     use std::path::PathBuf;
 
     use serde::{Deserialize, Serialize};
@@ -266,6 +290,19 @@ mod test {
     use crate::context::Context;
     use crate::define_global_property;
     use crate::error::IxaError;
+
+    #[derive(Debug)]
+    struct InvalidProperty3Value {
+        field_int: u32,
+    }
+
+    impl fmt::Display for InvalidProperty3Value {
+        fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+            write!(f, "field_int must be zero, got {}", self.field_int)
+        }
+    }
+
+    impl Error for InvalidProperty3Value {}
 
     #[derive(Serialize, Deserialize, Debug, Clone)]
     pub struct ParamType {
@@ -423,10 +460,9 @@ mod test {
     define_global_property!(Property3, Property3Type, |v: &Property3Type| {
         match v.field_int {
             0 => Ok(()),
-            _ => Err(IxaError::IllegalGlobalPropertyValue {
-                field: "field_int".to_string(),
-                value: v.field_int.to_string(),
-            }),
+            _ => Err(Box::new(InvalidProperty3Value {
+                field_int: v.field_int,
+            }) as Box<dyn Error + 'static>),
         }
     });
 
@@ -441,10 +477,20 @@ mod test {
     #[test]
     fn validate_property_set_failure() {
         let mut context = Context::new();
-        assert!(matches!(
-            context.set_global_property_value(Property3, Property3Type { field_int: 1 }),
-            Err(IxaError::IllegalGlobalPropertyValue { .. })
-        ));
+        let error = context
+            .set_global_property_value(Property3, Property3Type { field_int: 1 })
+            .unwrap_err();
+        assert_eq!(
+            error.to_string(),
+            "illegal value for global property `Property3`: field_int must be zero, got 1"
+        );
+        match error {
+            IxaError::IllegalGlobalPropertyValue { name, source } => {
+                assert_eq!(name, "Property3");
+                assert_eq!(source.to_string(), "field_int must be zero, got 1");
+            }
+            _ => panic!("Unexpected error type"),
+        }
     }
 
     #[test]
@@ -460,10 +506,18 @@ mod test {
         let mut context = Context::new();
         let path = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
             .join("tests/data/global_properties_invalid.json");
-        assert!(matches!(
-            context.load_global_properties(&path),
-            Err(IxaError::IllegalGlobalPropertyValue { .. })
-        ));
+        let error = context.load_global_properties(&path).unwrap_err();
+        assert_eq!(
+            error.to_string(),
+            "illegal value for global property `Property3`: field_int must be zero, got 42"
+        );
+        match error {
+            IxaError::IllegalGlobalPropertyValue { name, source } => {
+                assert_eq!(name, "Property3");
+                assert_eq!(source.to_string(), "field_int must be zero, got 42");
+            }
+            _ => panic!("Unexpected error type"),
+        }
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -87,11 +87,15 @@ pub mod hashing;
 pub mod numeric;
 
 // Re-export for macros
+pub use bincode;
+pub use csv;
+pub use ctor;
 pub use ixa_derive::{
     impl_make_canonical, impl_people_make_canonical, reorder_closure, sorted_tag,
     sorted_value_type, unreorder_closure,
 };
-pub use {bincode, csv, ctor, paste, rand};
+pub use paste;
+pub use rand;
 
 // Deterministic hashing data structures
 pub use crate::hashing::{HashMap, HashMapExt, HashSet, HashSetExt};

--- a/src/macros/define_global_property.rs
+++ b/src/macros/define_global_property.rs
@@ -1,7 +1,13 @@
 /// Defines a global property with the following parameters:
 /// * `$global_property`: Name for the identifier type of the global property
 /// * `$value`: The type of the property's value
-/// * `$validate`: A function (or closure) that checks the validity of the property (optional)
+/// * `$validate`: A function (or closure) that checks the validity of the property and returns
+///   `Result<(), Box<dyn std::error::Error + 'static>>` (optional)
+///
+/// Validator code is client code, so it should create and box its own error values.
+/// Ixa wraps any returned error in
+/// [`IxaError::IllegalGlobalPropertyValue`](crate::error::IxaError::IllegalGlobalPropertyValue)
+/// when the property is set or loaded.
 #[macro_export]
 macro_rules! define_global_property {
     ($global_property:ident, $value:ty, $validate: expr) => {
@@ -15,7 +21,12 @@ macro_rules! define_global_property {
                 $global_property
             }
 
-            fn validate(val: &$value) -> Result<(), $crate::error::IxaError> {
+            fn name() -> &'static str {
+                let full = std::any::type_name::<Self>();
+                full.rsplit("::").next().unwrap()
+            }
+
+            fn validate(val: &$value) -> Result<(), Box<dyn std::error::Error + 'static>> {
                 $validate(val)
             }
         }


### PR DESCRIPTION
In Ixa v2.0, we changed the paradigm for errors so that `IxaError` is an error type only generated from Ixa itself, meaning model client code is meant to be a consumer but not a producer of `IxaError` values. Client code is expected to either make their own error type (`thiserror`) or use a generic error type library (`anyhow`) if they need to generate their own errors.

It looks like we missed a particular case in Global Properties:

```rust
pub trait GlobalProperty: Any {
    type Value: Any; // The actual type of the data.

    fn new() -> Self;

    // A function which validates the global property.
    fn validate(value: &Self::Value) -> Result<(), IxaError>;
}
```

The validate function (usually provided by client code as a closure) is expected to generate an `IxaError`.

The fix is to have `GlobalProperty::validate` return a `Box<dyn Error>`. This error value is then wrapped in `IxaError::IllegalGlobalPropertyValue` in ixa code like `GlobalPropertiesDataContainer::set_global_property_value` that consumes and bubbles up these errors. This PR modifies that variant to hold the `Box<dyn Error>` value and the name of the property as a `String`.

The original implementation of this variant was:

```rust
#[error("illegal value for `{field}`: {value}")]
IllegalGlobalPropertyValue { field: String, value: String },
```

But it's use wasn't entirely consistent across the codebase. Not every usage site was capable of setting the fields of this variant. In our implementation we leave it up to client code to decide what is stored in the `Box<dyn Error>` it generates.