### PR TITLE
chore: Refactor `global_properties` to use the registry pattern

### DIFF
--- a/src/context.rs
+++ b/src/context.rs
@@ -17,6 +17,7 @@ use crate::execution_stats::{
     log_execution_statistics, print_execution_statistics, ExecutionProfilingCollector,
     ExecutionStatistics,
 };
+use crate::global_properties::get_global_property_count;
 use crate::plan::{PlanId, Queue};
 #[cfg(feature = "progress_bar")]
 use crate::progress::update_timeline_progress;
@@ -86,6 +87,7 @@ pub struct Context {
     event_handlers: HashMap<TypeId, Box<dyn Any>>,
     pub(crate) entity_store: EntityStore,
     data_plugins: Vec<OnceCell<Box<dyn Any>>>,
+    pub(crate) global_properties: Vec<OnceCell<Box<dyn Any>>>,
     current_time: Option<f64>,
     start_time: Option<f64>,
     shutdown_requested: bool,
@@ -101,6 +103,9 @@ impl Context {
         let data_plugins = std::iter::repeat_with(OnceCell::new)
             .take(get_data_plugin_count())
             .collect();
+        let global_properties = std::iter::repeat_with(OnceCell::new)
+            .take(get_global_property_count())
+            .collect();
 
         Context {
             plan_queue: Queue::new(),
@@ -108,6 +113,7 @@ impl Context {
             event_handlers: HashMap::new(),
             entity_store: EntityStore::new(),
             data_plugins,
+            global_properties,
             current_time: None,
             start_time: None,
             shutdown_requested: false,

--- a/src/global_properties.rs
+++ b/src/global_properties.rs
@@ -3,7 +3,7 @@
 //! Global properties are not mutable and represent variables that are
 //! required in a global scope during the simulation, such as
 //! simulation parameters.
-//! A global property can be of any type, and is is just a value
+//! A global property can be of any type and is just a value
 //! stored in the context. Global properties are defined by the
 //! [`crate::define_global_property!()`] macro and can then be
 //! set in one of two ways:
@@ -15,21 +15,21 @@
 //! will result in an error.
 //!
 //! Global properties can be read with [`Context::get_global_property_value()`]
-use std::any::{Any, TypeId};
+use std::any::Any;
 use std::cell::RefCell;
-use std::collections::hash_map::Entry;
 use std::error::Error;
 use std::fmt::Debug;
 use std::fs;
 use std::io::BufReader;
 use std::path::Path;
+use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::{Arc, LazyLock, Mutex};
 
 use serde::de::DeserializeOwned;
 
 use crate::context::Context;
 use crate::error::IxaError;
-use crate::{define_data_plugin, trace, ContextBase, HashMap, HashMapExt};
+use crate::{trace, ContextBase, HashMap, HashMapExt};
 
 type PropertySetterFn =
     dyn Fn(&mut Context, &str, serde_json::Value) -> Result<(), IxaError> + Send + Sync;
@@ -51,6 +51,38 @@ pub struct PropertyAccessors {
 #[doc(hidden)]
 pub static GLOBAL_PROPERTIES: LazyLock<Mutex<RefCell<HashMap<String, Arc<PropertyAccessors>>>>> =
     LazyLock::new(|| Mutex::new(RefCell::new(HashMap::new())));
+
+/// Global property ID counter, keeps track of the ID that will be assigned to
+/// the next global property that requests an ID.
+static NEXT_GLOBAL_PROPERTY_ID: Mutex<usize> = Mutex::new(0);
+
+/// A convenience getter for `NEXT_GLOBAL_PROPERTY_ID`.
+pub fn get_global_property_count() -> usize {
+    *NEXT_GLOBAL_PROPERTY_ID.lock().unwrap()
+}
+
+/// Encapsulates the synchronization logic for initializing a global property's ID.
+///
+/// Acquires a global lock on the next available global property ID, but only
+/// increments it if we successfully initialize the provided ID. The ID of a
+/// global property is assigned at runtime but only once per type.
+pub fn initialize_global_property_id(global_property_id: &AtomicUsize) -> usize {
+    let mut guard = NEXT_GLOBAL_PROPERTY_ID.lock().unwrap();
+    let candidate = *guard;
+
+    match global_property_id.compare_exchange(
+        usize::MAX,
+        candidate,
+        Ordering::AcqRel,
+        Ordering::Acquire,
+    ) {
+        Ok(_) => {
+            *guard += 1;
+            candidate
+        }
+        Err(existing) => existing,
+    }
+}
 
 #[allow(clippy::missing_panics_doc)]
 pub fn add_global_property<T: GlobalProperty>(name: &str)
@@ -112,6 +144,8 @@ pub trait GlobalProperty: Any {
     /// The actual type of the data stored in the global property
     type Value: Any;
 
+    fn id() -> usize;
+
     fn new() -> Self;
 
     fn name() -> &'static str {
@@ -119,51 +153,10 @@ pub trait GlobalProperty: Any {
         full.rsplit("::").next().unwrap()
     }
 
-    /// A function which validates the global property.
+    /// A function that validates the global property.
     ///
     /// Client code should box any produced error itself.
     fn validate(value: &Self::Value) -> Result<(), Box<dyn Error + 'static>>;
-}
-
-struct GlobalPropertiesDataContainer {
-    global_property_container: HashMap<TypeId, Box<dyn Any>>,
-}
-
-define_data_plugin!(
-    GlobalPropertiesPlugin,
-    GlobalPropertiesDataContainer,
-    GlobalPropertiesDataContainer {
-        global_property_container: HashMap::default(),
-    }
-);
-
-impl GlobalPropertiesDataContainer {
-    fn set_global_property_value<T: GlobalProperty + 'static>(
-        &mut self,
-        _property: &T,
-        value: T::Value,
-    ) -> Result<(), IxaError> {
-        match self.global_property_container.entry(TypeId::of::<T>()) {
-            Entry::Vacant(entry) => {
-                entry.insert(Box::new(value));
-                Ok(())
-            }
-            // Note: If we change global properties to be mutable, we'll need to
-            // update define_derived_person_property to either handle updates or only
-            // allow immutable properties.
-            Entry::Occupied(_) => Err(IxaError::EntryAlreadyExists),
-        }
-    }
-
-    #[must_use]
-    fn get_global_property_value<T: GlobalProperty + 'static>(&self) -> Option<&T::Value> {
-        let data_container = self.global_property_container.get(&TypeId::of::<T>());
-
-        match data_container {
-            Some(property) => Some(property.downcast_ref::<T::Value>().unwrap()),
-            None => None,
-        }
-    }
 }
 
 pub trait ContextGlobalPropertiesExt: ContextBase {
@@ -175,24 +168,14 @@ pub trait ContextGlobalPropertiesExt: ContextBase {
         &mut self,
         property: T,
         value: T::Value,
-    ) -> Result<(), IxaError> {
-        T::validate(&value).map_err(|source| IxaError::IllegalGlobalPropertyValue {
-            name: T::name().to_string(),
-            source,
-        })?;
-        let data_container = self.get_data_mut(GlobalPropertiesPlugin);
-        data_container.set_global_property_value(&property, value)
-    }
+    ) -> Result<(), IxaError>;
 
     /// Return value of global property T
     #[allow(unused_variables)]
     fn get_global_property_value<T: GlobalProperty + 'static>(
         &self,
         _property: T,
-    ) -> Option<&T::Value> {
-        self.get_data(GlobalPropertiesPlugin)
-            .get_global_property_value::<T>()
-    }
+    ) -> Option<&T::Value>;
 
     fn list_registered_global_properties(&self) -> Vec<String> {
         let properties = GLOBAL_PROPERTIES.lock().unwrap();
@@ -249,6 +232,54 @@ pub trait ContextGlobalPropertiesExt: ContextBase {
     fn load_global_properties(&mut self, file_name: &Path) -> Result<(), IxaError>;
 }
 impl ContextGlobalPropertiesExt for Context {
+    fn set_global_property_value<T: GlobalProperty + 'static>(
+        &mut self,
+        _property: T,
+        value: T::Value,
+    ) -> Result<(), IxaError> {
+        T::validate(&value).map_err(|source| IxaError::IllegalGlobalPropertyValue {
+            name: T::name().to_string(),
+            source,
+        })?;
+        let index = T::id();
+        let cell = self.global_properties.get_mut(index).unwrap_or_else(|| {
+            panic!(
+                "No global property found with index = {index:?}. You must use the \
+                 `define_global_property!` macro to create a global property."
+            )
+        });
+        if cell.get().is_some() {
+            // Note: If we change global properties to be mutable, we'll need to
+            // update define_derived_person_property to either handle updates or only
+            // allow immutable properties.
+            return Err(IxaError::EntryAlreadyExists);
+        }
+        let _ = cell.set(Box::new(value));
+        Ok(())
+    }
+
+    fn get_global_property_value<T: GlobalProperty + 'static>(
+        &self,
+        _property: T,
+    ) -> Option<&T::Value> {
+        let index = T::id();
+        self.global_properties
+            .get(index)
+            .unwrap_or_else(|| {
+                panic!(
+                    "No global property found with index = {index:?}. You must use the \
+                     `define_global_property!` macro to create a global property."
+                )
+            })
+            .get()
+            .map(|property| {
+                property.downcast_ref::<T::Value>().expect(
+                    "TypeID does not match global property type. You must use the \
+                     `define_global_property!` macro to create a global property.",
+                )
+            })
+    }
+
     fn get_serialized_value_by_string(&self, name: &str) -> Result<Option<String>, IxaError> {
         let accessor = get_global_property_accessor(name);
         match accessor {

--- a/src/global_properties.rs
+++ b/src/global_properties.rs
@@ -135,7 +135,7 @@ pub trait GlobalProperty: Any {
         full.rsplit("::").next().unwrap()
     }
 
-    /// A function that validates the global property.
+    /// A function which validates the global property.
     ///
     /// Client code should box any produced error itself.
     fn validate(value: &Self::Value) -> Result<(), Box<dyn Error + 'static>>;
@@ -153,7 +153,6 @@ pub trait ContextGlobalPropertiesExt: ContextBase {
     ) -> Result<(), IxaError>;
 
     /// Return value of global property T
-    #[allow(unused_variables)]
     fn get_global_property_value<T: GlobalProperty + 'static>(
         &self,
         _property: T,

--- a/src/global_properties.rs
+++ b/src/global_properties.rs
@@ -34,13 +34,6 @@ use crate::{trace, ContextBase, HashMap, HashMapExt};
 type PropertySetterFn =
     dyn Fn(&mut Context, &str, serde_json::Value) -> Result<(), IxaError> + Send + Sync;
 
-type PropertyGetterFn = dyn Fn(&Context) -> Result<Option<String>, IxaError> + Send + Sync;
-
-pub struct PropertyAccessors {
-    setter: Box<PropertySetterFn>,
-    getter: Box<PropertyGetterFn>,
-}
-
 #[allow(clippy::type_complexity)]
 // This is a global list of all the global properties that
 // are compiled in. Fundamentally it's a HashMap of property
@@ -49,7 +42,7 @@ pub struct PropertyAccessors {
 // shared and initialized at startup time while still being
 // safe.
 #[doc(hidden)]
-pub static GLOBAL_PROPERTIES: LazyLock<Mutex<RefCell<HashMap<String, Arc<PropertyAccessors>>>>> =
+pub static GLOBAL_PROPERTIES: LazyLock<Mutex<RefCell<HashMap<String, Arc<PropertySetterFn>>>>> =
     LazyLock::new(|| Mutex::new(RefCell::new(HashMap::new())));
 
 /// Global property ID counter, keeps track of the ID that will be assigned to
@@ -87,7 +80,7 @@ pub fn initialize_global_property_id(global_property_id: &AtomicUsize) -> usize 
 #[allow(clippy::missing_panics_doc)]
 pub fn add_global_property<T: GlobalProperty>(name: &str)
 where
-    for<'de> <T as GlobalProperty>::Value: serde::Deserialize<'de> + serde::Serialize,
+    for<'de> <T as GlobalProperty>::Value: serde::Deserialize<'de>,
 {
     trace!("Adding global property {name}");
     let properties = GLOBAL_PROPERTIES.lock().unwrap();
@@ -95,38 +88,27 @@ where
         .borrow_mut()
         .insert(
             name.to_string(),
-            Arc::new(PropertyAccessors {
-                setter: Box::new(
-                    |context: &mut Context, name, value| -> Result<(), IxaError> {
-                        let val: T::Value = serde_json::from_value(value)?;
-                        T::validate(&val).map_err(|source| {
-                            IxaError::IllegalGlobalPropertyValue {
-                                name: T::name().to_string(),
-                                source,
-                            }
-                        })?;
-                        if context.get_global_property_value(T::new()).is_some() {
-                            return Err(IxaError::DuplicateProperty {
-                                name: name.to_string(),
-                            });
-                        }
-                        context.set_global_property_value(T::new(), val)?;
-                        Ok(())
-                    },
-                ),
-                getter: Box::new(|context: &Context| -> Result<Option<String>, IxaError> {
-                    let value = context.get_global_property_value(T::new());
-                    match value {
-                        Some(val) => Ok(Some(serde_json::to_string(val)?)),
-                        None => Ok(None),
+            Arc::new(
+                |context: &mut Context, name, value| -> Result<(), IxaError> {
+                    let val: T::Value = serde_json::from_value(value)?;
+                    T::validate(&val).map_err(|source| IxaError::IllegalGlobalPropertyValue {
+                        name: T::name().to_string(),
+                        source,
+                    })?;
+                    if context.get_global_property_value(T::new()).is_some() {
+                        return Err(IxaError::DuplicateProperty {
+                            name: name.to_string(),
+                        });
                     }
-                }),
-            }),
+                    context.set_global_property_value(T::new(), val)?;
+                    Ok(())
+                },
+            ),
         )
         .inspect(|_| panic!("Duplicate global property {}", name));
 }
 
-fn get_global_property_accessor(name: &str) -> Option<Arc<PropertyAccessors>> {
+fn get_global_property_setter(name: &str) -> Option<Arc<PropertySetterFn>> {
     let properties = GLOBAL_PROPERTIES.lock().unwrap();
     let tmp = properties.borrow();
     tmp.get(name).map(Arc::clone)
@@ -176,19 +158,6 @@ pub trait ContextGlobalPropertiesExt: ContextBase {
         &self,
         _property: T,
     ) -> Option<&T::Value>;
-
-    fn list_registered_global_properties(&self) -> Vec<String> {
-        let properties = GLOBAL_PROPERTIES.lock().unwrap();
-        let tmp = properties.borrow();
-        tmp.keys().cloned().collect()
-    }
-
-    /// Return the serialized value of a global property by fully qualified name
-    ///
-    /// # Errors
-    ///
-    /// Will return an [`IxaError`] if the property does not exist
-    fn get_serialized_value_by_string(&self, name: &str) -> Result<Option<String>, IxaError>;
 
     /// Given a file path for a valid json file, deserialize parameter values
     /// for a given struct T
@@ -280,16 +249,6 @@ impl ContextGlobalPropertiesExt for Context {
             })
     }
 
-    fn get_serialized_value_by_string(&self, name: &str) -> Result<Option<String>, IxaError> {
-        let accessor = get_global_property_accessor(name);
-        match accessor {
-            Some(accessor) => (accessor.getter)(self),
-            None => Err(IxaError::NoGlobalProperty {
-                name: name.to_string(),
-            }),
-        }
-    }
-
     fn load_global_properties(&mut self, file_name: &Path) -> Result<(), IxaError> {
         trace!("Loading global properties from {file_name:?}");
         let config_file = fs::File::open(file_name)?;
@@ -297,8 +256,8 @@ impl ContextGlobalPropertiesExt for Context {
         let val: serde_json::Map<String, serde_json::Value> = serde_json::from_reader(reader)?;
 
         for (k, v) in val {
-            if let Some(accessor) = get_global_property_accessor(&k) {
-                (accessor.setter)(self, &k, v)?;
+            if let Some(setter) = get_global_property_setter(&k) {
+                setter(self, &k, v)?;
             } else {
                 return Err(IxaError::NoGlobalProperty { name: k });
             }
@@ -549,30 +508,5 @@ mod test {
             }
             _ => panic!("Unexpected error type"),
         }
-    }
-
-    #[test]
-    fn list_registered_global_properties() {
-        let context = Context::new();
-        let properties = context.list_registered_global_properties();
-        assert!(properties.contains(&"ixa.DiseaseParams".to_string()));
-    }
-
-    #[test]
-    fn get_serialized_value_by_string() {
-        let mut context = Context::new();
-        context
-            .set_global_property_value(
-                DiseaseParams,
-                ParamType {
-                    days: 10,
-                    diseases: 2,
-                },
-            )
-            .unwrap();
-        let serialized = context
-            .get_serialized_value_by_string("ixa.DiseaseParams")
-            .unwrap();
-        assert_eq!(serialized, Some("{\"days\":10,\"diseases\":2}".to_string()));
     }
 }

--- a/src/macros/define_global_property.rs
+++ b/src/macros/define_global_property.rs
@@ -17,6 +17,23 @@ macro_rules! define_global_property {
         impl $crate::global_properties::GlobalProperty for $global_property {
             type Value = $value;
 
+            fn id() -> usize {
+                // This static must be initialized with a compile-time constant expression.
+                // We use `usize::MAX` as a sentinel to mean "uninitialized". This
+                // static variable is shared among all instances of this concrete item type.
+                static INDEX: std::sync::atomic::AtomicUsize =
+                    std::sync::atomic::AtomicUsize::new(usize::MAX);
+
+                // Fast path: already initialized.
+                let index = INDEX.load(std::sync::atomic::Ordering::Relaxed);
+                if index != usize::MAX {
+                    return index;
+                }
+
+                // Slow path: initialize it.
+                $crate::global_properties::initialize_global_property_id(&INDEX)
+            }
+
             fn new() -> Self {
                 $global_property
             }
@@ -39,6 +56,7 @@ macro_rules! define_global_property {
                     let mut name = module.split("::").next().unwrap().to_string();
                     name += ".";
                     name += stringify!($global_property);
+                    <$global_property as $crate::global_properties::GlobalProperty>::id();
                     $crate::global_properties::add_global_property::<$global_property>(&name);
                 }
             }


### PR DESCRIPTION
This PR refactors global property storage out of the data plugin system and into `Context` directly. The original hash map based storage is replaced with the "registry pattern" we use for data plugins, entities, and other things elsewhere: `set_global_property_value` and `get_global_property_value` now index directly into `Context::global_properties` using `T::id()`. 

I also removed the unused string-based getter mechanism. 

Unfortunately, the name-based registration and loading machinery is otherwise left intact, so `load_global_properties`, `add_global_property`, and the serialized lookup path continue to work through the existing accessors. The reason is that the `load_global_properties`  uses a string name-based lookup, and it's not clear how to refactor this while also retaining source compatibility with existing code.

On the other hand, if we are willing to break source compatibility, we might as well wait until we have a better idea of the alternative design for global parameters in order to do so, so we don't give client code whiplash.

Client code should remain source compatible for this PR.
