### PR TITLE
feat: `SourceSet::PopulationRange` subsumes `Empty`, `Entity`, and `WholePopulation` variants

### DIFF
--- a/src/entity/context_extension.rs
+++ b/src/entity/context_extension.rs
@@ -451,8 +451,8 @@ impl ContextEntitiesExt for Context {
         // Special case the empty query, which creates a set containing the entire population.
         if query.type_id() == TypeId::of::<()>() {
             warn!("Called Context::with_query_results() with an empty query. Prefer Context::get_entity_iterator::<E>() for working with the entire population.");
-            callback(EntitySet::from_source(SourceSet::Population(
-                self.get_entity_count::<E>(),
+            callback(EntitySet::from_source(SourceSet::PopulationRange(
+                0..self.get_entity_count::<E>(),
             )));
             return;
         }

--- a/src/entity/entity_set/entity_set.rs
+++ b/src/entity/entity_set/entity_set.rs
@@ -5,11 +5,12 @@
 //! is constructed eagerly but evaluated lazily: membership tests ([`contains`]) walk
 //! the tree on demand, and iteration is deferred to [`EntitySetIterator`].
 //!
-//! Construction methods apply algebraic simplifications (e.g. `A ∪ ∅ = A`,
-//! `A ∩ A = A`) and reorder operands by estimated size to improve short-circuit
-//! performance.
+//! Construction methods reorder operands by estimated size to improve
+//! short-circuit performance and apply only minimal structural simplification.
 //!
 //! [`contains`]: EntitySet::contains
+
+use std::ops::Range;
 
 use super::{EntitySetIterator, SourceSet};
 use crate::entity::{Entity, EntityId};
@@ -66,7 +67,7 @@ impl<'a, E: Entity> EntitySet<'a, E> {
 
     /// Create an empty entity set.
     pub fn empty() -> Self {
-        EntitySet(EntitySetInner::Source(SourceSet::Empty))
+        EntitySet(EntitySetInner::Source(SourceSet::empty()))
     }
 
     /// Create an entity set from a single source set.
@@ -91,34 +92,25 @@ impl<'a, E: Entity> EntitySet<'a, E> {
     }
 
     pub fn union(self, other: Self) -> Self {
-        // Identity: A ∪ ∅ = A, ∅ ∪ B = B
-        if self.is_empty() {
-            return other;
-        }
-        if other.is_empty() {
-            return self;
-        }
         // Idempotence: A ∪ A = A  (same structure over same sources)
         if self.structurally_eq(&other) {
             return self;
         }
-        // Universal absorption: U ∪ A = U, A ∪ U = U
-        if self.is_universal() {
-            return self;
-        }
-        if other.is_universal() {
-            return other;
-        }
-        // Singleton absorption: {e} ∪ A = A if e ∈ A
-        if let Some(e) = self.as_singleton() {
-            if other.contains(e) {
-                return other;
+
+        // Adjacent or overlapping intervals
+        if let (Some(a), Some(b)) = (self.as_range(), other.as_range()) {
+            if a.start <= b.end && b.start <= a.end {
+                return Self::from_source(SourceSet::population_range(
+                    a.start.min(b.start)..a.end.max(b.end),
+                ));
             }
         }
-        if let Some(e) = other.as_singleton() {
-            if self.contains(e) {
-                return self;
-            }
+
+        // Union with empty set is identity: A ∪ ∅ = ∅ ∪ A = A
+        match (self.is_empty(), other.is_empty()) {
+            (true, _) => return other,
+            (_, true) => return self,
+            _ => { /* pass */ }
         }
 
         // Larger set on LHS: more likely to short-circuit `||`.
@@ -131,36 +123,26 @@ impl<'a, E: Entity> EntitySet<'a, E> {
     }
 
     pub fn intersection(self, other: Self) -> Self {
-        // Annihilator: A ∩ ∅ = ∅
-        if self.is_empty() || other.is_empty() {
-            return Self::empty();
-        }
         // Idempotence: A ∩ A = A
         if self.structurally_eq(&other) {
             return self;
         }
-        // Identity: U ∩ A = A
-        if self.is_universal() {
-            return other;
-        }
-        if other.is_universal() {
-            return self;
-        }
-        // Singleton restriction:
-        // {e} ∩ A = {e} if e ∈ A, otherwise ∅
-        if let Some(e) = self.as_singleton() {
-            return if other.contains(e) {
-                self
-            } else {
+
+        // Intersection of overlapping intervals
+        if let (Some(a), Some(b)) = (self.as_range(), other.as_range()) {
+            let overlap = a.start.max(b.start)..a.end.min(b.end);
+            return if overlap.is_empty() {
                 Self::empty()
+            } else {
+                Self::from_source(SourceSet::population_range(overlap))
             };
         }
-        if let Some(e) = other.as_singleton() {
-            return if self.contains(e) {
-                other
-            } else {
-                Self::empty()
-            };
+
+        // Intersection an empty set is empty: A ∩ ∅ = ∅ ∩ A = ∅
+        match (self.is_empty(), other.is_empty()) {
+            (true, _) => return self,
+            (_, true) => return other,
+            _ => { /* pass */ }
         }
 
         let mut sets = match self {
@@ -176,31 +158,37 @@ impl<'a, E: Entity> EntitySet<'a, E> {
     }
 
     pub fn difference(self, other: Self) -> Self {
-        // Identity: A \ ∅ = A
-        if other.is_empty() {
-            return self;
-        }
-        // Annihilator: ∅ \ B = ∅
-        if self.is_empty() {
-            return Self::empty();
-        }
         // Self-subtraction: A \ A = ∅
         if self.structurally_eq(&other) {
             return Self::empty();
         }
-        // Universal subtraction: A \ U = ∅
-        if other.is_universal() {
-            return Self::empty();
+
+        if let (Some(a), Some(b)) = (self.as_range(), other.as_range()) {
+            let overlap = a.start.max(b.start)..a.end.min(b.end);
+            // Disjoint ranges leave the left operand unchanged.
+            if overlap.is_empty() {
+                return Self::from_source(SourceSet::population_range(a));
+            }
+            // A covering subtraction removes the entire left range.
+            if overlap.start == a.start && overlap.end == a.end {
+                return Self::empty();
+            }
+            // Trimming the left edge still leaves one contiguous suffix.
+            if overlap.start == a.start {
+                return Self::from_source(SourceSet::population_range(overlap.end..a.end));
+            }
+            // Trimming the right edge still leaves one contiguous prefix.
+            if overlap.end == a.end {
+                return Self::from_source(SourceSet::population_range(a.start..overlap.start));
+            }
+            // An interior subtraction would split the range, so keep the generic difference node.
         }
-        // Singleton restriction:
-        // {e} \ A = {e} if e ∉ A, otherwise ∅
-        if let Some(e) = self.as_singleton() {
-            return if other.contains(e) {
-                Self::empty()
-            } else {
-                self
-            };
+
+        // Subtraction involving an empty set is identity: A \ ∅ = A, ∅ \ A = ∅
+        if self.is_empty() || other.is_empty() {
+            return self;
         }
+
         EntitySet(EntitySetInner::Difference(Box::new(self), Box::new(other)))
     }
 
@@ -236,25 +224,21 @@ impl<'a, E: Entity> EntitySet<'a, E> {
         }
     }
 
-    /// Returns `true` if this set is the abstract empty set (`∅`).
-    ///
-    /// A return value of `false` does not guarantee the set is non-empty.
-    /// For example, it may be an intersection of disjoint sets.
-    fn is_empty(&self) -> bool {
-        matches!(self, EntitySet(EntitySetInner::Source(SourceSet::Empty)))
-    }
-    /// Returns `true` if this set represents the entire entity population.
-    fn is_universal(&self) -> bool {
-        matches!(
-            self,
-            EntitySet(EntitySetInner::Source(SourceSet::Population(_)))
-        )
-    }
-    /// Returns the contained entity id if this set is a singleton leaf.
-    fn as_singleton(&self) -> Option<EntityId<E>> {
+    fn as_range(&self) -> Option<Range<usize>> {
         match self {
-            EntitySet(EntitySetInner::Source(SourceSet::Entity(e))) => Some(*e),
+            EntitySet(EntitySetInner::Source(SourceSet::PopulationRange(range))) => {
+                Some(range.clone())
+            }
             _ => None,
+        }
+    }
+
+    fn is_empty(&self) -> bool {
+        match self {
+            EntitySet(EntitySetInner::Source(SourceSet::PopulationRange(range))) => {
+                range.is_empty()
+            }
+            _ => false,
         }
     }
 
@@ -351,7 +335,7 @@ mod tests {
 
     #[test]
     fn from_source_empty_is_empty() {
-        let es = EntitySet::<Person>::from_source(SourceSet::Empty);
+        let es = EntitySet::<Person>::empty();
         assert_eq!(es.sort_key().0, 0);
         for value in 0..10 {
             assert!(!es.contains(EntityId::<Person>::new(value)));
@@ -359,107 +343,140 @@ mod tests {
     }
 
     #[test]
-    fn from_source_entity_and_population() {
-        let entity =
-            EntitySet::from_source(SourceSet::<Person>::Entity(EntityId::<Person>::new(5)));
-        assert!(entity.contains(EntityId::<Person>::new(5)));
-        assert!(!entity.contains(EntityId::<Person>::new(4)));
-        assert_eq!(entity.sort_key().0, 1);
-
-        let population = EntitySet::from_source(SourceSet::<Person>::Population(3));
+    fn from_source_population_ranges() {
+        let population = EntitySet::from_source(SourceSet::<Person>::population_range(0..3));
         assert!(population.contains(EntityId::<Person>::new(0)));
         assert!(population.contains(EntityId::<Person>::new(2)));
         assert!(!population.contains(EntityId::<Person>::new(3)));
         assert_eq!(population.sort_key().0, 3);
+
+        let singleton = EntitySet::from_source(SourceSet::<Person>::singleton(EntityId::new(5)));
+        assert!(singleton.contains(EntityId::<Person>::new(5)));
+        assert!(!singleton.contains(EntityId::<Person>::new(4)));
+        assert_eq!(singleton.sort_key().0, 1);
+
+        let range = EntitySet::from_source(SourceSet::<Person>::population_range(2..5));
+        assert!(range.contains(EntityId::<Person>::new(2)));
+        assert!(range.contains(EntityId::<Person>::new(4)));
+        assert!(!range.contains(EntityId::<Person>::new(1)));
+        assert!(!range.contains(EntityId::<Person>::new(5)));
+        assert_eq!(range.try_len(), Some(3));
     }
 
     #[test]
-    fn union_algebraic_reductions() {
+    fn union_basic_behavior_without_legacy_reductions() {
         let a = finite_set(&[1, 2, 3]);
         let e = EntitySet::<Person>::empty();
-        let u = EntitySet::from_source(SourceSet::<Person>::Population(10));
+        let u = EntitySet::from_source(SourceSet::<Person>::population_range(0..10));
 
         let a_union_empty = as_entity_set(&a).union(e);
         assert!(a_union_empty.contains(EntityId::<Person>::new(1)));
         assert!(!a_union_empty.contains(EntityId::<Person>::new(4)));
 
         let u_union_a = u.union(as_entity_set(&a));
-        assert!(matches!(
-            u_union_a,
-            EntitySet(EntitySetInner::Source(SourceSet::Population(10)))
-        ));
+        assert!(u_union_a.contains(EntityId::<Person>::new(0)));
+        assert!(u_union_a.contains(EntityId::<Person>::new(9)));
+        assert!(!u_union_a.contains(EntityId::<Person>::new(10)));
     }
 
     #[test]
-    fn union_entity_absorption() {
-        let a = finite_set(&[1, 2, 3]);
-        let absorbed =
-            EntitySet::from_source(SourceSet::<Person>::Entity(EntityId::<Person>::new(2)))
-                .union(as_entity_set(&a));
-        assert!(absorbed.contains(EntityId::<Person>::new(1)));
-        assert!(absorbed.contains(EntityId::<Person>::new(2)));
-        assert!(absorbed.contains(EntityId::<Person>::new(3)));
-
-        let b = finite_set(&[1, 2, 3]);
-        let not_absorbed =
-            EntitySet::from_source(SourceSet::<Person>::Entity(EntityId::<Person>::new(8)))
-                .union(as_entity_set(&b));
-        assert!(not_absorbed.contains(EntityId::<Person>::new(8)));
-        assert!(not_absorbed.contains(EntityId::<Person>::new(1)));
-    }
-
-    #[test]
-    fn intersection_algebraic_reductions() {
-        let a = finite_set(&[1, 2, 3]);
-        let u = EntitySet::from_source(SourceSet::<Person>::Population(10));
-
-        let a_inter_u = as_entity_set(&a).intersection(u);
-        assert!(a_inter_u.contains(EntityId::<Person>::new(1)));
-        assert!(a_inter_u.contains(EntityId::<Person>::new(2)));
-        assert!(!a_inter_u.contains(EntityId::<Person>::new(9)));
-
-        let b = finite_set(&[1, 2, 3]);
-        let present =
-            EntitySet::from_source(SourceSet::<Person>::Entity(EntityId::<Person>::new(2)))
-                .intersection(as_entity_set(&b));
+    fn union_range_optimizations() {
+        let adjacent = EntitySet::from_source(SourceSet::<Person>::population_range(0..3)).union(
+            EntitySet::from_source(SourceSet::<Person>::population_range(3..6)),
+        );
         assert!(matches!(
-            present,
-            EntitySet(EntitySetInner::Source(SourceSet::Entity(_)))
+            adjacent,
+            EntitySet(EntitySetInner::Source(SourceSet::PopulationRange(ref range))) if range == &(0..6)
         ));
 
-        let c = finite_set(&[1, 2, 3]);
-        let absent =
-            EntitySet::from_source(SourceSet::<Person>::Entity(EntityId::<Person>::new(7)))
-                .intersection(as_entity_set(&c));
-        assert!(!absent.contains(EntityId::<Person>::new(7)));
+        let overlapping = EntitySet::from_source(SourceSet::<Person>::population_range(2..6))
+            .union(EntitySet::from_source(
+                SourceSet::<Person>::population_range(4..8),
+            ));
+        assert!(matches!(
+            overlapping,
+            EntitySet(EntitySetInner::Source(SourceSet::PopulationRange(ref range))) if range == &(2..8)
+        ));
+
+        let disjoint = EntitySet::from_source(SourceSet::<Person>::singleton(EntityId::new(1)))
+            .union(EntitySet::from_source(SourceSet::<Person>::singleton(
+                EntityId::new(4),
+            )));
+        assert!(matches!(disjoint, EntitySet(EntitySetInner::Union(_, _))));
     }
 
     #[test]
-    fn difference_algebraic_reductions() {
-        let a = finite_set(&[1, 2, 3]);
+    fn intersection_range_optimizations() {
+        let overlap = EntitySet::from_source(SourceSet::<Person>::population_range(2..6))
+            .intersection(EntitySet::from_source(
+                SourceSet::<Person>::population_range(4..8),
+            ));
+        assert!(matches!(
+            overlap,
+            EntitySet(EntitySetInner::Source(SourceSet::PopulationRange(ref range))) if range == &(4..6)
+        ));
 
-        let minus_empty = as_entity_set(&a).difference(EntitySet::empty());
-        assert!(minus_empty.contains(EntityId::<Person>::new(1)));
-        assert!(!minus_empty.contains(EntityId::<Person>::new(9)));
+        let empty = EntitySet::from_source(SourceSet::<Person>::population_range(1..3))
+            .intersection(EntitySet::from_source(
+                SourceSet::<Person>::population_range(5..7),
+            ));
+        assert!(matches!(
+            empty,
+            EntitySet(EntitySetInner::Source(SourceSet::PopulationRange(ref range))) if range == &(0..0)
+        ));
 
-        let minus_universe =
-            as_entity_set(&a)
-                .difference(EntitySet::from_source(SourceSet::<Person>::Population(10)));
-        for value in 0..10 {
-            assert!(!minus_universe.contains(EntityId::<Person>::new(value)));
-        }
+        let indexed_ids = finite_set(&[1, 2, 3]);
+        let mixed = EntitySet::from_source(SourceSet::<Person>::singleton(EntityId::new(2)))
+            .intersection(as_entity_set(&indexed_ids));
+        assert!(mixed.contains(EntityId::<Person>::new(2)));
+        assert!(!mixed.contains(EntityId::<Person>::new(1)));
+    }
 
-        let b = finite_set(&[1, 2, 3]);
-        let singleton_absent =
-            EntitySet::from_source(SourceSet::<Person>::Entity(EntityId::<Person>::new(8)))
-                .difference(as_entity_set(&b));
-        assert!(singleton_absent.contains(EntityId::<Person>::new(8)));
+    #[test]
+    fn difference_range_optimizations() {
+        let unchanged = EntitySet::from_source(SourceSet::<Person>::population_range(2..6))
+            .difference(EntitySet::from_source(
+                SourceSet::<Person>::population_range(8..10),
+            ));
+        assert!(matches!(
+            unchanged,
+            EntitySet(EntitySetInner::Source(SourceSet::PopulationRange(ref range))) if range == &(2..6)
+        ));
 
-        let c = finite_set(&[1, 2, 3]);
-        let singleton_present =
-            EntitySet::from_source(SourceSet::<Person>::Entity(EntityId::<Person>::new(2)))
-                .difference(as_entity_set(&c));
-        assert!(!singleton_present.contains(EntityId::<Person>::new(2)));
+        let empty = EntitySet::from_source(SourceSet::<Person>::population_range(2..6)).difference(
+            EntitySet::from_source(SourceSet::<Person>::population_range(1..7)),
+        );
+        assert!(matches!(
+            empty,
+            EntitySet(EntitySetInner::Source(SourceSet::PopulationRange(ref range))) if range == &(0..0)
+        ));
+
+        let trim_left = EntitySet::from_source(SourceSet::<Person>::population_range(2..6))
+            .difference(EntitySet::from_source(
+                SourceSet::<Person>::population_range(1..4),
+            ));
+        assert!(matches!(
+            trim_left,
+            EntitySet(EntitySetInner::Source(SourceSet::PopulationRange(ref range))) if range == &(4..6)
+        ));
+
+        let trim_right = EntitySet::from_source(SourceSet::<Person>::population_range(2..6))
+            .difference(EntitySet::from_source(
+                SourceSet::<Person>::population_range(4..8),
+            ));
+        assert!(matches!(
+            trim_right,
+            EntitySet(EntitySetInner::Source(SourceSet::PopulationRange(ref range))) if range == &(2..4)
+        ));
+
+        let split = EntitySet::from_source(SourceSet::<Person>::population_range(2..8)).difference(
+            EntitySet::from_source(SourceSet::<Person>::population_range(4..6)),
+        );
+        assert!(matches!(split, EntitySet(EntitySetInner::Difference(_, _))));
+        assert!(split.contains(EntityId::<Person>::new(2)));
+        assert!(split.contains(EntityId::<Person>::new(7)));
+        assert!(!split.contains(EntityId::<Person>::new(4)));
+        assert!(!split.contains(EntityId::<Person>::new(5)));
     }
 
     #[test]
@@ -542,21 +559,24 @@ mod tests {
 
     #[test]
     fn population_zero_is_empty() {
-        let es = EntitySet::from_source(SourceSet::<Person>::Population(0));
+        let es = EntitySet::from_source(SourceSet::<Person>::empty());
         assert_eq!(es.sort_key().0, 0);
         assert!(!es.contains(EntityId::<Person>::new(0)));
     }
 
     #[test]
     fn try_len_known_only_for_non_property_sources() {
-        let empty = EntitySet::<Person>::from_source(SourceSet::Empty);
+        let empty = EntitySet::<Person>::from_source(SourceSet::empty());
         assert_eq!(empty.try_len(), Some(0));
 
-        let singleton = EntitySet::<Person>::from_source(SourceSet::Entity(EntityId::new(42)));
+        let singleton = EntitySet::<Person>::from_source(SourceSet::singleton(EntityId::new(42)));
         assert_eq!(singleton.try_len(), Some(1));
 
-        let population = EntitySet::<Person>::from_source(SourceSet::Population(5));
+        let population = EntitySet::<Person>::from_source(SourceSet::population_range(0..5));
         assert_eq!(population.try_len(), Some(5));
+
+        let range = EntitySet::<Person>::from_source(SourceSet::population_range(4..9));
+        assert_eq!(range.try_len(), Some(5));
 
         let index_data = [EntityId::new(1), EntityId::new(2), EntityId::new(3)]
             .into_iter()
@@ -571,9 +591,24 @@ mod tests {
         let property_set = EntitySet::<Person>::from_source(property_source);
         assert_eq!(property_set.try_len(), None);
 
-        let composed = EntitySet::<Person>::from_source(SourceSet::Population(3))
-            .difference(EntitySet::from_source(SourceSet::Entity(EntityId::new(1))));
+        let composed = EntitySet::<Person>::from_source(SourceSet::population_range(0..3))
+            .difference(EntitySet::from_source(SourceSet::singleton(EntityId::new(
+                1,
+            ))));
         assert_eq!(composed.try_len(), None);
+    }
+
+    #[test]
+    fn range_leaf_works_inside_composite_expressions() {
+        let indexed_ids = finite_set(&[1, 3, 5, 8]);
+        let indexed = as_entity_set(&indexed_ids);
+        let range = EntitySet::from_source(SourceSet::<Person>::population_range(2..8));
+
+        let intersection = range.intersection(indexed);
+        assert!(!intersection.contains(EntityId::new(1)));
+        assert!(intersection.contains(EntityId::new(3)));
+        assert!(intersection.contains(EntityId::new(5)));
+        assert!(!intersection.contains(EntityId::new(8)));
     }
 
     #[test]

--- a/src/entity/entity_set/entity_set_iterator.rs
+++ b/src/entity/entity_set/entity_set_iterator.rs
@@ -1,8 +1,8 @@
 //! Iterator implementation for [`EntitySet`].
 //!
 //! `EntitySetIterator` mirrors an `EntitySet` expression tree and evaluates nodes lazily.
-//! - `Source` iterates a concrete backing source (`Population`, singleton `Entity`, index set,
-//!   or property-backed source).
+//! - `Source` iterates a concrete backing source (`Population`, contiguous
+//!   `PopulationRange`, index set, or property-backed source).
 //! - `Intersection` and `Difference` drive iteration from one branch and filter candidates using
 //!   membership checks.
 //! - `Union` yields the left branch first, then lazily activates the right branch (`Pending` to
@@ -14,7 +14,7 @@ use log::warn;
 use rand::Rng;
 
 use crate::entity::entity_set::entity_set::{EntitySet, EntitySetInner};
-use crate::entity::entity_set::source_iterator::SourceIterator;
+use crate::entity::entity_set::source_iterator::{PopulationRangeIterator, SourceIterator};
 use crate::entity::entity_set::source_set::SourceSet;
 use crate::entity::{Entity, EntityId, PopulationIterator};
 use crate::hashing::IndexSet;
@@ -24,7 +24,6 @@ use crate::random::{
 };
 
 enum EntitySetIteratorInner<'a, E: Entity> {
-    Empty,
     Source(SourceIterator<'a, E>),
     // The `IntersectionSources` variant is a micro-optimization to avoid recursive
     // `EntitySet` membership checks in the most common case, improving tight-loop
@@ -53,18 +52,24 @@ enum UnionRightState<'a, E: Entity> {
 }
 
 impl<'a, E: Entity> EntitySetIteratorInner<'a, E> {
+    fn empty_source() -> Self {
+        Self::Source(SourceIterator::PopulationRange(
+            PopulationRangeIterator::new(0..0),
+        ))
+    }
+
     fn from_entity_set(set: EntitySet<'a, E>) -> Self {
         match set.into_inner() {
             EntitySetInner::Source(source) => {
-                if matches!(source, SourceSet::Empty) {
-                    Self::Empty
+                if source.try_len() == Some(0) {
+                    Self::empty_source()
                 } else {
                     Self::Source(source.into_iter())
                 }
             }
             EntitySetInner::Intersection(mut sets) => {
                 if sets.is_empty() {
-                    return Self::Empty;
+                    return Self::empty_source();
                 }
                 if sets.len() == 1 {
                     return Self::from_entity_set(sets.pop().unwrap());
@@ -108,7 +113,6 @@ impl<'a, E: Entity> EntitySetIteratorInner<'a, E> {
 
     fn contains(&self, entity_id: EntityId<E>) -> bool {
         match self {
-            Self::Empty => false,
             Self::Source(iter) => iter.contains(entity_id),
             Self::IntersectionSources { driver, filters } => {
                 driver.contains(entity_id) && filters.iter().all(|set| set.contains(entity_id))
@@ -138,7 +142,6 @@ impl<'a, E: Entity> EntitySetIteratorInner<'a, E> {
     #[inline]
     fn next_inner(&mut self) -> Option<EntityId<E>> {
         match self {
-            Self::Empty => None,
             Self::Source(source) => source.next(),
             Self::IntersectionSources { driver, filters } => driver
                 .by_ref()
@@ -187,7 +190,6 @@ impl<'a, E: Entity> EntitySetIteratorInner<'a, E> {
     #[inline]
     fn size_hint_inner(&self) -> (usize, Option<usize>) {
         match self {
-            Self::Empty => (0, Some(0)),
             Self::Source(source) => source.size_hint(),
             Self::IntersectionSources { driver, .. } => {
                 let (_, upper) = driver.size_hint();
@@ -225,13 +227,15 @@ pub struct EntitySetIterator<'c, E: Entity> {
 impl<'c, E: Entity> EntitySetIterator<'c, E> {
     pub(crate) fn empty() -> EntitySetIterator<'c, E> {
         EntitySetIterator {
-            inner: EntitySetIteratorInner::Empty,
+            inner: EntitySetIteratorInner::empty_source(),
         }
     }
 
     pub(crate) fn from_population_iterator(iter: PopulationIterator<E>) -> Self {
         EntitySetIterator {
-            inner: EntitySetIteratorInner::Source(SourceIterator::Population(iter)),
+            inner: EntitySetIteratorInner::Source(SourceIterator::PopulationRange(
+                PopulationRangeIterator::from_population_iterator(iter),
+            )),
         }
     }
 
@@ -911,8 +915,9 @@ mod tests {
 
     #[test]
     fn test_expression_intersection_iteration() {
-        let set = EntitySet::from_source(SourceSet::<Person>::Population(10))
-            .intersection(EntitySet::from_source(SourceSet::<Person>::Population(6)));
+        let set = EntitySet::from_source(SourceSet::<Person>::PopulationRange(0..10)).intersection(
+            EntitySet::from_source(SourceSet::<Person>::PopulationRange(0..6)),
+        );
 
         let ids = set.into_iter().collect::<Vec<_>>();
         let expected = (0..6).map(EntityId::new).collect::<Vec<_>>();
@@ -921,8 +926,8 @@ mod tests {
 
     #[test]
     fn test_expression_difference_iteration() {
-        let set = EntitySet::from_source(SourceSet::<Person>::Population(5)).difference(
-            EntitySet::from_source(SourceSet::<Person>::Entity(EntityId::new(2))),
+        let set = EntitySet::from_source(SourceSet::<Person>::PopulationRange(0..5)).difference(
+            EntitySet::from_source(SourceSet::<Person>::PopulationRange(2..3)),
         );
 
         let ids = set.into_iter().collect::<Vec<_>>();
@@ -937,11 +942,11 @@ mod tests {
 
     #[test]
     fn test_expression_union_deduplicates() {
-        let left = EntitySet::from_source(SourceSet::<Person>::Population(3)).difference(
-            EntitySet::from_source(SourceSet::<Person>::Entity(EntityId::new(99))),
+        let left = EntitySet::from_source(SourceSet::<Person>::PopulationRange(0..3)).difference(
+            EntitySet::from_source(SourceSet::<Person>::PopulationRange(99..100)),
         );
-        let right = EntitySet::from_source(SourceSet::<Person>::Population(5)).difference(
-            EntitySet::from_source(SourceSet::<Person>::Entity(EntityId::new(99))),
+        let right = EntitySet::from_source(SourceSet::<Person>::PopulationRange(0..5)).difference(
+            EntitySet::from_source(SourceSet::<Person>::PopulationRange(99..100)),
         );
         let set = left.union(right);
 
@@ -952,11 +957,11 @@ mod tests {
 
     #[test]
     fn test_expression_union_overlap_no_duplicates() {
-        let left = EntitySet::from_source(SourceSet::<Person>::Population(5)).difference(
-            EntitySet::from_source(SourceSet::<Person>::Entity(EntityId::new(4))),
+        let left = EntitySet::from_source(SourceSet::<Person>::PopulationRange(0..5)).difference(
+            EntitySet::from_source(SourceSet::<Person>::PopulationRange(4..5)),
         );
-        let right = EntitySet::from_source(SourceSet::<Person>::Population(7)).difference(
-            EntitySet::from_source(SourceSet::<Person>::Entity(EntityId::new(0))),
+        let right = EntitySet::from_source(SourceSet::<Person>::PopulationRange(0..7)).difference(
+            EntitySet::from_source(SourceSet::<Person>::PopulationRange(0..1)),
         );
 
         let ids = left.union(right).into_iter().collect::<IndexSet<_>>();
@@ -966,20 +971,20 @@ mod tests {
 
     #[test]
     fn test_expression_intersection_of_unions() {
-        let ab = EntitySet::from_source(SourceSet::<Person>::Entity(EntityId::new(1)))
-            .union(EntitySet::from_source(SourceSet::<Person>::Entity(
-                EntityId::new(2),
-            )))
-            .union(EntitySet::from_source(SourceSet::<Person>::Entity(
-                EntityId::new(3),
-            )));
-        let cd = EntitySet::from_source(SourceSet::<Person>::Entity(EntityId::new(2)))
-            .union(EntitySet::from_source(SourceSet::<Person>::Entity(
-                EntityId::new(3),
-            )))
-            .union(EntitySet::from_source(SourceSet::<Person>::Entity(
-                EntityId::new(4),
-            )));
+        let ab = EntitySet::from_source(SourceSet::<Person>::PopulationRange(1..2))
+            .union(EntitySet::from_source(
+                SourceSet::<Person>::PopulationRange(2..3),
+            ))
+            .union(EntitySet::from_source(
+                SourceSet::<Person>::PopulationRange(3..4),
+            ));
+        let cd = EntitySet::from_source(SourceSet::<Person>::PopulationRange(2..3))
+            .union(EntitySet::from_source(
+                SourceSet::<Person>::PopulationRange(3..4),
+            ))
+            .union(EntitySet::from_source(
+                SourceSet::<Person>::PopulationRange(4..5),
+            ));
 
         let ids = ab.intersection(cd).into_iter().collect::<Vec<_>>();
         assert_eq!(ids, vec![EntityId::new(2), EntityId::new(3)]);
@@ -987,41 +992,40 @@ mod tests {
 
     #[test]
     fn test_expression_difference_not_commutative() {
-        let left = EntitySet::from_source(SourceSet::<Person>::Entity(EntityId::new(1)))
-            .union(EntitySet::from_source(SourceSet::<Person>::Entity(
-                EntityId::new(2),
-            )))
-            .union(EntitySet::from_source(SourceSet::<Person>::Entity(
-                EntityId::new(3),
-            )));
-        let right = EntitySet::from_source(SourceSet::<Person>::Entity(EntityId::new(2)))
-            .union(EntitySet::from_source(SourceSet::<Person>::Entity(
-                EntityId::new(3),
-            )))
-            .union(EntitySet::from_source(SourceSet::<Person>::Entity(
-                EntityId::new(4),
-            )));
+        let left = EntitySet::from_source(SourceSet::<Person>::PopulationRange(1..2))
+            .union(EntitySet::from_source(
+                SourceSet::<Person>::PopulationRange(2..3),
+            ))
+            .union(EntitySet::from_source(
+                SourceSet::<Person>::PopulationRange(3..4),
+            ));
+        let right = EntitySet::from_source(SourceSet::<Person>::PopulationRange(2..3))
+            .union(EntitySet::from_source(
+                SourceSet::<Person>::PopulationRange(3..4),
+            ))
+            .union(EntitySet::from_source(
+                SourceSet::<Person>::PopulationRange(4..5),
+            ));
 
         let left_minus_right = left.difference(right).into_iter().collect::<Vec<_>>();
-        let right_minus_left =
-            EntitySet::from_source(SourceSet::<Person>::Entity(EntityId::new(2)))
-                .union(EntitySet::from_source(SourceSet::<Person>::Entity(
-                    EntityId::new(3),
-                )))
-                .union(EntitySet::from_source(SourceSet::<Person>::Entity(
-                    EntityId::new(4),
-                )))
-                .difference(
-                    EntitySet::from_source(SourceSet::<Person>::Entity(EntityId::new(1)))
-                        .union(EntitySet::from_source(SourceSet::<Person>::Entity(
-                            EntityId::new(2),
-                        )))
-                        .union(EntitySet::from_source(SourceSet::<Person>::Entity(
-                            EntityId::new(3),
-                        ))),
-                )
-                .into_iter()
-                .collect::<Vec<_>>();
+        let right_minus_left = EntitySet::from_source(SourceSet::<Person>::PopulationRange(2..3))
+            .union(EntitySet::from_source(
+                SourceSet::<Person>::PopulationRange(3..4),
+            ))
+            .union(EntitySet::from_source(
+                SourceSet::<Person>::PopulationRange(4..5),
+            ))
+            .difference(
+                EntitySet::from_source(SourceSet::<Person>::PopulationRange(1..2))
+                    .union(EntitySet::from_source(
+                        SourceSet::<Person>::PopulationRange(2..3),
+                    ))
+                    .union(EntitySet::from_source(
+                        SourceSet::<Person>::PopulationRange(3..4),
+                    )),
+            )
+            .into_iter()
+            .collect::<Vec<_>>();
 
         assert_eq!(left_minus_right, vec![EntityId::new(1)]);
         assert_eq!(right_minus_left, vec![EntityId::new(4)]);
@@ -1029,24 +1033,80 @@ mod tests {
 
     #[test]
     fn test_union_size_hint_pending_right_is_unknown() {
-        let left = EntitySet::from_source(SourceSet::<Person>::Population(2)).difference(
-            EntitySet::from_source(SourceSet::<Person>::Entity(EntityId::new(99))),
+        let left = EntitySet::from_source(SourceSet::<Person>::PopulationRange(0..2)).difference(
+            EntitySet::from_source(SourceSet::<Person>::PopulationRange(99..100)),
         );
-        let right = EntitySet::from_source(SourceSet::<Person>::Population(4)).difference(
-            EntitySet::from_source(SourceSet::<Person>::Entity(EntityId::new(98))),
+        let right = EntitySet::from_source(SourceSet::<Person>::PopulationRange(0..4)).difference(
+            EntitySet::from_source(SourceSet::<Person>::PopulationRange(98..99)),
         );
         let iter = left.union(right).into_iter();
 
-        assert_eq!(iter.size_hint(), (0, None));
+        assert_eq!(iter.size_hint(), (4, Some(4)));
     }
 
     #[test]
     fn test_nth_and_count_on_source() {
-        let mut iter = EntitySet::from_source(SourceSet::<Person>::Population(5)).into_iter();
+        let mut iter =
+            EntitySet::from_source(SourceSet::<Person>::PopulationRange(0..5)).into_iter();
         assert_eq!(iter.nth(2), Some(EntityId::new(2)));
 
         let remaining = iter.count();
         assert_eq!(remaining, 2);
+    }
+
+    #[test]
+    fn population_range_source_iteration_and_size_hint() {
+        let mut iter =
+            EntitySet::from_source(SourceSet::<Person>::PopulationRange(3..7)).into_iter();
+        assert_eq!(iter.size_hint(), (4, Some(4)));
+        assert_eq!(iter.next(), Some(EntityId::new(3)));
+        assert_eq!(iter.size_hint(), (3, Some(3)));
+        assert_eq!(
+            iter.collect::<Vec<_>>(),
+            vec![EntityId::new(4), EntityId::new(5), EntityId::new(6)]
+        );
+    }
+
+    #[test]
+    fn optimized_range_results_iterate_as_single_source() {
+        let union = EntitySet::from_source(SourceSet::<Person>::PopulationRange(0..3)).union(
+            EntitySet::from_source(SourceSet::<Person>::PopulationRange(3..5)),
+        );
+        assert_eq!(
+            union.into_iter().collect::<Vec<_>>(),
+            vec![
+                EntityId::new(0),
+                EntityId::new(1),
+                EntityId::new(2),
+                EntityId::new(3),
+                EntityId::new(4),
+            ]
+        );
+
+        let intersection = EntitySet::from_source(SourceSet::<Person>::PopulationRange(2..8))
+            .intersection(EntitySet::from_source(
+                SourceSet::<Person>::PopulationRange(4..6),
+            ));
+        assert_eq!(
+            intersection.into_iter().collect::<Vec<_>>(),
+            vec![EntityId::new(4), EntityId::new(5)]
+        );
+    }
+
+    #[test]
+    fn split_difference_still_uses_generic_iteration_path() {
+        let split = EntitySet::from_source(SourceSet::<Person>::PopulationRange(2..8)).difference(
+            EntitySet::from_source(SourceSet::<Person>::PopulationRange(4..6)),
+        );
+        assert_eq!(
+            split.into_iter().collect::<Vec<_>>(),
+            vec![
+                EntityId::new(2),
+                EntityId::new(3),
+                EntityId::new(6),
+                EntityId::new(7)
+            ]
+        );
     }
 
     fn finite_set(ids: &[usize]) -> FxIndexSet<EntityId<Person>> {
@@ -1145,7 +1205,8 @@ mod tests {
 
     #[test]
     fn prototype_size_hint_single_source_and_partial_consume() {
-        let mut iter = EntitySet::from_source(SourceSet::<Person>::Population(5)).into_iter();
+        let mut iter =
+            EntitySet::from_source(SourceSet::<Person>::PopulationRange(0..5)).into_iter();
         assert_eq!(iter.size_hint(), (5, Some(5)));
         iter.next();
         assert_eq!(iter.size_hint(), (4, Some(4)));

--- a/src/entity/entity_set/source_iterator.rs
+++ b/src/entity/entity_set/source_iterator.rs
@@ -2,26 +2,125 @@
 //! `EntitySetIterator`.
 //!
 //! It encapsulates the concrete source chosen for traversal: an index-set
-//! iterator, a property-source iterator, a whole-population iterator, or an
-//! empty iterator.
+//! iterator, a property-source iterator, or a contiguous population range
+//! iterator.
 //!
 //! `SourceSet` (defined in `source_set.rs`) builds `SourceIterator` values,
 //! and `EntitySetIterator` drives them while applying remaining set-membership
 //! filters.
 //!
 //! Depending on source kind, the underlying iterator may be implemented either:
-//! - directly in this module (for `IndexSetIterator` and `PopulationIterator`), or
+//! - directly in this module (for `IndexSetIterator` and `PopulationRangeIterator`), or
 //! - on intermediate wrapper types defined in `source_set.rs`
 //!   (`ConcretePropertySource` and `DerivedPropertySource`), which serve as both
 //!   set-facing wrappers and iterators.
 
 use std::fmt::{Debug, Formatter};
+use std::marker::PhantomData;
+use std::ops::Range;
 
 use ouroboros::self_referencing;
 
 use super::source_set::AbstractPropertySource;
 use crate::entity::{Entity, EntityId, PopulationIterator};
 use crate::hashing::{IndexSet, IndexSetIter};
+
+#[derive(Clone)]
+pub(super) struct PopulationRangeIterator<E: Entity> {
+    range: Range<usize>,
+    next: usize,
+    _phantom: PhantomData<E>,
+}
+
+impl<E: Entity> PopulationRangeIterator<E> {
+    pub fn new(range: Range<usize>) -> Self {
+        Self {
+            next: range.start,
+            range,
+            _phantom: PhantomData,
+        }
+    }
+
+    #[must_use]
+    pub fn range(&self) -> Range<usize> {
+        self.range.clone()
+    }
+
+    pub fn from_population_iterator(iter: PopulationIterator<E>) -> Self {
+        Self::new(0..iter.population())
+    }
+}
+
+impl<E: Entity> Iterator for PopulationRangeIterator<E> {
+    type Item = EntityId<E>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.next < self.range.end {
+            let current = self.next;
+            self.next += 1;
+            Some(EntityId::new(current))
+        } else {
+            None
+        }
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        let remaining = self.len();
+        (remaining, Some(remaining))
+    }
+
+    fn count(self) -> usize {
+        self.len()
+    }
+
+    fn nth(&mut self, n: usize) -> Option<Self::Item> {
+        self.next = self.next.saturating_add(n).min(self.range.end);
+        self.next()
+    }
+
+    fn last(self) -> Option<Self::Item>
+    where
+        Self: Sized,
+    {
+        if self.next < self.range.end {
+            Some(EntityId::new(self.range.end - 1))
+        } else {
+            None
+        }
+    }
+
+    fn for_each<F>(mut self, mut f: F)
+    where
+        F: FnMut(Self::Item),
+    {
+        while self.next < self.range.end {
+            let current = self.next;
+            self.next += 1;
+            f(EntityId::new(current));
+        }
+    }
+
+    fn fold<B, F>(mut self, init: B, mut f: F) -> B
+    where
+        F: FnMut(B, Self::Item) -> B,
+    {
+        let mut acc = init;
+        while self.next < self.range.end {
+            let current = self.next;
+            self.next += 1;
+            acc = f(acc, EntityId::new(current));
+        }
+        acc
+    }
+}
+
+impl<E: Entity> ExactSizeIterator for PopulationRangeIterator<E> {
+    fn len(&self) -> usize {
+        self.range.end.saturating_sub(self.next)
+    }
+}
+
+impl<E: Entity> std::iter::FusedIterator for PopulationRangeIterator<E> {}
 
 /// The self-referential iterator type for index sets. We don't implement
 /// `Iterator` for this struct, choosing instead to access the inner
@@ -50,12 +149,8 @@ pub(super) enum SourceIterator<'a, E: Entity> {
     IndexIter(IndexSetIterator<'a, E>),
     /// An iterator over a property vector
     PropertyVecIter(Box<dyn AbstractPropertySource<'a, E> + 'a>),
-    /// An iterator over the entire population
-    Population(PopulationIterator<E>),
-    /// A singleton iterator
-    Entity { id: EntityId<E>, exhausted: bool },
-    /// An empty iterator
-    Empty,
+    /// An iterator over a contiguous population subrange
+    PopulationRange(PopulationRangeIterator<E>),
 }
 
 impl<'a, E: Entity> Debug for SourceIterator<'a, E> {
@@ -63,9 +158,7 @@ impl<'a, E: Entity> Debug for SourceIterator<'a, E> {
         match self {
             SourceIterator::IndexIter(_iter) => write!(f, "IndexIter"),
             SourceIterator::PropertyVecIter(_iter) => write!(f, "PropertyVecIter"),
-            SourceIterator::Population { .. } => write!(f, "WholePopulation"),
-            SourceIterator::Entity { .. } => write!(f, "Entity"),
-            SourceIterator::Empty => write!(f, "Empty"),
+            SourceIterator::PopulationRange(..) => write!(f, "PopulationRange"),
         }
     }
 }
@@ -80,9 +173,7 @@ impl<'a, E: Entity> SourceIterator<'a, E> {
                 iter.with_index_set(|index_set| index_set.contains(&id))
             }
             SourceIterator::PropertyVecIter(source) => source.contains(id),
-            SourceIterator::Population(source) => id.0 < source.population(),
-            SourceIterator::Entity { id: entity_id, .. } => *entity_id == id,
-            SourceIterator::Empty => false,
+            SourceIterator::PopulationRange(source) => source.range().contains(&id.0),
         }
     }
 }
@@ -97,16 +188,7 @@ impl<'a, E: Entity> Iterator for SourceIterator<'a, E> {
                 index_set_iter.with_iter_mut(|iter| iter.next().copied())
             }
             SourceIterator::PropertyVecIter(iter) => iter.next(),
-            SourceIterator::Population(iter) => iter.next(),
-            SourceIterator::Entity { id, exhausted } => {
-                if *exhausted {
-                    None
-                } else {
-                    *exhausted = true;
-                    Some(*id)
-                }
-            }
-            SourceIterator::Empty => None,
+            SourceIterator::PopulationRange(iter) => iter.next(),
         }
     }
 
@@ -115,15 +197,7 @@ impl<'a, E: Entity> Iterator for SourceIterator<'a, E> {
         match self {
             SourceIterator::IndexIter(iter) => iter.with_iter(|iter| iter.size_hint()),
             SourceIterator::PropertyVecIter(iter) => iter.size_hint(),
-            SourceIterator::Population(iter) => iter.size_hint(),
-            SourceIterator::Entity { exhausted, .. } => {
-                if *exhausted {
-                    (0, Some(0))
-                } else {
-                    (1, Some(1))
-                }
-            }
-            SourceIterator::Empty => (0, Some(0)),
+            SourceIterator::PopulationRange(iter) => iter.size_hint(),
         }
     }
 
@@ -133,15 +207,7 @@ impl<'a, E: Entity> Iterator for SourceIterator<'a, E> {
         match self {
             SourceIterator::IndexIter(mut iter) => iter.with_iter_mut(|iter| iter.count()),
             SourceIterator::PropertyVecIter(iter) => iter.count(),
-            SourceIterator::Population(iter) => iter.count(),
-            SourceIterator::Entity { exhausted, .. } => {
-                if exhausted {
-                    0
-                } else {
-                    1
-                }
-            }
-            SourceIterator::Empty => 0,
+            SourceIterator::PopulationRange(iter) => iter.count(),
         }
     }
 
@@ -149,15 +215,7 @@ impl<'a, E: Entity> Iterator for SourceIterator<'a, E> {
         match self {
             Self::IndexIter(mut iter) => iter.with_iter_mut(|iter| iter.last().copied()),
             Self::PropertyVecIter(iter) => iter.last(),
-            Self::Population(iter) => iter.last(),
-            Self::Entity { id, exhausted } => {
-                if exhausted {
-                    None
-                } else {
-                    Some(id)
-                }
-            }
-            Self::Empty => None,
+            Self::PopulationRange(iter) => iter.last(),
         }
     }
 
@@ -166,17 +224,7 @@ impl<'a, E: Entity> Iterator for SourceIterator<'a, E> {
         match self {
             Self::IndexIter(iter) => iter.with_iter_mut(|iter| iter.nth(n).copied()),
             Self::PropertyVecIter(iter) => iter.nth(n),
-            Self::Population(iter) => iter.nth(n),
-            Self::Entity { id, exhausted } => {
-                if n == 0 && !*exhausted {
-                    *exhausted = true;
-                    Some(*id)
-                } else {
-                    *exhausted = true;
-                    None
-                }
-            }
-            Self::Empty => None,
+            Self::PopulationRange(iter) => iter.nth(n),
         }
     }
 
@@ -189,13 +237,7 @@ impl<'a, E: Entity> Iterator for SourceIterator<'a, E> {
                 iter.with_iter_mut(|iter| iter.for_each(|entity_id| f(*entity_id)))
             }
             Self::PropertyVecIter(iter) => iter.for_each(f),
-            Self::Population(iter) => iter.for_each(f),
-            Self::Entity { id, exhausted } => {
-                if !exhausted {
-                    f(id);
-                }
-            }
-            Self::Empty => {}
+            Self::PopulationRange(iter) => iter.for_each(f),
         }
     }
 
@@ -208,15 +250,7 @@ impl<'a, E: Entity> Iterator for SourceIterator<'a, E> {
                 iter.with_iter_mut(|iter| iter.fold(init, |acc, entity_id| f(acc, *entity_id)))
             }
             Self::PropertyVecIter(iter) => iter.fold(init, f),
-            Self::Population(iter) => iter.fold(init, f),
-            Self::Entity { id, exhausted } => {
-                if exhausted {
-                    init
-                } else {
-                    f(init, id)
-                }
-            }
-            Self::Empty => init,
+            Self::PopulationRange(iter) => iter.fold(init, f),
         }
     }
 }
@@ -267,26 +301,24 @@ mod tests {
     }
 
     #[test]
-    fn source_iterator_contains_for_population_and_empty() {
-        let mut population_iter = SourceSet::<Person>::Population(5).into_iter();
-        assert_eq!(population_iter.next(), Some(EntityId::new(0)));
-        assert_eq!(population_iter.next(), Some(EntityId::new(1)));
-
-        assert!(population_iter.contains(EntityId::new(0)));
-        assert!(population_iter.contains(EntityId::new(4)));
-        assert!(!population_iter.contains(EntityId::new(5)));
-
-        let empty_iter = SourceSet::<Person>::Empty.into_iter();
+    fn source_iterator_contains_for_empty_population_range() {
+        let empty_iter = SourceSet::<Person>::PopulationRange(0..0).into_iter();
         assert!(!empty_iter.contains(EntityId::new(0)));
     }
 
     #[test]
-    fn source_iterator_contains_for_entity_uses_original_set() {
-        let mut iter = SourceSet::<Person>::Entity(EntityId::new(11)).into_iter();
-        assert_eq!(iter.next(), Some(EntityId::new(11)));
+    fn source_iterator_contains_for_population_range_uses_original_set() {
+        let mut iter = SourceSet::<Person>::PopulationRange(3..7).into_iter();
+        assert_eq!(iter.next(), Some(EntityId::new(3)));
 
-        assert!(iter.contains(EntityId::new(11)));
-        assert!(!iter.contains(EntityId::new(10)));
-        assert_eq!(iter.next(), None);
+        assert!(iter.contains(EntityId::new(3)));
+        assert!(iter.contains(EntityId::new(6)));
+        assert!(!iter.contains(EntityId::new(2)));
+        assert!(!iter.contains(EntityId::new(7)));
+
+        assert_eq!(
+            iter.collect::<Vec<_>>(),
+            vec![EntityId::new(4), EntityId::new(5), EntityId::new(6)]
+        );
     }
 }

--- a/src/entity/entity_set/source_set.rs
+++ b/src/entity/entity_set/source_set.rs
@@ -20,8 +20,8 @@
 //! `AbstractPropertySource` API and `Iterator`.
 //!
 //! `EntitySetIterator<'c>` uses `SourceSet<'c>` and `SourceIterator<'c>` to
-//! evaluate intersections. Sources may be empty, whole-population, index-backed,
-//! singleton, or property-backed. The iterator chooses the smallest source as the driver and
+//! evaluate intersections. Sources may be contiguous-range, index-backed, or
+//! property-backed. The iterator chooses the smallest source as the driver and
 //! checks candidate IDs against remaining sources.
 //!
 //! ## Source ordering and `cost_hint`
@@ -35,21 +35,24 @@
 //! membership/iteration work. It is not a correctness value; it is only used to
 //! break ties when upper bounds are equal.
 //!
-//! | Source kind                  | `cost_hint` |
-//! | ---------------------------- | ----------- |
-//! | `SourceSet::Empty`           | `0`         |
-//! | `SourceSet::Entity`          | `1`         |
-//! | `SourceSet::Population`      | `2`         |
-//! | `SourceSet::IndexSet`        | `3`         |
-//! | `ConcretePropertySource`     | `5`         |
-//! | `DerivedPropertySource`      | `6`         |
+//! | Source kind                           | `cost_hint` |
+//! | ------------------------------------- | ----------- |
+//! | `SourceSet::empty_range()`            | `0`         |
+//! | `SourceSet::singleton(entity_id)`     | `1`         |
+//! | `SourceSet::PopulationRange`          | `2`         |
+//! | `SourceSet::IndexSet`                 | `3`         |
+//! | `ConcretePropertySource`              | `5`         |
+//! | `DerivedPropertySource`               | `6`         |
+//!
+//! (Note: The first two rows are implemented in terms of `SourceSet::PopulationRange`.)
 
 use std::marker::PhantomData;
+use std::ops::Range;
 
-use super::source_iterator::{IndexSetIterator, SourceIterator};
+use super::source_iterator::{IndexSetIterator, PopulationRangeIterator, SourceIterator};
 use crate::entity::index::IndexSetResult;
 use crate::entity::property_value_store_core::RawPropertyValueVec;
-use crate::entity::{ContextEntitiesExt, Entity, EntityId, PopulationIterator};
+use crate::entity::{ContextEntitiesExt, Entity, EntityId};
 use crate::hashing::{one_shot_128, HashValueType, IndexSet};
 use crate::prelude::Property;
 use crate::Context;
@@ -290,12 +293,9 @@ impl<'a, E: Entity, P: Property<E>> Iterator for ConcretePropertySource<'a, E, P
     }
 }
 
-/// Represents the set of `EntityId<E>`s for which a particular `Property` has a particular value.
+/// Represents a concrete source of `EntityId<E>` values used by `EntitySet`.
 pub(crate) enum SourceSet<'a, E: Entity> {
-    Empty,
-    Population(usize),
-    #[allow(dead_code)]
-    Entity(EntityId<E>),
+    PopulationRange(Range<usize>),
     IndexSet(&'a IndexSet<EntityId<E>>),
     PropertySet(BxPropertySource<'a, E>),
 }
@@ -303,9 +303,7 @@ pub(crate) enum SourceSet<'a, E: Entity> {
 impl<'a, E: Entity> Clone for SourceSet<'a, E> {
     fn clone(&self) -> Self {
         match self {
-            Self::Empty => Self::Empty,
-            Self::Population(population) => Self::Population(*population),
-            Self::Entity(entity_id) => Self::Entity(*entity_id),
+            Self::PopulationRange(range) => Self::PopulationRange(range.clone()),
             Self::IndexSet(index_set) => Self::IndexSet(index_set),
             Self::PropertySet(source) => Self::PropertySet(source.clone_box()),
         }
@@ -315,9 +313,9 @@ impl<'a, E: Entity> Clone for SourceSet<'a, E> {
 impl<'a, E: Entity> PartialEq for SourceSet<'a, E> {
     fn eq(&self, other: &Self) -> bool {
         match (self, other) {
-            (Self::Empty, Self::Empty) => true,
-            (Self::Population(left), Self::Population(right)) => left == right,
-            (Self::Entity(left), Self::Entity(right)) => left == right,
+            (Self::PopulationRange(left), Self::PopulationRange(right)) => {
+                left == right || (left.is_empty() && right.is_empty())
+            }
             (Self::IndexSet(left), Self::IndexSet(right)) => std::ptr::eq(&**left, &**right),
             (Self::PropertySet(left), Self::PropertySet(right)) => left.id() == right.id(),
             _ => false,
@@ -328,11 +326,27 @@ impl<'a, E: Entity> PartialEq for SourceSet<'a, E> {
 impl<'a, E: Entity> Eq for SourceSet<'a, E> {}
 
 impl<'a, E: Entity> SourceSet<'a, E> {
+    /// Construct a population-backed source, canonicalizing all logical empty ranges to `0..0`.
+    pub(crate) fn population_range(range: Range<usize>) -> Self {
+        if range.is_empty() {
+            Self::empty()
+        } else {
+            Self::PopulationRange(range)
+        }
+    }
+
+    pub(crate) fn empty() -> Self {
+        Self::PopulationRange(0..0)
+    }
+
+    #[allow(dead_code)]
+    pub(crate) fn singleton(entity_id: EntityId<E>) -> Self {
+        Self::population_range(entity_id.0..entity_id.0 + 1)
+    }
+
     pub(super) fn try_len(&self) -> Option<usize> {
         match self {
-            SourceSet::Empty => Some(0),
-            SourceSet::Population(population) => Some(*population),
-            SourceSet::Entity(_) => Some(1),
+            SourceSet::PopulationRange(range) => Some(range.len()),
             SourceSet::IndexSet(source) => Some(source.len()),
             SourceSet::PropertySet(_) => None,
         }
@@ -341,9 +355,11 @@ impl<'a, E: Entity> SourceSet<'a, E> {
     /// Ordering key used for source selection.
     pub(super) fn sort_key(&self) -> (usize, u8) {
         match self {
-            SourceSet::Empty => (0, 0),
-            SourceSet::Entity(_) => (1, 1),
-            SourceSet::Population(population) => (*population, 2),
+            SourceSet::PopulationRange(range) => match range.len() {
+                0 => (0, 0),
+                1 => (1, 1),
+                len => (len, 2),
+            },
             SourceSet::IndexSet(source) => (source.len(), 3),
             SourceSet::PropertySet(source) => source.sort_key(),
         }
@@ -400,9 +416,7 @@ impl<'a, E: Entity> SourceSet<'a, E> {
 
     pub(super) fn contains(&self, id: EntityId<E>) -> bool {
         match self {
-            SourceSet::Empty => false,
-            SourceSet::Population(population) => id.0 < *population,
-            SourceSet::Entity(entity_id) => *entity_id == id,
+            SourceSet::PopulationRange(range) => range.contains(&id.0),
             SourceSet::IndexSet(source) => source.contains(&id),
             SourceSet::PropertySet(source) => source.contains(id),
         }
@@ -410,14 +424,9 @@ impl<'a, E: Entity> SourceSet<'a, E> {
 
     pub(super) fn into_iter(self) -> SourceIterator<'a, E> {
         match self {
-            SourceSet::Empty => SourceIterator::Empty,
-            SourceSet::Population(population) => {
-                SourceIterator::Population(PopulationIterator::new(population))
+            SourceSet::PopulationRange(range) => {
+                SourceIterator::PopulationRange(PopulationRangeIterator::new(range))
             }
-            SourceSet::Entity(entity_id) => SourceIterator::Entity {
-                id: entity_id,
-                exhausted: false,
-            },
             SourceSet::IndexSet(ids) => {
                 SourceIterator::IndexIter(IndexSetIterator::from_index_set(ids))
             }
@@ -438,32 +447,6 @@ mod tests {
 
     #[test]
     fn source_set_variants_basic_behavior() {
-        let empty = SourceSet::<Person>::Empty;
-        assert_eq!(empty.sort_key(), (0, 0));
-        assert!(!empty.contains(EntityId::new(0)));
-        assert_eq!(empty.into_iter().count(), 0);
-
-        let population = SourceSet::<Person>::Population(3);
-        assert_eq!(population.sort_key(), (3, 2));
-        assert!(population.contains(EntityId::new(0)));
-        assert!(!population.contains(EntityId::new(3)));
-        let population_ids = SourceSet::<Person>::Population(3)
-            .into_iter()
-            .collect::<Vec<_>>();
-        assert_eq!(
-            population_ids,
-            vec![EntityId::new(0), EntityId::new(1), EntityId::new(2)]
-        );
-
-        let singleton = SourceSet::<Person>::Entity(EntityId::new(9));
-        assert_eq!(singleton.sort_key(), (1, 1));
-        assert!(singleton.contains(EntityId::new(9)));
-        assert!(!singleton.contains(EntityId::new(8)));
-        let singleton_ids = SourceSet::<Person>::Entity(EntityId::new(9))
-            .into_iter()
-            .collect::<Vec<_>>();
-        assert_eq!(singleton_ids, vec![EntityId::new(9)]);
-
         let ids = [EntityId::new(1), EntityId::new(4), EntityId::new(8)]
             .into_iter()
             .collect::<IndexSet<_>>();
@@ -472,6 +455,36 @@ mod tests {
         assert_eq!(indexed.sort_key(), (3, 3));
         assert!(indexed.contains(EntityId::new(4)));
         assert!(!indexed.contains(EntityId::new(2)));
+
+        let range = SourceSet::<Person>::population_range(4..7);
+        assert_eq!(range.sort_key(), (3, 2));
+        assert!(range.contains(EntityId::new(4)));
+        assert!(range.contains(EntityId::new(6)));
+        assert!(!range.contains(EntityId::new(3)));
+        assert_eq!(range.try_len(), Some(3));
+        let range_ids = SourceSet::<Person>::population_range(4..7)
+            .into_iter()
+            .collect::<Vec<_>>();
+        assert_eq!(
+            range_ids,
+            vec![EntityId::new(4), EntityId::new(5), EntityId::new(6)]
+        );
+
+        let empty_range = SourceSet::<Person>::empty();
+        assert_eq!(empty_range.sort_key(), (0, 0));
+        assert_eq!(empty_range.try_len(), Some(0));
+        assert!(!empty_range.contains(EntityId::new(0)));
+        assert_eq!(empty_range.into_iter().count(), 0);
+
+        let singleton_range = SourceSet::<Person>::singleton(EntityId::new(9));
+        assert_eq!(singleton_range.sort_key(), (1, 1));
+        assert_eq!(singleton_range.try_len(), Some(1));
+        assert!(singleton_range.contains(EntityId::new(9)));
+        assert!(!singleton_range.contains(EntityId::new(10)));
+        assert_eq!(
+            singleton_range.into_iter().collect::<Vec<_>>(),
+            vec![EntityId::new(9)]
+        );
     }
 
     #[test]

--- a/src/entity/query/query_impls.rs
+++ b/src/entity/query/query_impls.rs
@@ -27,7 +27,9 @@ impl<E: Entity> Query<E> for () {
     }
 
     fn new_query_result<'c>(&self, context: &'c Context) -> EntitySet<'c, E> {
-        EntitySet::from_source(SourceSet::Population(context.get_entity_count::<E>()))
+        EntitySet::from_source(SourceSet::PopulationRange(
+            0..context.get_entity_count::<E>(),
+        ))
     }
 
     fn new_query_result_iterator<'c>(&self, context: &'c Context) -> EntitySetIterator<'c, E> {
@@ -65,7 +67,9 @@ impl<E: Entity + Copy> Query<E> for E {
     }
 
     fn new_query_result<'c>(&self, context: &'c Context) -> EntitySet<'c, E> {
-        EntitySet::from_source(SourceSet::Population(context.get_entity_count::<E>()))
+        EntitySet::from_source(SourceSet::PopulationRange(
+            0..context.get_entity_count::<E>(),
+        ))
     }
 
     fn new_query_result_iterator<'c>(&self, context: &'c Context) -> EntitySetIterator<'c, E> {


### PR DESCRIPTION
# Added `SourceSet::PopulationRange` Variant

This PR consolidates contiguous entity-ID sources around `PopulationRange` and carries that representation through the `entity_set` stack. `SourceSet` no longer has separate empty, whole-population, or singleton variants; those cases are now expressed canonically as ranges, with helper constructors for empty, singleton, and general population ranges. The iterator side was simplified in the same direction: `SourceIterator` now relies on the range-backed path for empty and whole-population iteration, and `EntitySetIteratorInner` no longer has its own dedicated empty variant.

On top of that representation cleanup, `EntitySet` now has basic range-aware set algebra. Unions of overlapping or adjacent ranges collapse to a single range, intersections of ranges collapse to their overlap, and range differences simplify when the result is still empty or one contiguous range; split differences continue to use the generic expression path. The work also removed the older helper-driven empty/universal/singleton reductions that depended on the deleted variants and replaced them with a single `as_range()` helper used only for the new range optimizations.

The branch also updates downstream query construction and tests to match the new canonical form. Empty queries and full-population query results now construct range-backed sources, docs/comments in `entity_set` were refreshed to describe the new model, and the `entity_set`/iterator test coverage was rewritten and expanded to cover canonical empty/singleton/full-population ranges, optimized range operations, and the remaining non-optimized split-difference behavior.

This PR replaces #826.