### PR TITLE
fix: reject type aliases in define_multi_property! (#843)

### DIFF
--- a/src/entity/property.rs
+++ b/src/entity/property.rs
@@ -39,15 +39,36 @@ pub enum PropertyInitializationKind {
 pub trait AnyProperty: Copy + Debug + PartialEq + Serialize + 'static {}
 impl<T> AnyProperty for T where T: Copy + Debug + PartialEq + Serialize + 'static {}
 
+/// `const fn` string equality — `==` on `&str` isn't `const` on stable.
+#[must_use]
+pub const fn const_str_eq(a: &str, b: &str) -> bool {
+    if a.len() != b.len() {
+        return false;
+    }
+    let a = a.as_bytes();
+    let b = b.as_bytes();
+    let mut i = 0;
+    while i < a.len() {
+        if a[i] != b[i] {
+            return false;
+        }
+        i += 1;
+    }
+    true
+}
+
 /// All properties must implement this trait using one of the `define_property` macros.
 pub trait Property<E: Entity>: AnyProperty {
     /// Some properties might store a transformed version of the value in the index. This is the
     /// type of the transformed value. For simple properties this will be the same as `Self`.
     type CanonicalValue: AnyProperty;
 
+    /// Source-level name, set by the macros to `stringify!($property)`. Used by
+    /// `define_multi_property!` to reject type aliases (see issue #843).
+    const NAME: &'static str;
+
     fn name() -> &'static str {
-        let full = std::any::type_name::<Self>();
-        full.rsplit("::").next().unwrap()
+        Self::NAME
     }
 
     /// The kind of initialization this property has.

--- a/src/macros/property_impl.rs
+++ b/src/macros/property_impl.rs
@@ -450,6 +450,8 @@ macro_rules! impl_property {
         impl $crate::entity::property::Property<$entity> for $property {
             type CanonicalValue = $canonical_value;
 
+            const NAME: &'static str = stringify!($property);
+
             fn initialization_kind() -> $crate::entity::property::PropertyInitializationKind {
                 $initialization_kind
             }
@@ -726,6 +728,17 @@ macro_rules! impl_derived_property {
 /// reordering of the component properties. The querying subsystem is able to detect when its multiple
 /// component properties are equivalent to an indexed multi-property and use that index to perform the
 /// query.
+///
+/// Components must be the underlying property type, not a type alias (see issue #843):
+///
+/// ```compile_fail
+/// use ixa::{define_entity, define_property, define_multi_property};
+/// define_entity!(Person);
+/// define_property!(struct Age(u8), Person, default_const = Age(0));
+/// define_property!(struct Height(u8), Person, default_const = Height(0));
+/// type Years = Age;
+/// define_multi_property!((Years, Height), Person);
+/// ```
 #[macro_export]
 macro_rules! define_multi_property {
         (
@@ -734,6 +747,21 @@ macro_rules! define_multi_property {
         ) => {
             $crate::paste::paste! {
                 type [<$($dependency)*>] = ( $($dependency),+ );
+
+                // Reject type aliases; see issue #843.
+                $(
+                    const _: () = assert!(
+                        $crate::entity::property::const_str_eq(
+                            stringify!($dependency),
+                            <$dependency as $crate::entity::property::Property<$entity>>::NAME,
+                        ),
+                        concat!(
+                            "define_multi_property!: `",
+                            stringify!($dependency),
+                            "` is a type alias; use the underlying property type (see issue #843)."
+                        ),
+                    );
+                )+
 
                 $crate::impl_property!(
                     [<$($dependency)*>],


### PR DESCRIPTION
This isn't a great solution but would give a better error message. Incidentally, it also saves some work on every call to name() so there are some benchmark improvements. Thoughts?