### PR TITLE
feat: Introduce `DenseEntityMap`, `EntityVec`

### DIFF
--- a/src/data_structures/dense_entity_map.rs
+++ b/src/data_structures/dense_entity_map.rs
@@ -1,0 +1,610 @@
+/*!
+
+A `DenseEntityMap<E, V>` is a map from `EntityId<E>` to values of type `V` with a hash-map-like API
+optimized for densely populated maps.
+
+A `DenseEntityMap` is "dense" in the sense that it uses a vector `Vec<Option<V>>` internally for
+storage, using the `EntityId<E>` to index into the vector. Use a `DenseEntityMap` in any of the
+following cases:
+
+ - The number of entities is small
+ - Most entities are expected to be used as a key
+ - Access or creation speed is important
+ - You want access to the `EntityId<E>` key a value was stored with
+
+A `DenseEntityMap` allocates lazily by default, only allocating enough memory to access the item for
+the largest entity ID stored in the map. If you know beforehand how many entities you expect to
+store, you can use the `DenseEntityMap::with_capacity` constructor or `DenseEntityMap::reserve` to
+preallocate the map, which avoids reallocations.
+
+Because every value added to a `DenseEntityMap` is accompanied by a valid `EntityId<E>`,
+`DenseEntityMap` is guaranteed to only "store" valid entity IDs. You can therefore use it as a
+replacement for `EntityVec<E, V>` (or just `Vec<V>`) for cases where you need to recover the original
+entity ID that a value was stored with, for example, by iterating over the (entity ID, value) pairs
+returned by `DenseEntityMap::iter`. The only cost you pay for this is the extra memory needed to
+store `Option<V>` values instead of `V` values, which in some cases is nothing. The `EntityId<E>`
+itself is not stored.
+
+A `DenseEntityMap<E, V>` can be cheaply converted to an `EntityVec<E, Option<V>>` using the
+`DenseEntityMap::into_entity_vec` method.
+
+## Example
+
+Imagine you have `Person` and `Setting` entities, and you want an efficient way to store for each
+`SettingId` a `Vec<PersonId>` representing all the people that can be found in the setting. It is
+possible to use a `HashMap<SettingId, Vec<PersonId>>` to store this information, but a
+`DenseEntityMap<SettingId, Vec<PersonId>>` would be more efficient.
+
+```rust,ignore
+use ixa::data_structures::DenseEntityMap;
+
+let mut setting_membership = DenseEntityMap::<SettingId, Vec<PersonId>>::new();
+
+// During population initialization you might initialize the map with data in, say, a `PersonRecord`
+// struct that has a `home_id` field of type `SettingId`.
+let person_id = context.add_entity(with!(Person, person_record.age));
+let setting_members = setting_membership.get_or_insert(person_record.home_id, Vec::new);
+setting_members.push(person_id);
+
+// Look-ups are extremely efficient.
+if let Some(setting_members) = setting_membership.get(setting_id){
+    // Do something with the setting members.
+}
+
+// You can also iterate over the (entity ID, value) pairs.
+for (setting_id, setting_members) in setting_membership.iter() {
+    // Do something with the setting and its members.
+}
+```
+
+*/
+
+use std::fmt::{self, Debug};
+use std::iter::FusedIterator;
+use std::marker::PhantomData;
+
+use crate::data_structures::entity_vec::EntityVec;
+use crate::entity::{Entity, EntityId};
+
+/**
+A `Vec`-backed map keyed by `EntityId<E>`.
+*/
+#[derive(Clone, PartialEq, Eq)]
+pub struct DenseEntityMap<E: Entity, V> {
+    data: Vec<Option<V>>,
+    len: usize,
+    _phantom: PhantomData<E>,
+}
+
+impl<E: Entity, V> DenseEntityMap<E, V> {
+    /// Creates an empty `DenseEntityMap`.
+    pub fn new() -> Self {
+        Self {
+            data: Vec::new(),
+            len: 0,
+            _phantom: PhantomData,
+        }
+    }
+
+    /// Creates an empty `DenseEntityMap` with space for at least `capacity` entity IDs.
+    pub fn with_capacity(capacity: usize) -> Self {
+        Self {
+            data: Vec::with_capacity(capacity),
+            len: 0,
+            _phantom: PhantomData,
+        }
+    }
+
+    /// Cheap conversion to an `EntityVec<E, Option<V>>`
+    pub fn into_entity_vec(self) -> EntityVec<E, Option<V>> {
+        self.data.into()
+    }
+
+    /// Returns the number of stored key-value pairs.
+    #[inline]
+    pub fn len(&self) -> usize {
+        self.len
+    }
+
+    /// Returns the capacity of the backing vector.
+    #[inline]
+    pub fn capacity(&self) -> usize {
+        self.data.capacity()
+    }
+
+    /// Returns `true` if the map contains no values.
+    #[inline]
+    pub fn is_empty(&self) -> bool {
+        self.len == 0
+    }
+
+    /// Reserves capacity for at least `additional` more entity IDs.
+    pub fn reserve(&mut self, additional: usize) {
+        self.data.reserve(additional);
+    }
+
+    /// Shrinks the backing vector to fit the highest occupied entity ID.
+    pub fn shrink_to_fit(&mut self) {
+        self.trim_trailing_empty_slots();
+        self.data.shrink_to_fit();
+    }
+
+    /// Returns `true` if `entity_id` is present in the map.
+    pub fn contains_key(&self, entity_id: EntityId<E>) -> bool {
+        self.get(entity_id).is_some()
+    }
+
+    /// Returns the value for `entity_id`, or `None` if not present.
+    pub fn get(&self, entity_id: EntityId<E>) -> Option<&V> {
+        self.data.get(entity_id.0).and_then(Option::as_ref)
+    }
+
+    /// Returns the value for `entity_id` mutably, or `None` if not present.
+    pub fn get_mut(&mut self, entity_id: EntityId<E>) -> Option<&mut V> {
+        self.data.get_mut(entity_id.0).and_then(Option::as_mut)
+    }
+
+    /// Inserts `value` for `entity_id`, returning the previous value if one existed.
+    pub fn insert(&mut self, entity_id: EntityId<E>, value: V) -> Option<V> {
+        if entity_id.0 >= self.data.len() {
+            self.data.resize_with(entity_id.0 + 1, || None);
+        }
+
+        let slot = &mut self.data[entity_id.0];
+        let previous = slot.replace(value);
+        if previous.is_none() {
+            self.len += 1;
+        }
+        previous
+    }
+
+    /// Returns the value for `entity_id`, inserting `value` if it is not already present.
+    pub fn get_or_insert(&mut self, entity_id: EntityId<E>, value: V) -> &mut V {
+        self.get_or_insert_with(entity_id, || value)
+    }
+
+    /// Returns the value for `entity_id`, inserting a value from `f` if it is not already present.
+    pub fn get_or_insert_with<F>(&mut self, entity_id: EntityId<E>, f: F) -> &mut V
+    where
+        F: FnOnce() -> V,
+    {
+        if entity_id.0 >= self.data.len() {
+            self.data.resize_with(entity_id.0 + 1, || None);
+        }
+
+        let slot = &mut self.data[entity_id.0];
+        if slot.is_none() {
+            *slot = Some(f());
+            self.len += 1;
+        }
+
+        slot.as_mut().unwrap()
+    }
+
+    /// Removes and returns the value for `entity_id`, if present.
+    pub fn remove(&mut self, entity_id: EntityId<E>) -> Option<V> {
+        let removed = self.data.get_mut(entity_id.0).and_then(Option::take);
+        if removed.is_some() {
+            self.len -= 1;
+            self.trim_trailing_empty_slots();
+        }
+        removed
+    }
+
+    /// Clears the map, removing all key-value pairs.
+    pub fn clear(&mut self) {
+        self.data.clear();
+        self.len = 0;
+    }
+
+    /// Returns an iterator over `(EntityId<E>, &V)` pairs.
+    pub fn iter(&self) -> Iter<'_, E, V> {
+        Iter {
+            inner: self.data.iter().enumerate(),
+            remaining: self.len,
+            _phantom: PhantomData,
+        }
+    }
+
+    fn trim_trailing_empty_slots(&mut self) {
+        while self.data.last().is_some_and(Option::is_none) {
+            self.data.pop();
+        }
+    }
+}
+
+impl<E: Entity, V> Default for DenseEntityMap<E, V> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl<E: Entity, V: Debug> Debug for DenseEntityMap<E, V> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_map().entries(self.iter()).finish()
+    }
+}
+
+impl<E: Entity, V> Extend<(EntityId<E>, V)> for DenseEntityMap<E, V> {
+    fn extend<I: IntoIterator<Item = (EntityId<E>, V)>>(&mut self, iter: I) {
+        for (entity_id, value) in iter {
+            let _ = self.insert(entity_id, value);
+        }
+    }
+}
+
+impl<E: Entity, V> FromIterator<(EntityId<E>, V)> for DenseEntityMap<E, V> {
+    fn from_iter<I: IntoIterator<Item = (EntityId<E>, V)>>(iter: I) -> Self {
+        let mut map = Self::new();
+        map.extend(iter);
+        map
+    }
+}
+
+impl<'a, E: Entity, V> IntoIterator for &'a DenseEntityMap<E, V> {
+    type Item = (EntityId<E>, &'a V);
+    type IntoIter = Iter<'a, E, V>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.iter()
+    }
+}
+
+/// Iterator over `(EntityId<E>, &V)` pairs from a `DenseEntityMap<E, V>`.
+pub struct Iter<'a, E: Entity, V> {
+    inner: std::iter::Enumerate<std::slice::Iter<'a, Option<V>>>,
+    remaining: usize,
+    _phantom: PhantomData<E>,
+}
+
+impl<'a, E: Entity, V> Iterator for Iter<'a, E, V> {
+    type Item = (EntityId<E>, &'a V);
+
+    fn next(&mut self) -> Option<Self::Item> {
+        for (index, value) in self.inner.by_ref() {
+            if let Some(value) = value.as_ref() {
+                self.remaining -= 1;
+                return Some((EntityId::new(index), value));
+            }
+        }
+        None
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        (self.remaining, Some(self.remaining))
+    }
+
+    fn count(self) -> usize {
+        self.remaining
+    }
+
+    fn nth(&mut self, n: usize) -> Option<Self::Item> {
+        if n >= self.remaining {
+            self.remaining = 0;
+            self.inner.by_ref().for_each(drop);
+            return None;
+        }
+
+        let mut skipped = 0;
+        for (index, value) in self.inner.by_ref() {
+            if let Some(value) = value.as_ref() {
+                if skipped == n {
+                    self.remaining -= n + 1;
+                    return Some((EntityId::new(index), value));
+                }
+                skipped += 1;
+            }
+        }
+
+        self.remaining = 0;
+        None
+    }
+}
+
+impl<'a, E: Entity, V> ExactSizeIterator for Iter<'a, E, V> {
+    fn len(&self) -> usize {
+        self.remaining
+    }
+}
+
+impl<'a, E: Entity, V> FusedIterator for Iter<'a, E, V> {}
+
+#[cfg(test)]
+mod tests {
+    use super::DenseEntityMap;
+    use crate::define_entity;
+    use crate::entity::EntityId;
+
+    define_entity!(TestEntity);
+
+    #[test]
+    fn new_is_empty() {
+        let map = DenseEntityMap::<TestEntity, i32>::new();
+
+        assert_eq!(map.len(), 0);
+        assert!(map.is_empty());
+        assert_eq!(map.capacity(), 0);
+    }
+
+    #[test]
+    fn with_capacity_sets_initial_capacity() {
+        let map = DenseEntityMap::<TestEntity, i32>::with_capacity(8);
+
+        assert_eq!(map.len(), 0);
+        assert!(map.capacity() >= 8);
+    }
+
+    #[test]
+    fn insert_and_get_work_for_sparse_ids() {
+        let mut map = DenseEntityMap::<TestEntity, &'static str>::new();
+        let id2 = EntityId::new(2);
+        let id5 = EntityId::new(5);
+
+        assert_eq!(map.insert(id2, "two"), None);
+        assert_eq!(map.insert(id5, "five"), None);
+
+        assert_eq!(map.len(), 2);
+        assert!(!map.is_empty());
+        assert_eq!(map.get(EntityId::new(0)), None);
+        assert_eq!(map.get(id2), Some(&"two"));
+        assert_eq!(map.get(id5), Some(&"five"));
+        assert_eq!(map.get(EntityId::new(6)), None);
+    }
+
+    #[test]
+    fn insert_replaces_existing_value_without_changing_len() {
+        let mut map = DenseEntityMap::<TestEntity, i32>::new();
+        let id = EntityId::new(3);
+
+        assert_eq!(map.insert(id, 10), None);
+        assert_eq!(map.insert(id, 20), Some(10));
+
+        assert_eq!(map.len(), 1);
+        assert_eq!(map.get(id), Some(&20));
+    }
+
+    #[test]
+    fn get_mut_updates_value() {
+        let mut map = DenseEntityMap::<TestEntity, i32>::new();
+        let id = EntityId::new(1);
+        let _ = map.insert(id, 10);
+
+        *map.get_mut(id).unwrap() = 99;
+
+        assert_eq!(map.get(id), Some(&99));
+        assert_eq!(map.get_mut(EntityId::new(7)), None);
+    }
+
+    #[test]
+    fn get_or_insert_inserts_missing_value_and_returns_mutable_reference() {
+        let mut map = DenseEntityMap::<TestEntity, i32>::new();
+        let id = EntityId::new(3);
+
+        let value = map.get_or_insert(id, 10);
+        *value = 15;
+
+        assert_eq!(map.len(), 1);
+        assert_eq!(map.get(id), Some(&15));
+    }
+
+    #[test]
+    fn get_or_insert_does_not_replace_existing_value() {
+        let mut map = DenseEntityMap::<TestEntity, i32>::new();
+        let id = EntityId::new(2);
+        let _ = map.insert(id, 20);
+
+        let value = map.get_or_insert(id, 99);
+
+        assert_eq!(*value, 20);
+        assert_eq!(map.len(), 1);
+        assert_eq!(map.get(id), Some(&20));
+    }
+
+    #[test]
+    fn get_or_insert_with_only_evaluates_closure_for_missing_key() {
+        let mut map = DenseEntityMap::<TestEntity, i32>::new();
+        let missing_id = EntityId::new(1);
+        let existing_id = EntityId::new(4);
+        let _ = map.insert(existing_id, 40);
+        let mut calls = 0;
+
+        let inserted = map.get_or_insert_with(missing_id, || {
+            calls += 1;
+            10
+        });
+        assert_eq!(*inserted, 10);
+
+        let existing = map.get_or_insert_with(existing_id, || {
+            calls += 1;
+            99
+        });
+        assert_eq!(*existing, 40);
+
+        assert_eq!(calls, 1);
+        assert_eq!(map.len(), 2);
+    }
+
+    #[test]
+    fn contains_key_tracks_presence() {
+        let mut map = DenseEntityMap::<TestEntity, i32>::new();
+        let id = EntityId::new(4);
+
+        assert!(!map.contains_key(id));
+        let _ = map.insert(id, 12);
+        assert!(map.contains_key(id));
+        assert!(!map.contains_key(EntityId::new(3)));
+    }
+
+    #[test]
+    fn remove_returns_value_and_decrements_len() {
+        let mut map = DenseEntityMap::<TestEntity, i32>::new();
+        let id1 = EntityId::new(1);
+        let id4 = EntityId::new(4);
+        let _ = map.insert(id1, 10);
+        let _ = map.insert(id4, 40);
+
+        assert_eq!(map.remove(id1), Some(10));
+        assert_eq!(map.remove(id1), None);
+
+        assert_eq!(map.len(), 1);
+        assert_eq!(map.get(id1), None);
+        assert_eq!(map.get(id4), Some(&40));
+    }
+
+    #[test]
+    fn remove_highest_key_removes_entry_cleanly() {
+        let mut map = DenseEntityMap::<TestEntity, i32>::new();
+        let _ = map.insert(EntityId::new(1), 10);
+        let _ = map.insert(EntityId::new(8), 80);
+
+        assert_eq!(map.remove(EntityId::new(8)), Some(80));
+        assert_eq!(map.remove(EntityId::new(1)), Some(10));
+
+        assert_eq!(map.len(), 0);
+        assert!(map.is_empty());
+        assert!(!map.contains_key(EntityId::new(1)));
+        assert_eq!(map.get(EntityId::new(8)), None);
+    }
+
+    #[test]
+    fn clear_removes_all_entries() {
+        let mut map = DenseEntityMap::<TestEntity, i32>::new();
+        let _ = map.insert(EntityId::new(0), 1);
+        let _ = map.insert(EntityId::new(2), 2);
+
+        map.clear();
+
+        assert!(map.is_empty());
+        assert_eq!(map.len(), 0);
+        assert_eq!(map.get(EntityId::new(0)), None);
+        assert_eq!(map.get(EntityId::new(2)), None);
+    }
+
+    #[test]
+    fn reserve_and_shrink_to_fit_manage_capacity() {
+        let mut map = DenseEntityMap::<TestEntity, i32>::new();
+        map.reserve(16);
+        assert!(map.capacity() >= 16);
+
+        let _ = map.insert(EntityId::new(10), 10);
+        let _ = map.insert(EntityId::new(20), 20);
+        assert_eq!(map.remove(EntityId::new(20)), Some(20));
+
+        map.shrink_to_fit();
+
+        assert_eq!(map.len(), 1);
+        assert_eq!(map.get(EntityId::new(10)), Some(&10));
+        assert_eq!(map.get(EntityId::new(20)), None);
+        assert!(map.capacity() >= 11);
+    }
+
+    #[test]
+    fn iter_yields_only_present_entries_in_entity_id_order() {
+        let mut map = DenseEntityMap::<TestEntity, &'static str>::new();
+        let _ = map.insert(EntityId::new(3), "three");
+        let _ = map.insert(EntityId::new(0), "zero");
+        let _ = map.insert(EntityId::new(5), "five");
+
+        let items: Vec<_> = map.iter().collect();
+
+        assert_eq!(
+            items,
+            vec![
+                (EntityId::new(0), &"zero"),
+                (EntityId::new(3), &"three"),
+                (EntityId::new(5), &"five"),
+            ]
+        );
+    }
+
+    #[test]
+    fn iter_size_hint_len_and_count_track_remaining_entries() {
+        let mut map = DenseEntityMap::<TestEntity, i32>::new();
+        let _ = map.insert(EntityId::new(1), 10);
+        let _ = map.insert(EntityId::new(4), 40);
+        let _ = map.insert(EntityId::new(7), 70);
+
+        let mut iter = map.iter();
+        assert_eq!(iter.size_hint(), (3, Some(3)));
+        assert_eq!(iter.len(), 3);
+
+        assert_eq!(iter.next(), Some((EntityId::new(1), &10)));
+        assert_eq!(iter.size_hint(), (2, Some(2)));
+        assert_eq!(iter.len(), 2);
+        assert_eq!(iter.count(), 2);
+    }
+
+    #[test]
+    fn iter_nth_skips_missing_entries_and_updates_remaining_len() {
+        let mut map = DenseEntityMap::<TestEntity, i32>::new();
+        let _ = map.insert(EntityId::new(2), 20);
+        let _ = map.insert(EntityId::new(5), 50);
+        let _ = map.insert(EntityId::new(8), 80);
+
+        let mut iter = map.iter();
+        assert_eq!(iter.nth(1), Some((EntityId::new(5), &50)));
+        assert_eq!(iter.len(), 1);
+        assert_eq!(iter.next(), Some((EntityId::new(8), &80)));
+        assert_eq!(iter.next(), None);
+        assert_eq!(iter.next(), None);
+    }
+
+    #[test]
+    fn iter_nth_past_end_returns_none_and_exhausts_iterator() {
+        let mut map = DenseEntityMap::<TestEntity, i32>::new();
+        let _ = map.insert(EntityId::new(1), 10);
+        let _ = map.insert(EntityId::new(3), 30);
+
+        let mut iter = map.iter();
+        assert_eq!(iter.nth(2), None);
+        assert_eq!(iter.len(), 0);
+        assert_eq!(iter.next(), None);
+    }
+
+    #[test]
+    fn debug_formats_like_a_map() {
+        let mut map = DenseEntityMap::<TestEntity, i32>::new();
+        let _ = map.insert(EntityId::new(1), 10);
+        let _ = map.insert(EntityId::new(4), 40);
+
+        assert_eq!(
+            format!("{:?}", map),
+            "{TestEntityId(1): 10, TestEntityId(4): 40}"
+        );
+    }
+
+    #[test]
+    fn default_matches_new() {
+        let map = DenseEntityMap::<TestEntity, i32>::default();
+
+        assert!(map.is_empty());
+        assert_eq!(map.len(), 0);
+    }
+
+    #[test]
+    fn extend_and_from_iter_insert_all_entries() {
+        let entries = vec![(EntityId::new(2), 20), (EntityId::new(5), 50)];
+
+        let mut map = DenseEntityMap::<TestEntity, i32>::new();
+        map.extend(entries.clone());
+        assert_eq!(map.get(EntityId::new(2)), Some(&20));
+        assert_eq!(map.get(EntityId::new(5)), Some(&50));
+
+        let collected = DenseEntityMap::<TestEntity, i32>::from_iter(entries);
+        assert_eq!(collected.get(EntityId::new(2)), Some(&20));
+        assert_eq!(collected.get(EntityId::new(5)), Some(&50));
+        assert_eq!(collected.len(), 2);
+    }
+
+    #[test]
+    fn into_iterator_for_reference_matches_iter() {
+        let mut map = DenseEntityMap::<TestEntity, i32>::new();
+        let _ = map.insert(EntityId::new(0), 10);
+        let _ = map.insert(EntityId::new(2), 20);
+
+        let from_iter: Vec<_> = map.iter().collect();
+        let from_into_iter: Vec<_> = (&map).into_iter().collect();
+
+        assert_eq!(from_iter, from_into_iter);
+    }
+}

--- a/src/data_structures/entity_map.rs
+++ b/src/data_structures/entity_map.rs
@@ -1,10 +1,10 @@
 /*!
 
-A `DenseEntityMap<E, V>` is a map from `EntityId<E>` to values of type `V` with a hash-map-like API
+An `EntityMap<E, V>` is a map from `EntityId<E>` to values of type `V` with a hash-map-like API
 optimized for densely populated maps.
 
-A `DenseEntityMap` is "dense" in the sense that it uses a vector `Vec<Option<V>>` internally for
-storage, using the `EntityId<E>` to index into the vector. Use a `DenseEntityMap` in any of the
+An `EntityMap` is "dense" in the sense that it uses a vector `Vec<Option<V>>` internally for
+storage, using the `EntityId<E>` to index into the vector. Use an `EntityMap` in any of the
 following cases:
 
  - The number of entities is small
@@ -12,33 +12,32 @@ following cases:
  - Access or creation speed is important
  - You want access to the `EntityId<E>` key a value was stored with
 
-A `DenseEntityMap` allocates lazily by default, only allocating enough memory to access the item for
-the largest entity ID stored in the map. If you know beforehand how many entities you expect to
-store, you can use the `DenseEntityMap::with_capacity` constructor or `DenseEntityMap::reserve` to
-preallocate the map, which avoids reallocations.
+If you know beforehand how many entities you expect to store, use the `EntityMap::with_capacity`
+constructor or `EntityMap::reserve` to preallocate the map, as that is more efficient than letting
+it lazily reallocate as needed.
 
-Because every value added to a `DenseEntityMap` is accompanied by a valid `EntityId<E>`,
-`DenseEntityMap` is guaranteed to only "store" valid entity IDs. You can therefore use it as a
-replacement for `EntityVec<E, V>` (or just `Vec<V>`) for cases where you need to recover the original
-entity ID that a value was stored with, for example, by iterating over the (entity ID, value) pairs
-returned by `DenseEntityMap::iter`. The only cost you pay for this is the extra memory needed to
-store `Option<V>` values instead of `V` values, which in some cases is nothing. The `EntityId<E>`
-itself is not stored.
+Because every value added to an `EntityMap` is accompanied by a valid `EntityId<E>`, `EntityMap` is
+guaranteed to only "store" valid entity IDs. You can therefore use it as a replacement for
+`EntityVec<E, V>` (or just `Vec<V>`) for cases where you need to recover the original entity ID that
+a value was stored with, for example, by iterating over the (entity ID, value) pairs returned by
+`EntityMap::iter`. The only cost you pay for this is the extra memory needed to store `Option<V>`
+values instead of `V` values, which in some cases is nothing. The `EntityId<E>` itself is not
+stored.
 
-A `DenseEntityMap<E, V>` can be cheaply converted to an `EntityVec<E, Option<V>>` using the
-`DenseEntityMap::into_entity_vec` method.
+An `EntityMap<E, V>` can be cheaply converted to an `EntityVec<E, Option<V>>` using the
+`EntityMap::into_entity_vec` method.
 
 ## Example
 
 Imagine you have `Person` and `Setting` entities, and you want an efficient way to store for each
 `SettingId` a `Vec<PersonId>` representing all the people that can be found in the setting. It is
-possible to use a `HashMap<SettingId, Vec<PersonId>>` to store this information, but a
-`DenseEntityMap<SettingId, Vec<PersonId>>` would be more efficient.
+possible to use a `HashMap<SettingId, Vec<PersonId>>` to store this information, but an
+`EntityMap<SettingId, Vec<PersonId>>` is more efficient.
 
 ```rust,ignore
-use ixa::data_structures::DenseEntityMap;
+use ixa::data_structures::entity_map::EntityMap;
 
-let mut setting_membership = DenseEntityMap::<SettingId, Vec<PersonId>>::new();
+let mut setting_membership = EntityMap::<SettingId, Vec<PersonId>>::new();
 
 // During population initialization you might initialize the map with data in, say, a `PersonRecord`
 // struct that has a `home_id` field of type `SettingId`.
@@ -66,18 +65,16 @@ use std::marker::PhantomData;
 use crate::data_structures::entity_vec::EntityVec;
 use crate::entity::{Entity, EntityId};
 
-/**
-A `Vec`-backed map keyed by `EntityId<E>`.
-*/
+/// A `Vec`-backed map keyed by `EntityId<E>`.
 #[derive(Clone, PartialEq, Eq)]
-pub struct DenseEntityMap<E: Entity, V> {
+pub struct EntityMap<E: Entity, V> {
     data: Vec<Option<V>>,
     len: usize,
     _phantom: PhantomData<E>,
 }
 
-impl<E: Entity, V> DenseEntityMap<E, V> {
-    /// Creates an empty `DenseEntityMap`.
+impl<E: Entity, V> EntityMap<E, V> {
+    /// Creates an empty `EntityMap`.
     pub fn new() -> Self {
         Self {
             data: Vec::new(),
@@ -86,7 +83,7 @@ impl<E: Entity, V> DenseEntityMap<E, V> {
         }
     }
 
-    /// Creates an empty `DenseEntityMap` with space for at least `capacity` entity IDs.
+    /// Creates an empty `EntityMap` with space for at least `capacity` values.
     pub fn with_capacity(capacity: usize) -> Self {
         Self {
             data: Vec::with_capacity(capacity),
@@ -106,7 +103,7 @@ impl<E: Entity, V> DenseEntityMap<E, V> {
         self.len
     }
 
-    /// Returns the capacity of the backing vector.
+    /// Returns the capacity of the backing storage.
     #[inline]
     pub fn capacity(&self) -> usize {
         self.data.capacity()
@@ -118,14 +115,16 @@ impl<E: Entity, V> DenseEntityMap<E, V> {
         self.len == 0
     }
 
-    /// Reserves capacity for at least `additional` more entity IDs.
+    /// Reserves capacity for at least `additional` more values.
     pub fn reserve(&mut self, additional: usize) {
         self.data.reserve(additional);
     }
 
     /// Shrinks the backing vector to fit the highest occupied entity ID.
     pub fn shrink_to_fit(&mut self) {
-        self.trim_trailing_empty_slots();
+        while self.data.last().is_some_and(Option::is_none) {
+            self.data.pop();
+        }
         self.data.shrink_to_fit();
     }
 
@@ -186,7 +185,6 @@ impl<E: Entity, V> DenseEntityMap<E, V> {
         let removed = self.data.get_mut(entity_id.0).and_then(Option::take);
         if removed.is_some() {
             self.len -= 1;
-            self.trim_trailing_empty_slots();
         }
         removed
     }
@@ -205,27 +203,21 @@ impl<E: Entity, V> DenseEntityMap<E, V> {
             _phantom: PhantomData,
         }
     }
-
-    fn trim_trailing_empty_slots(&mut self) {
-        while self.data.last().is_some_and(Option::is_none) {
-            self.data.pop();
-        }
-    }
 }
 
-impl<E: Entity, V> Default for DenseEntityMap<E, V> {
+impl<E: Entity, V> Default for EntityMap<E, V> {
     fn default() -> Self {
         Self::new()
     }
 }
 
-impl<E: Entity, V: Debug> Debug for DenseEntityMap<E, V> {
+impl<E: Entity, V: Debug> Debug for EntityMap<E, V> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_map().entries(self.iter()).finish()
     }
 }
 
-impl<E: Entity, V> Extend<(EntityId<E>, V)> for DenseEntityMap<E, V> {
+impl<E: Entity, V> Extend<(EntityId<E>, V)> for EntityMap<E, V> {
     fn extend<I: IntoIterator<Item = (EntityId<E>, V)>>(&mut self, iter: I) {
         for (entity_id, value) in iter {
             let _ = self.insert(entity_id, value);
@@ -233,7 +225,7 @@ impl<E: Entity, V> Extend<(EntityId<E>, V)> for DenseEntityMap<E, V> {
     }
 }
 
-impl<E: Entity, V> FromIterator<(EntityId<E>, V)> for DenseEntityMap<E, V> {
+impl<E: Entity, V> FromIterator<(EntityId<E>, V)> for EntityMap<E, V> {
     fn from_iter<I: IntoIterator<Item = (EntityId<E>, V)>>(iter: I) -> Self {
         let mut map = Self::new();
         map.extend(iter);
@@ -241,7 +233,7 @@ impl<E: Entity, V> FromIterator<(EntityId<E>, V)> for DenseEntityMap<E, V> {
     }
 }
 
-impl<'a, E: Entity, V> IntoIterator for &'a DenseEntityMap<E, V> {
+impl<'a, E: Entity, V> IntoIterator for &'a EntityMap<E, V> {
     type Item = (EntityId<E>, &'a V);
     type IntoIter = Iter<'a, E, V>;
 
@@ -250,7 +242,7 @@ impl<'a, E: Entity, V> IntoIterator for &'a DenseEntityMap<E, V> {
     }
 }
 
-/// Iterator over `(EntityId<E>, &V)` pairs from a `DenseEntityMap<E, V>`.
+/// Iterator over `(EntityId<E>, &V)` pairs from an `EntityMap<E, V>`.
 pub struct Iter<'a, E: Entity, V> {
     inner: std::iter::Enumerate<std::slice::Iter<'a, Option<V>>>,
     remaining: usize,
@@ -311,7 +303,7 @@ impl<'a, E: Entity, V> FusedIterator for Iter<'a, E, V> {}
 
 #[cfg(test)]
 mod tests {
-    use super::DenseEntityMap;
+    use super::EntityMap;
     use crate::define_entity;
     use crate::entity::EntityId;
 
@@ -319,7 +311,7 @@ mod tests {
 
     #[test]
     fn new_is_empty() {
-        let map = DenseEntityMap::<TestEntity, i32>::new();
+        let map = EntityMap::<TestEntity, i32>::new();
 
         assert_eq!(map.len(), 0);
         assert!(map.is_empty());
@@ -328,7 +320,7 @@ mod tests {
 
     #[test]
     fn with_capacity_sets_initial_capacity() {
-        let map = DenseEntityMap::<TestEntity, i32>::with_capacity(8);
+        let map = EntityMap::<TestEntity, i32>::with_capacity(8);
 
         assert_eq!(map.len(), 0);
         assert!(map.capacity() >= 8);
@@ -336,7 +328,7 @@ mod tests {
 
     #[test]
     fn insert_and_get_work_for_sparse_ids() {
-        let mut map = DenseEntityMap::<TestEntity, &'static str>::new();
+        let mut map = EntityMap::<TestEntity, &'static str>::new();
         let id2 = EntityId::new(2);
         let id5 = EntityId::new(5);
 
@@ -353,7 +345,7 @@ mod tests {
 
     #[test]
     fn insert_replaces_existing_value_without_changing_len() {
-        let mut map = DenseEntityMap::<TestEntity, i32>::new();
+        let mut map = EntityMap::<TestEntity, i32>::new();
         let id = EntityId::new(3);
 
         assert_eq!(map.insert(id, 10), None);
@@ -365,7 +357,7 @@ mod tests {
 
     #[test]
     fn get_mut_updates_value() {
-        let mut map = DenseEntityMap::<TestEntity, i32>::new();
+        let mut map = EntityMap::<TestEntity, i32>::new();
         let id = EntityId::new(1);
         let _ = map.insert(id, 10);
 
@@ -377,7 +369,7 @@ mod tests {
 
     #[test]
     fn get_or_insert_inserts_missing_value_and_returns_mutable_reference() {
-        let mut map = DenseEntityMap::<TestEntity, i32>::new();
+        let mut map = EntityMap::<TestEntity, i32>::new();
         let id = EntityId::new(3);
 
         let value = map.get_or_insert(id, 10);
@@ -389,7 +381,7 @@ mod tests {
 
     #[test]
     fn get_or_insert_does_not_replace_existing_value() {
-        let mut map = DenseEntityMap::<TestEntity, i32>::new();
+        let mut map = EntityMap::<TestEntity, i32>::new();
         let id = EntityId::new(2);
         let _ = map.insert(id, 20);
 
@@ -402,7 +394,7 @@ mod tests {
 
     #[test]
     fn get_or_insert_with_only_evaluates_closure_for_missing_key() {
-        let mut map = DenseEntityMap::<TestEntity, i32>::new();
+        let mut map = EntityMap::<TestEntity, i32>::new();
         let missing_id = EntityId::new(1);
         let existing_id = EntityId::new(4);
         let _ = map.insert(existing_id, 40);
@@ -426,7 +418,7 @@ mod tests {
 
     #[test]
     fn contains_key_tracks_presence() {
-        let mut map = DenseEntityMap::<TestEntity, i32>::new();
+        let mut map = EntityMap::<TestEntity, i32>::new();
         let id = EntityId::new(4);
 
         assert!(!map.contains_key(id));
@@ -437,7 +429,7 @@ mod tests {
 
     #[test]
     fn remove_returns_value_and_decrements_len() {
-        let mut map = DenseEntityMap::<TestEntity, i32>::new();
+        let mut map = EntityMap::<TestEntity, i32>::new();
         let id1 = EntityId::new(1);
         let id4 = EntityId::new(4);
         let _ = map.insert(id1, 10);
@@ -452,23 +444,22 @@ mod tests {
     }
 
     #[test]
-    fn remove_highest_key_removes_entry_cleanly() {
-        let mut map = DenseEntityMap::<TestEntity, i32>::new();
+    fn remove_missing_key_returns_none_without_changing_len() {
+        let mut map = EntityMap::<TestEntity, i32>::new();
         let _ = map.insert(EntityId::new(1), 10);
         let _ = map.insert(EntityId::new(8), 80);
 
-        assert_eq!(map.remove(EntityId::new(8)), Some(80));
-        assert_eq!(map.remove(EntityId::new(1)), Some(10));
+        assert_eq!(map.remove(EntityId::new(4)), None);
 
-        assert_eq!(map.len(), 0);
-        assert!(map.is_empty());
-        assert!(!map.contains_key(EntityId::new(1)));
-        assert_eq!(map.get(EntityId::new(8)), None);
+        assert_eq!(map.len(), 2);
+        assert!(!map.is_empty());
+        assert_eq!(map.get(EntityId::new(1)), Some(&10));
+        assert_eq!(map.get(EntityId::new(8)), Some(&80));
     }
 
     #[test]
     fn clear_removes_all_entries() {
-        let mut map = DenseEntityMap::<TestEntity, i32>::new();
+        let mut map = EntityMap::<TestEntity, i32>::new();
         let _ = map.insert(EntityId::new(0), 1);
         let _ = map.insert(EntityId::new(2), 2);
 
@@ -482,7 +473,7 @@ mod tests {
 
     #[test]
     fn reserve_and_shrink_to_fit_manage_capacity() {
-        let mut map = DenseEntityMap::<TestEntity, i32>::new();
+        let mut map = EntityMap::<TestEntity, i32>::new();
         map.reserve(16);
         assert!(map.capacity() >= 16);
 
@@ -500,7 +491,7 @@ mod tests {
 
     #[test]
     fn iter_yields_only_present_entries_in_entity_id_order() {
-        let mut map = DenseEntityMap::<TestEntity, &'static str>::new();
+        let mut map = EntityMap::<TestEntity, &'static str>::new();
         let _ = map.insert(EntityId::new(3), "three");
         let _ = map.insert(EntityId::new(0), "zero");
         let _ = map.insert(EntityId::new(5), "five");
@@ -519,7 +510,7 @@ mod tests {
 
     #[test]
     fn iter_size_hint_len_and_count_track_remaining_entries() {
-        let mut map = DenseEntityMap::<TestEntity, i32>::new();
+        let mut map = EntityMap::<TestEntity, i32>::new();
         let _ = map.insert(EntityId::new(1), 10);
         let _ = map.insert(EntityId::new(4), 40);
         let _ = map.insert(EntityId::new(7), 70);
@@ -536,7 +527,7 @@ mod tests {
 
     #[test]
     fn iter_nth_skips_missing_entries_and_updates_remaining_len() {
-        let mut map = DenseEntityMap::<TestEntity, i32>::new();
+        let mut map = EntityMap::<TestEntity, i32>::new();
         let _ = map.insert(EntityId::new(2), 20);
         let _ = map.insert(EntityId::new(5), 50);
         let _ = map.insert(EntityId::new(8), 80);
@@ -551,7 +542,7 @@ mod tests {
 
     #[test]
     fn iter_nth_past_end_returns_none_and_exhausts_iterator() {
-        let mut map = DenseEntityMap::<TestEntity, i32>::new();
+        let mut map = EntityMap::<TestEntity, i32>::new();
         let _ = map.insert(EntityId::new(1), 10);
         let _ = map.insert(EntityId::new(3), 30);
 
@@ -563,7 +554,7 @@ mod tests {
 
     #[test]
     fn debug_formats_like_a_map() {
-        let mut map = DenseEntityMap::<TestEntity, i32>::new();
+        let mut map = EntityMap::<TestEntity, i32>::new();
         let _ = map.insert(EntityId::new(1), 10);
         let _ = map.insert(EntityId::new(4), 40);
 
@@ -575,7 +566,7 @@ mod tests {
 
     #[test]
     fn default_matches_new() {
-        let map = DenseEntityMap::<TestEntity, i32>::default();
+        let map = EntityMap::<TestEntity, i32>::default();
 
         assert!(map.is_empty());
         assert_eq!(map.len(), 0);
@@ -585,12 +576,12 @@ mod tests {
     fn extend_and_from_iter_insert_all_entries() {
         let entries = vec![(EntityId::new(2), 20), (EntityId::new(5), 50)];
 
-        let mut map = DenseEntityMap::<TestEntity, i32>::new();
+        let mut map = EntityMap::<TestEntity, i32>::new();
         map.extend(entries.clone());
         assert_eq!(map.get(EntityId::new(2)), Some(&20));
         assert_eq!(map.get(EntityId::new(5)), Some(&50));
 
-        let collected = DenseEntityMap::<TestEntity, i32>::from_iter(entries);
+        let collected = EntityMap::<TestEntity, i32>::from_iter(entries);
         assert_eq!(collected.get(EntityId::new(2)), Some(&20));
         assert_eq!(collected.get(EntityId::new(5)), Some(&50));
         assert_eq!(collected.len(), 2);
@@ -598,7 +589,7 @@ mod tests {
 
     #[test]
     fn into_iterator_for_reference_matches_iter() {
-        let mut map = DenseEntityMap::<TestEntity, i32>::new();
+        let mut map = EntityMap::<TestEntity, i32>::new();
         let _ = map.insert(EntityId::new(0), 10);
         let _ = map.insert(EntityId::new(2), 20);
 

--- a/src/data_structures/entity_vec.rs
+++ b/src/data_structures/entity_vec.rs
@@ -11,9 +11,9 @@ construct an `EntityId<E>` value itself, because it does not guarantee that its 
 exceed the range of valid `EntityId<E>` values. This allows methods like `EntityVec::push` and
 `EntityVec::extend` that extend the length of the vector to remain unconstrained. If you need to be
 able to retrieve the `EntityId<E>` that a value is associated with (e.g. by iterating over
-(entity ID, value) pairs), use a [`DenseEntityMap`](super::dense_entity_map::DenseEntityMap) instead.
+(entity ID, value) pairs), use an [`EntityMap`](super::entity_map::EntityMap) instead.
 
-For a hash-map-like API, see [`DenseEntityMap`](super::dense_entity_map::DenseEntityMap).
+For a hash-map-like API, see [`EntityMap`](super::entity_map::EntityMap).
 
 ## Example
 

--- a/src/data_structures/entity_vec.rs
+++ b/src/data_structures/entity_vec.rs
@@ -1,0 +1,497 @@
+/*!
+
+An `EntityVec<E: Entity, V>` is a vector of values of type `V` that can only be indexed by keys of
+type `EntityId<E>`.
+
+An `EntityVec<E: Entity, V>` is a thin wrapper around a `Vec<V>` that enforces type safety of the
+indexing (key) values. The most common `Vec<V>` methods are implemented.
+
+Importantly, while `EntityVec<E: Entity, V>` can be _indexed_ by an `EntityId<E>` value, it cannot
+construct an `EntityId<E>` value itself, because it does not guarantee that its length does not
+exceed the range of valid `EntityId<E>` values. This allows methods like `EntityVec::push` and
+`EntityVec::extend` that extend the length of the vector to remain unconstrained. If you need to be
+able to retrieve the `EntityId<E>` that a value is associated with (e.g. by iterating over
+(entity ID, value) pairs), use a [`DenseEntityMap`](super::dense_entity_map::DenseEntityMap) instead.
+
+For a hash-map-like API, see [`DenseEntityMap`](super::dense_entity_map::DenseEntityMap).
+
+## Example
+
+Imagine you have a `Person` entity, and you want an efficient way to store for each `PersonId` a
+`Vec<Itinerary>` representing different itineraries associated with that person. You might
+initialize `itineraries_by_person: EntityVec<Person, Vec<Itinerary>>` during population creation, by
+subscribing to the `EntityCreationEvent<Person>` event, or as a separate iteration over an existing
+population.
+
+```rust,ignore
+use ixa::data_structures::entity_vec::EntityVec;
+
+let mut itineraries_by_person: EntityVec<Person, Vec<Itinerary>> = EntityVec::new();
+
+// Populate in entity-id order. For example, this could be done while creating people
+// or while iterating over an existing population.
+for person_id in context.get_entity_iterator::<Person>() {
+    let itinerary_list = compute_itineraries_for_person(person_id);
+    itineraries_by_person.push(itinerary_list);
+}
+
+// Later, given an existing PersonId:
+let person_id: PersonId = /* fetch the `PersonId` somehow. */;
+
+if let Some(itineraries) = itineraries_by_person.get_mut(person_id) {
+    itineraries.push(/* some Itinerary */);
+}
+```
+
+*/
+
+use std::fmt::{self, Debug};
+use std::marker::PhantomData;
+use std::ops::{Index, IndexMut};
+
+use crate::entity::{Entity, EntityId};
+
+/**
+A `Vec`-backed collection indexed by `EntityId<E>`.
+*/
+#[derive(Clone, PartialEq, Eq, Hash)]
+pub struct EntityVec<E: Entity, V> {
+    data: Vec<V>,
+    _phantom: PhantomData<E>,
+}
+
+impl<E: Entity, V> EntityVec<E, V> {
+    /// Creates an empty `EntityVec`.
+    pub fn new() -> Self {
+        Self {
+            data: Vec::new(),
+            _phantom: PhantomData,
+        }
+    }
+
+    /// Creates an empty `EntityVec` with space for at least `capacity` items.
+    pub fn with_capacity(capacity: usize) -> Self {
+        Self {
+            data: Vec::with_capacity(capacity),
+            _phantom: PhantomData,
+        }
+    }
+
+    /// Returns the number of values stored.
+    #[inline]
+    pub fn len(&self) -> usize {
+        self.data.len()
+    }
+
+    /// Returns the capacity of the backing vector.
+    #[inline]
+    pub fn capacity(&self) -> usize {
+        self.data.capacity()
+    }
+
+    /// Returns `true` if no values are stored.
+    #[inline]
+    pub fn is_empty(&self) -> bool {
+        self.data.is_empty()
+    }
+
+    /// Reserves capacity for at least `additional` more values.
+    pub fn reserve(&mut self, additional: usize) {
+        self.data.reserve(additional);
+    }
+
+    /// Shrinks the backing vector to fit its length.
+    pub fn shrink_to_fit(&mut self) {
+        self.data.shrink_to_fit();
+    }
+
+    /// Appends `value` to the end of the vector.
+    pub fn push(&mut self, value: V) {
+        self.data.push(value);
+    }
+
+    /// Removes and returns the last value, or `None` if empty.
+    pub fn pop(&mut self) -> Option<V> {
+        self.data.pop()
+    }
+
+    /// Returns the value for `entity_id`, or `None` if this vector is not long enough.
+    pub fn get(&self, entity_id: EntityId<E>) -> Option<&V> {
+        self.data.get(entity_id.0)
+    }
+
+    /// Returns the mutable value for `entity_id`, or `None` if this vector is not long enough.
+    pub fn get_mut(&mut self, entity_id: EntityId<E>) -> Option<&mut V> {
+        self.data.get_mut(entity_id.0)
+    }
+
+    /// Returns the last value, or `None` if empty.
+    pub fn last(&self) -> Option<&V> {
+        self.data.last()
+    }
+
+    /// Returns the last value mutably, or `None` if empty.
+    pub fn last_mut(&mut self) -> Option<&mut V> {
+        self.data.last_mut()
+    }
+
+    /// Returns the backing slice.
+    pub fn as_slice(&self) -> &[V] {
+        &self.data
+    }
+
+    /// Returns the backing slice mutably.
+    pub fn as_mut_slice(&mut self) -> &mut [V] {
+        &mut self.data
+    }
+
+    /// Returns an iterator over the stored values.
+    pub fn iter(&self) -> std::slice::Iter<'_, V> {
+        self.data.iter()
+    }
+
+    /// Returns a mutable iterator over the stored values.
+    pub fn iter_mut(&mut self) -> std::slice::IterMut<'_, V> {
+        self.data.iter_mut()
+    }
+
+    /// Clears the vector, removing all values.
+    pub fn clear(&mut self) {
+        self.data.clear();
+    }
+
+    /// Truncates the vector to `len` items.
+    pub fn truncate(&mut self, len: usize) {
+        self.data.truncate(len);
+    }
+
+    /// Extends the vector with values from `iter`, assigning contiguous IDs to new items.
+    pub fn extend<I>(&mut self, iter: I)
+    where
+        I: IntoIterator<Item = V>,
+    {
+        self.data.extend(iter);
+    }
+
+    /// Resizes the vector to `new_len`, cloning `value` as needed.
+    pub fn resize(&mut self, new_len: usize, value: V)
+    where
+        V: Clone,
+    {
+        self.data.resize(new_len, value);
+    }
+
+    /// Resizes the vector to `new_len`, generating values with `f` as needed.
+    pub fn resize_with<F>(&mut self, new_len: usize, f: F)
+    where
+        F: FnMut() -> V,
+    {
+        self.data.resize_with(new_len, f);
+    }
+
+    /// Returns `true` if the vector contains `value`.
+    pub fn contains(&self, value: &V) -> bool
+    where
+        V: PartialEq,
+    {
+        self.data.contains(value)
+    }
+
+    /// Consumes the `EntityVec` and returns the backing `Vec`.
+    pub fn into_vec(self) -> Vec<V> {
+        self.data
+    }
+}
+
+impl<E: Entity, V> Default for EntityVec<E, V> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl<E: Entity, V: Debug> Debug for EntityVec<E, V> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.data.fmt(f)
+    }
+}
+
+impl<E: Entity, V> From<Vec<V>> for EntityVec<E, V> {
+    fn from(data: Vec<V>) -> Self {
+        Self {
+            data,
+            _phantom: PhantomData,
+        }
+    }
+}
+
+impl<E: Entity, V> From<EntityVec<E, V>> for Vec<V> {
+    fn from(value: EntityVec<E, V>) -> Self {
+        value.data
+    }
+}
+
+impl<E: Entity, V> FromIterator<V> for EntityVec<E, V> {
+    fn from_iter<I: IntoIterator<Item = V>>(iter: I) -> Self {
+        Self::from(Vec::from_iter(iter))
+    }
+}
+
+impl<E: Entity, V> Extend<V> for EntityVec<E, V> {
+    fn extend<I: IntoIterator<Item = V>>(&mut self, iter: I) {
+        self.data.extend(iter);
+    }
+}
+
+impl<E: Entity, V> Index<EntityId<E>> for EntityVec<E, V> {
+    type Output = V;
+
+    fn index(&self, index: EntityId<E>) -> &Self::Output {
+        &self.data[index.0]
+    }
+}
+
+impl<E: Entity, V> IndexMut<EntityId<E>> for EntityVec<E, V> {
+    fn index_mut(&mut self, index: EntityId<E>) -> &mut Self::Output {
+        &mut self.data[index.0]
+    }
+}
+
+impl<E: Entity, V> IntoIterator for EntityVec<E, V> {
+    type Item = V;
+    type IntoIter = std::vec::IntoIter<V>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.data.into_iter()
+    }
+}
+
+impl<'a, E: Entity, V> IntoIterator for &'a EntityVec<E, V> {
+    type Item = &'a V;
+    type IntoIter = std::slice::Iter<'a, V>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.iter()
+    }
+}
+
+impl<'a, E: Entity, V> IntoIterator for &'a mut EntityVec<E, V> {
+    type Item = &'a mut V;
+    type IntoIter = std::slice::IterMut<'a, V>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.iter_mut()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::EntityVec;
+    use crate::define_entity;
+    use crate::entity::EntityId;
+
+    define_entity!(TestEntity);
+    #[test]
+    fn new_is_empty() {
+        let vec = EntityVec::<TestEntity, i32>::new();
+        assert_eq!(vec.len(), 0);
+        assert!(vec.is_empty());
+        assert_eq!(vec.capacity(), 0);
+    }
+
+    #[test]
+    fn with_capacity_sets_initial_capacity() {
+        let vec = EntityVec::<TestEntity, i32>::with_capacity(8);
+        assert_eq!(vec.len(), 0);
+        assert!(vec.capacity() >= 8);
+    }
+
+    #[test]
+    fn push_appends_values_in_order() {
+        let mut vec = EntityVec::<TestEntity, &'static str>::new();
+        vec.push("zero");
+        vec.push("one");
+        vec.push("two");
+
+        assert_eq!(vec.len(), 3);
+        assert_eq!(vec[EntityId::new(0)], "zero");
+        assert_eq!(vec[EntityId::new(1)], "one");
+        assert_eq!(vec[EntityId::new(2)], "two");
+    }
+
+    #[test]
+    fn get_and_get_mut_are_bounds_checked() {
+        let mut vec = EntityVec::<TestEntity, i32>::new();
+        vec.push(10);
+        vec.push(20);
+        let id0 = EntityId::new(0);
+        let id1 = EntityId::new(1);
+
+        assert_eq!(vec.get(id0), Some(&10));
+        assert_eq!(vec.get(id1), Some(&20));
+        assert_eq!(vec.get(EntityId::new(2)), None);
+
+        *vec.get_mut(id1).unwrap() = 99;
+        assert_eq!(vec.get(id1), Some(&99));
+        assert_eq!(vec.get_mut(EntityId::new(2)), None);
+    }
+
+    #[test]
+    fn index_and_index_mut_use_entity_ids() {
+        let mut vec = EntityVec::<TestEntity, i32>::new();
+        vec.push(1);
+        vec.push(2);
+        let id0 = EntityId::new(0);
+        let id1 = EntityId::new(1);
+
+        vec[id1] = 7;
+
+        assert_eq!(vec[id0], 1);
+        assert_eq!(vec[id1], 7);
+    }
+
+    #[test]
+    fn pop_last_last_mut_and_clear_work() {
+        let mut vec = EntityVec::<TestEntity, String>::new();
+        vec.push(String::from("a"));
+        vec.push(String::from("b"));
+
+        assert_eq!(vec.last().map(String::as_str), Some("b"));
+        vec.last_mut().unwrap().push('!');
+        assert_eq!(vec.last().map(String::as_str), Some("b!"));
+        assert_eq!(vec.pop(), Some(String::from("b!")));
+        assert_eq!(vec.pop(), Some(String::from("a")));
+        assert_eq!(vec.pop(), None);
+
+        vec.push(String::from("c"));
+        vec.clear();
+        assert!(vec.is_empty());
+        assert_eq!(vec.last(), None);
+        assert_eq!(vec.last_mut(), None);
+    }
+
+    #[test]
+    fn reserve_and_shrink_to_fit_forward_to_backing_vec() {
+        let mut vec = EntityVec::<TestEntity, i32>::new();
+        vec.reserve(16);
+        assert!(vec.capacity() >= 16);
+
+        vec.extend(0..4);
+        vec.shrink_to_fit();
+        assert!(vec.capacity() >= vec.len());
+    }
+
+    #[test]
+    fn as_slice_and_as_mut_slice_expose_backing_storage() {
+        let mut vec = EntityVec::<TestEntity, i32>::from(vec![1, 2, 3]);
+        assert_eq!(vec.as_slice(), &[1, 2, 3]);
+
+        vec.as_mut_slice()[1] = 9;
+        assert_eq!(vec.as_slice(), &[1, 9, 3]);
+    }
+
+    #[test]
+    fn iter_and_iter_mut_visit_values_in_order() {
+        let mut vec = EntityVec::<TestEntity, i32>::from(vec![1, 2, 3]);
+        let values: Vec<_> = vec.iter().copied().collect();
+        assert_eq!(values, vec![1, 2, 3]);
+
+        for value in vec.iter_mut() {
+            *value *= 2;
+        }
+
+        assert_eq!(vec.as_slice(), &[2, 4, 6]);
+    }
+
+    #[test]
+    fn truncate_removes_trailing_items() {
+        let mut vec = EntityVec::<TestEntity, i32>::from(vec![1, 2, 3, 4]);
+        vec.truncate(2);
+
+        assert_eq!(vec.len(), 2);
+        assert_eq!(vec.get(EntityId::new(0)), Some(&1));
+        assert_eq!(vec.get(EntityId::new(1)), Some(&2));
+        assert_eq!(vec.get(EntityId::new(2)), None);
+    }
+
+    #[test]
+    fn contains_checks_values() {
+        let vec = EntityVec::<TestEntity, i32>::from(vec![3, 5, 8]);
+        assert!(vec.contains(&5));
+        assert!(!vec.contains(&13));
+    }
+
+    #[test]
+    fn from_iter_and_inherent_extend_append_in_order() {
+        let mut vec: EntityVec<TestEntity, i32> = [1, 2].into_iter().collect();
+        EntityVec::extend(&mut vec, [3, 4]);
+
+        assert_eq!(vec.as_slice(), &[1, 2, 3, 4]);
+        vec.push(5);
+        assert_eq!(vec[EntityId::new(4)], 5);
+    }
+
+    #[test]
+    fn trait_extend_appends_values() {
+        let mut vec = EntityVec::<TestEntity, i32>::new();
+        <EntityVec<TestEntity, i32> as Extend<i32>>::extend(&mut vec, [7, 8, 9]);
+        assert_eq!(vec.as_slice(), &[7, 8, 9]);
+    }
+
+    #[test]
+    fn into_vec_and_from_vec_round_trip() {
+        let vec = EntityVec::<TestEntity, i32>::from(vec![4, 5, 6]);
+        let raw = vec.into_vec();
+        assert_eq!(raw, vec![4, 5, 6]);
+
+        let wrapped = EntityVec::<TestEntity, i32>::from(raw.clone());
+        let round_trip: Vec<_> = wrapped.into();
+        assert_eq!(round_trip, raw);
+    }
+
+    #[test]
+    fn into_iterator_variants_match_backing_vec_order() {
+        let mut vec = EntityVec::<TestEntity, i32>::from(vec![1, 2, 3]);
+
+        let shared: Vec<_> = (&vec).into_iter().copied().collect();
+        assert_eq!(shared, vec![1, 2, 3]);
+
+        for value in &mut vec {
+            *value += 10;
+        }
+        assert_eq!(vec.as_slice(), &[11, 12, 13]);
+
+        let owned: Vec<_> = vec.into_iter().collect();
+        assert_eq!(owned, vec![11, 12, 13]);
+    }
+
+    #[test]
+    fn debug_delegates_to_backing_vec() {
+        let vec = EntityVec::<TestEntity, i32>::from(vec![1, 2, 3]);
+        assert_eq!(format!("{vec:?}"), "[1, 2, 3]");
+    }
+
+    #[test]
+    fn clone_and_eq_compare_stored_values() {
+        let vec = EntityVec::<TestEntity, i32>::from(vec![1, 2, 3]);
+        let clone = vec.clone();
+
+        assert_eq!(vec, clone);
+        assert_ne!(vec, EntityVec::<TestEntity, i32>::from(vec![1, 2]));
+    }
+
+    #[test]
+    fn resize_and_resize_with_extend_storage_by_index() {
+        let mut vec = EntityVec::<TestEntity, i32>::new();
+        vec.resize(3, 7);
+        assert_eq!(vec.as_slice(), &[7, 7, 7]);
+
+        let mut next = 10;
+        vec.resize_with(5, || {
+            let value = next;
+            next += 1;
+            value
+        });
+
+        assert_eq!(vec.as_slice(), &[7, 7, 7, 10, 11]);
+    }
+}

--- a/src/data_structures/mod.rs
+++ b/src/data_structures/mod.rs
@@ -1,3 +1,3 @@
-pub mod dense_entity_map;
+pub mod entity_map;
 pub mod entity_vec;
 pub mod value_vec;

--- a/src/data_structures/mod.rs
+++ b/src/data_structures/mod.rs
@@ -1,1 +1,3 @@
+pub mod dense_entity_map;
+pub mod entity_vec;
 pub mod value_vec;


### PR DESCRIPTION
This PR adds two typed, vector-backed data structures for working with `EntityId<E>` keys:

- `EntityVec<E, V>`: a thin `Vec<V>` wrapper that can be indexed by `EntityId<E>`.
- `DenseEntityMap<E, V>`: a dense map from `EntityId<E>` to `V`, backed by `Vec<Option<V>>`.

The motivation here is that we want to maintain the invariant for `EntityId<E>` that only _valid_ entity ID values can ever exist, which requires preventing client code from constructing them, but we _also_ want efficient data structures in which we associate values to `EntityId<E>` efficiently. `HashMap<EntityId<E>, V>` is already available to client code, so we're really talking about using `EntityId<E>` to index into a vector-like structure.

# Issues and Open Questions

## In General

- There might be other opaque ID types like `PlanId` that we want to use with this. Right now our only use case seems to be `EntityId<E>`, but if there are other types in the future, we can change these data structures to be generic over a trait type (`AsIndex` / `Indexable`).

## `EntityVec<E, V>`

- Should an `EntityVec` *also* be indexable with a `usize`? Or only with `EntityId<E>`?

## `DenseEntityMap<E, V>`

- We could also have methods that expose the underlying `Vec<Option<V>>` so long as we don't allow unconstrained vector-growing operations on it (`push`, `extend`). The use case I am imagining is iterating over `(EntityId<E>, &mut Option<V>)`, where you are given the entity ID even when no `V` is associated with it yet.
