### PR TITLE
feat: Optimize `set_property` if dependent does not need partial change-event processing

### DIFF
--- a/ixa-bench/criterion/set_property.rs
+++ b/ixa-bench/criterion/set_property.rs
@@ -1,12 +1,19 @@
+use std::cell::RefCell;
 use std::hint::black_box;
 
-use criterion::{criterion_group, criterion_main, Criterion};
+use criterion::{criterion_group, criterion_main, BatchSize, Criterion};
 use ixa::prelude::*;
+use ixa::{impl_derived_property, impl_property};
 
 define_entity!(Person);
 
 define_property!(struct IndependentValue(u64), Person, default_const = IndependentValue(0));
 define_property!(struct BaseValue(u64), Person, default_const = BaseValue(0));
+
+#[derive(Debug, PartialEq, Eq, Clone, Copy, serde::Serialize, Hash)]
+struct MixedBaseValue(u64);
+
+impl_property!(MixedBaseValue, Person, default_const = MixedBaseValue(0));
 
 define_derived_property!(
     struct DerivedLowBit(bool),
@@ -41,6 +48,36 @@ define_derived_property!(
     }
 );
 
+define_derived_property!(
+    struct MixedDerivedIndexed(bool),
+    Person,
+    [MixedBaseValue],
+    [],
+    |base| {
+        let base: MixedBaseValue = base;
+        MixedDerivedIndexed(base.0 & 1 == 0)
+    }
+);
+
+#[derive(Debug, PartialEq, Eq, Clone, Copy, serde::Serialize, Hash)]
+struct MixedDerivedCounted(u8);
+
+impl_derived_property!(MixedDerivedCounted, Person, [MixedBaseValue], [], |base| {
+    let base: MixedBaseValue = base;
+    MixedDerivedCounted((base.0 % 4) as u8)
+});
+
+define_derived_property!(
+    struct MixedDerivedHandled(bool),
+    Person,
+    [MixedBaseValue],
+    [],
+    |base| {
+        let base: MixedBaseValue = base;
+        MixedDerivedHandled(base.0.trailing_zeros() == 0)
+    }
+);
+
 pub fn criterion_benchmark(c: &mut Criterion) {
     let mut group = c.benchmark_group("set_property");
 
@@ -64,6 +101,43 @@ pub fn criterion_benchmark(c: &mut Criterion) {
             next_value = next_value.wrapping_add(1);
             context.set_property(black_box(person), BaseValue(black_box(next_value)));
         });
+    });
+
+    group.bench_function("set_property_three_dependents_mixed", |bencher| {
+        let mut context = Context::new();
+        let person = context
+            .add_entity((MixedBaseValue(0), IndependentValue(0)))
+            .unwrap();
+
+        context.index_property::<Person, MixedDerivedIndexed>();
+        context
+            .track_periodic_value_change_counts::<Person, (MixedBaseValue, ), MixedDerivedCounted, _>(
+                1.0,
+                |_context, _counter| {},
+            );
+        context.subscribe_to_event(
+            |_context, _event: PropertyChangeEvent<Person, MixedDerivedHandled>| {},
+        );
+
+        // Set a value to trigger lazy initialization of the derived properties.
+        context.set_property(person, MixedBaseValue(42));
+        context.execute();
+        let context = RefCell::new(context);
+
+        // Reuse one Context so lazy initialization is amortized, but flush callbacks between
+        // measured chunks to avoid pathological callback queue growth.
+        bencher.iter_batched(
+            || {
+                context.borrow_mut().execute();
+            },
+            |_| {
+                let mut context = context.borrow_mut();
+                for value in 0..256 {
+                    context.set_property(black_box(person), MixedBaseValue(black_box(value)));
+                }
+            },
+            BatchSize::SmallInput,
+        );
     });
 
     group.finish();

--- a/src/context.rs
+++ b/src/context.rs
@@ -147,6 +147,10 @@ impl Context {
         E::on_subscribe(self);
     }
 
+    pub(crate) fn has_event_handlers<E: IxaEvent + 'static>(&self) -> bool {
+        self.event_handlers.contains_key(&TypeId::of::<E>())
+    }
+
     /// Emit an event of type E to be handled by registered receivers
     ///
     /// Receivers will handle events in the order that they have subscribed and

--- a/src/entity/context_extension.rs
+++ b/src/entity/context_extension.rs
@@ -288,8 +288,8 @@ impl ContextEntitiesExt for Context {
         debug_assert!(!P::is_derived(), "cannot set a derived property");
 
         // The algorithm is as follows:
-        // 1. Snapshot previous values for the main property and its dependents by creating
-        //    `PartialPropertyChangeEvent` instances.
+        // 1. Snapshot previous values for the main property and any dependents that need change
+        //    processing by creating `PartialPropertyChangeEvent` instances.
         // 2. Set the new value of the main property in the property store.
         // 3. Emit each partial event; during emission each event computes the current value,
         //    updates its index (remove old/add new), and emits a `PropertyChangeEvent`.
@@ -326,18 +326,22 @@ impl ContextEntitiesExt for Context {
             let property_store = self.entity_store.get_property_store::<E>();
 
             // Create the partial property change for this value.
-            dependents.push(property_store.create_partial_property_change(
-                P::id(),
-                entity_id,
-                self,
-            ));
-            // Now create partial property change events for each dependent.
-            for dependent_idx in P::dependents() {
+            if property_store.should_create_partial_property_change(P::id(), self) {
                 dependents.push(property_store.create_partial_property_change(
-                    *dependent_idx,
+                    P::id(),
                     entity_id,
                     self,
                 ));
+            }
+            // Now create partial property change events for each dependent.
+            for dependent_idx in P::dependents() {
+                if property_store.should_create_partial_property_change(*dependent_idx, self) {
+                    dependents.push(property_store.create_partial_property_change(
+                        *dependent_idx,
+                        entity_id,
+                        self,
+                    ));
+                }
             }
         }
 

--- a/src/entity/property_store.rs
+++ b/src/entity/property_store.rs
@@ -328,6 +328,19 @@ impl<E: Entity> PropertyStore<E> {
         property_value_store.create_partial_property_change(entity_id, context)
     }
 
+    /// Returns whether the property with `property_index` needs partial change-event processing.
+    pub(crate) fn should_create_partial_property_change(
+        &self,
+        property_index: usize,
+        context: &Context,
+    ) -> bool {
+        let property_value_store = self.items
+                                       .get(property_index)
+            .unwrap_or_else(|| panic!("No registered property found with index = {property_index:?}. You must use the `define_property!` macro to create a registered property."));
+
+        property_value_store.should_create_partial_change(context)
+    }
+
     /// Returns whether or not the property `P` is indexed.
     ///
     /// This method can return `true` even if `context.index_property::<P>()` has never been called. For example,

--- a/src/entity/property_value_store.rs
+++ b/src/entity/property_value_store.rs
@@ -16,6 +16,7 @@ use log::{error, trace};
 
 use crate::entity::events::{
     PartialPropertyChangeEvent, PartialPropertyChangeEventBox, PartialPropertyChangeEventCore,
+    PropertyChangeEvent,
 };
 use crate::entity::index::{
     FullIndex, IndexCountResult, IndexSetResult, PropertyIndex, PropertyIndexType, ValueCountIndex,
@@ -40,6 +41,11 @@ pub(crate) trait PropertyValueStore<E: Entity>: Any {
         entity_id: EntityId<E>,
         context: &Context,
     ) -> PartialPropertyChangeEventBox;
+
+    /// Returns whether a property write needs the partial change-event machinery.
+    ///
+    /// This is true if the property has change-event subscribers, value change counters, or an index.
+    fn should_create_partial_change(&self, context: &Context) -> bool;
 
     // Index-related methods. Anything beyond these requires the `PropertyValueStoreCore<E, P>`.
 
@@ -96,6 +102,12 @@ impl<E: Entity, P: Property<E>> PropertyValueStore<E> for PropertyValueStoreCore
             entity_id,
             previous_value,
         ))
+    }
+
+    fn should_create_partial_change(&self, context: &Context) -> bool {
+        context.has_event_handlers::<PropertyChangeEvent<E, P>>()
+            || !self.value_change_counters.is_empty()
+            || self.index.index_type() != PropertyIndexType::Unindexed
     }
 
     fn add_entity_to_index_with_hash(&mut self, hash: HashValueType, entity_id: EntityId<E>) {


### PR DESCRIPTION
This PR makes `set_property` faster when property-change machinery is not actually needed.

Previously, `set_property` always created `PartialPropertyChangeEvent`s for the property being written and for every derived dependent. These hold the previous value of their respective properties so that property change events can be emitted and indexes and value change counters updated. This PR adds a cheap per-property check and does not create partial change events for properties that have no `PropertyChangeEvent` subscribers, no value-change counters, and no indexes to maintain.

To support that, the change adds:

- a way for `Context` to check whether a given event type has any registered handlers;
- a type-erased property-store hook that answers whether a property needs change processing because it has subscribers, counters, or an index;
- a `set_property` fast path that skips partial-event creation for unaffected properties.

The benchmarks were also expanded with a steady-state mixed benchmark that keeps one `Context` alive, flushes callbacks between measured chunks, and exercises the three relevant cases at once: indexed dependent, counted dependent, and handler-backed dependent. That gives us a way to measure both the new best case and the pessimistic path without distorting results with unbounded callback queue growth.

# Local Benchmarks

Local Criterion benchmarks in the `ixa` repo:

```
set_property/set_property_no_dependents
                        time:   [19.035 ns 19.063 ns 19.096 ns]
                        change: [−42.210% −40.648% −39.368%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 3 outliers among 100 measurements (3.00%)
  2 (2.00%) high mild
  1 (1.00%) high severe
set_property/set_property_three_dependents
                        time:   [20.509 ns 20.522 ns 20.536 ns]
                        change: [−75.287% −74.613% −74.072%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 10 outliers among 100 measurements (10.00%)
  1 (1.00%) low mild
  3 (3.00%) high mild
  6 (6.00%) high severe
set_property/set_property_three_dependents_mixed
                        time:   [45.268 µs 45.355 µs 45.436 µs]
                        change: [−5.4784% −5.0960% −4.7522%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 3 outliers among 100 measurements (3.00%)
  1 (1.00%) low mild
  1 (1.00%) high mild
  1 (1.00%) high severe
```

The improvement in the last case is spurious: that's the "control" in which we actually can't avoid doing the work. The fact that it isn't a regression, though, is good, because that says that the extra checking this optimization requires is negligible.

The result of a few runs of `ixa-epi-covid`'s comparison benchmarks (`make bench-compare`) on my local machine:

| **Benchmark**           | **Base (mean)** | **Current (mean)** | **Change**    | **Base Var** | **Base Std Dev** | **Current Var** | **Current Std Dev** |
| ----------------------- | --------------- | ------------------ | ------------- | ------------ | ---------------- | --------------- | ------------------- |
| init/population/10k     | 10.093 ms       | 8.1505 ms          | -19.2% faster | 0.04953 ms²  | 0.2226 ms        | 0.01145 ms²     | 0.1070 ms           |
| init/population/100k    | 107.85 ms       | 89.923 ms          | -16.6% faster | 3.6279 ms²   | 1.9047 ms        | 2.1749 ms²      | 1.4748 ms           |
| execute/population/10k  | 80.725 ms       | 82.416 ms          | +2.1% slower  | 1.0578 ms²   | 1.0285 ms        | 1.4813 ms²      | 1.2171 ms           |
| execute/population/100k | 1.2950 s        | 1.2058 s           | -6.9% faster  | 0.00155 s²   | 0.0394 s         | 0.00526 s²      | 0.0725 s            |