### PR TITLE
feat: add `sample_single_excluding` to `random` module

### DIFF
--- a/ixa-bench/Cargo.toml
+++ b/ixa-bench/Cargo.toml
@@ -108,3 +108,8 @@ harness = false
 name = "property_semantics"
 path = "criterion/property_semantics.rs"
 harness = false
+
+[[bench]]
+name = "sample_single_excluding"
+path = "criterion/sample_single_excluding.rs"
+harness = false

--- a/ixa-bench/criterion/sample_single_excluding.rs
+++ b/ixa-bench/criterion/sample_single_excluding.rs
@@ -16,7 +16,7 @@ use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion};
 use ixa::rand::rngs::StdRng;
 use ixa::rand::SeedableRng;
 use ixa::random::{
-    sample_excluding_iteration, sample_excluding_rejection, sample_single_excluding,
+    sample_single_excluding, sample_single_excluding_iteration, sample_single_excluding_rejection,
 };
 
 const SEED: u64 = 42;
@@ -65,9 +65,12 @@ fn bench_strategies(c: &mut Criterion, results: &Results) {
         group.bench_with_input(BenchmarkId::new("rejection", &id_param), &(), |b, _| {
             let mut rng = StdRng::seed_from_u64(SEED);
             let ns = bench_ns_per_sample(b, || {
-                let v =
-                    sample_excluding_rejection(black_box(&mut rng), black_box(&slice), excluded)
-                        .unwrap();
+                let v = sample_single_excluding_rejection(
+                    black_box(&mut rng),
+                    black_box(&slice),
+                    excluded,
+                )
+                .unwrap();
                 black_box(v);
             });
             record(results, "rejection", n, ns);
@@ -76,9 +79,12 @@ fn bench_strategies(c: &mut Criterion, results: &Results) {
         group.bench_with_input(BenchmarkId::new("iteration", &id_param), &(), |b, _| {
             let mut rng = StdRng::seed_from_u64(SEED);
             let ns = bench_ns_per_sample(b, || {
-                let v =
-                    sample_excluding_iteration(black_box(&mut rng), black_box(&slice), excluded)
-                        .unwrap();
+                let v = sample_single_excluding_iteration(
+                    black_box(&mut rng),
+                    black_box(&slice),
+                    excluded,
+                )
+                .unwrap();
                 black_box(v);
             });
             record(results, "iteration", n, ns);

--- a/ixa-bench/criterion/sample_single_excluding.rs
+++ b/ixa-bench/criterion/sample_single_excluding.rs
@@ -1,0 +1,124 @@
+//! Benchmarks for `ixa::random::sample_single_excluding`.
+//!
+//! Compares the two sampling strategies (rejection sampling vs. linear scan)
+//! across a range of slice sizes, with a single occurrence of `excluded` in
+//! the slice (the typical "sample a peer, but not me" pattern).
+//!
+//! The output `=== Strategy comparison ===` summary shows the crossover point
+//! that the implementation's small-slice threshold should target.
+
+use std::collections::BTreeMap;
+use std::hint::black_box;
+use std::sync::{Arc, Mutex};
+use std::time::Instant;
+
+use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion};
+use ixa::rand::rngs::StdRng;
+use ixa::rand::SeedableRng;
+use ixa::random::{
+    sample_excluding_iteration, sample_excluding_rejection, sample_single_excluding,
+};
+
+const SEED: u64 = 42;
+
+/// Slice sizes to test. Focused on the small-n regime where the strategy
+/// crossover happens — at larger n rejection wins by orders of magnitude.
+const SLICE_SIZES: [usize; 3] = [2, 3, 4];
+
+type Results = Arc<Mutex<BTreeMap<(String, usize), f64>>>;
+
+/// Builds a Vec<u32> with values 0..n, and returns it together with one
+/// "excluded" value that is present exactly once in the slice (mid-range).
+fn build_slice(n: usize) -> (Vec<u32>, u32) {
+    let data: Vec<u32> = (0..n as u32).collect();
+    let excluded = (n / 2) as u32;
+    (data, excluded)
+}
+
+fn bench_ns_per_sample<F: FnMut()>(b: &mut criterion::Bencher, mut f: F) -> f64 {
+    let mut ns_per_sample = 0.0_f64;
+    b.iter_custom(|iters| {
+        let start = Instant::now();
+        for _ in 0..iters {
+            f();
+            black_box(());
+        }
+        let elapsed = start.elapsed();
+        ns_per_sample = elapsed.as_secs_f64() * 1e9 / (iters as f64);
+        elapsed
+    });
+    ns_per_sample
+}
+
+fn record(results: &Results, name: &str, n: usize, ns: f64) {
+    results.lock().unwrap().insert((name.to_string(), n), ns);
+}
+
+fn bench_strategies(c: &mut Criterion, results: &Results) {
+    let mut group = c.benchmark_group("sample_single_excluding");
+    group.sample_size(50);
+
+    for &n in &SLICE_SIZES {
+        let (slice, excluded) = build_slice(n);
+        let id_param = format!("n={n:>7}");
+
+        group.bench_with_input(BenchmarkId::new("rejection", &id_param), &(), |b, _| {
+            let mut rng = StdRng::seed_from_u64(SEED);
+            let ns = bench_ns_per_sample(b, || {
+                let v =
+                    sample_excluding_rejection(black_box(&mut rng), black_box(&slice), excluded)
+                        .unwrap();
+                black_box(v);
+            });
+            record(results, "rejection", n, ns);
+        });
+
+        group.bench_with_input(BenchmarkId::new("iteration", &id_param), &(), |b, _| {
+            let mut rng = StdRng::seed_from_u64(SEED);
+            let ns = bench_ns_per_sample(b, || {
+                let v =
+                    sample_excluding_iteration(black_box(&mut rng), black_box(&slice), excluded)
+                        .unwrap();
+                black_box(v);
+            });
+            record(results, "iteration", n, ns);
+        });
+
+        group.bench_with_input(BenchmarkId::new("auto", &id_param), &(), |b, _| {
+            let mut rng = StdRng::seed_from_u64(SEED);
+            let ns = bench_ns_per_sample(b, || {
+                let v = sample_single_excluding(black_box(&mut rng), black_box(&slice), excluded)
+                    .unwrap();
+                black_box(v);
+            });
+            record(results, "auto", n, ns);
+        });
+    }
+
+    group.finish();
+}
+
+fn print_summary(results: &BTreeMap<(String, usize), f64>) {
+    eprintln!("\n=== Strategy comparison: sample_single_excluding (ns/sample) ===");
+    eprintln!(
+        "{:>10}  {:>12}  {:>12}  {:>12}  {:>10}",
+        "n", "rejection", "iteration", "auto", "winner"
+    );
+
+    for &n in &SLICE_SIZES {
+        let r = results[&("rejection".to_string(), n)];
+        let i = results[&("iteration".to_string(), n)];
+        let a = results[&("auto".to_string(), n)];
+        let winner = if r < i { "rejection" } else { "iteration" };
+        eprintln!("{n:>10}  {r:>12.1}  {i:>12.1}  {a:>12.1}  {winner:>10}");
+    }
+}
+
+fn benches(c: &mut Criterion) {
+    let results: Results = Arc::new(Mutex::new(BTreeMap::new()));
+    bench_strategies(c, &results);
+    print_summary(&results.lock().unwrap());
+}
+
+criterion_group!(group, benches);
+criterion_main!(group);

--- a/src/entity/context_extension.rs
+++ b/src/entity/context_extension.rs
@@ -504,7 +504,7 @@ impl ContextEntitiesExt for Context {
             });
         }
 
-        let query_result = self.query_result_iterator(query);
+        let query_result = self.query(query);
         self.sample(rng_id, move |rng| query_result.sample_entity(rng))
     }
 
@@ -530,7 +530,7 @@ impl ContextEntitiesExt for Context {
             });
         }
 
-        let query_result = self.query_result_iterator(query);
+        let query_result = self.query(query);
         self.sample(rng_id, move |rng| query_result.count_and_sample_entity(rng))
     }
 
@@ -555,7 +555,7 @@ impl ContextEntitiesExt for Context {
             });
         }
 
-        let query_result = self.query_result_iterator(query);
+        let query_result = self.query(query);
         self.sample(rng_id, move |rng| query_result.sample_entities(rng, n))
     }
 

--- a/src/entity/entity_set/entity_set.rs
+++ b/src/entity/entity_set/entity_set.rs
@@ -10,10 +10,14 @@
 //!
 //! [`contains`]: EntitySet::contains
 
+use std::borrow::Borrow;
 use std::ops::Range;
+
+use rand::Rng;
 
 use super::{EntitySetIterator, SourceSet};
 use crate::entity::{Entity, EntityId};
+use crate::random::sample_single_excluding_l_reservoir;
 
 /// Opaque public wrapper around the internal set-expression tree.
 pub struct EntitySet<'a, E: Entity>(EntitySetInner<'a, E>);
@@ -213,6 +217,42 @@ impl<'a, E: Entity> EntitySet<'a, E> {
         self.into_iter().collect()
     }
 
+    /// Sample a single entity uniformly from this set, excluding any entity
+    /// equal to `excluded`. Returns `None` if the set is empty or contains
+    /// only the excluded entity.
+    ///
+    /// For source-leaf sets with random-access backing (`PopulationRange`,
+    /// `IndexSet`), runs in O(1) with at most two index lookups and no
+    /// iterator construction. Falls back to O(n) reservoir sampling for
+    /// composite sets and `PropertySet` sources.
+    pub fn sample_entity_excluding<R, X>(&self, rng: &mut R, excluded: X) -> Option<EntityId<E>>
+    where
+        R: Rng,
+        X: Borrow<EntityId<E>>,
+    {
+        let excluded = *excluded.borrow();
+        if let Some(n) = self.try_len() {
+            if n == 0 {
+                return None;
+            }
+            let p = rng.random_range(0..n as u32) as usize;
+            let candidate = self.try_nth(p)?;
+            if candidate != excluded {
+                return Some(candidate);
+            }
+            // `excluded` is at position `p`. Resample from the n-1 remaining
+            // positions: pick `k` uniform in `[0, n-1)`, then map it around
+            // the hole at `p`.
+            if n == 1 {
+                return None;
+            }
+            let k = rng.random_range(0..(n - 1) as u32) as usize;
+            let target = if k < p { k } else { k + 1 };
+            return self.try_nth(target);
+        }
+        sample_single_excluding_l_reservoir(rng, self.clone(), excluded)
+    }
+
     /// Returns `Some(length)` only when the set length is trivially known.
     ///
     /// This is true only for direct `SourceSet` leaves except `PropertySet`.
@@ -220,6 +260,14 @@ impl<'a, E: Entity> EntitySet<'a, E> {
     pub fn try_len(&self) -> Option<usize> {
         match self {
             EntitySet(EntitySetInner::Source(source)) => source.try_len(),
+            _ => None,
+        }
+    }
+
+    /// Random-access lookup. Defined for the same variants as `try_len`.
+    fn try_nth(&self, idx: usize) -> Option<EntityId<E>> {
+        match self {
+            EntitySet(EntitySetInner::Source(source)) => source.try_nth(idx),
             _ => None,
         }
     }
@@ -313,6 +361,9 @@ impl<'a, E: Entity> IntoIterator for EntitySet<'a, E> {
 
 #[cfg(test)]
 mod tests {
+    use rand::rngs::StdRng;
+    use rand::SeedableRng;
+
     use super::*;
     use crate::entity::ContextEntitiesExt;
     use crate::hashing::IndexSet;
@@ -646,5 +697,80 @@ mod tests {
         assert!(set.contains(p3));
         assert_eq!(set.into_iter().collect::<Vec<_>>(), vec![p2, p3]);
         assert_eq!(cloned.into_iter().collect::<Vec<_>>(), vec![p2, p3]);
+    }
+
+    #[test]
+    fn sample_entity_excluding_skips_excluded() {
+        let set = EntitySet::from_source(SourceSet::<Person>::PopulationRange(0..5));
+        let excluded = EntityId::<Person>::new(2);
+        let mut rng = StdRng::seed_from_u64(42);
+        for _ in 0..200 {
+            let sampled = set.sample_entity_excluding(&mut rng, excluded).unwrap();
+            assert_ne!(sampled, excluded);
+            assert!(sampled.0 < 5);
+        }
+    }
+
+    #[test]
+    fn sample_entity_excluding_returns_none_when_only_excluded_present() {
+        let only = EntityId::<Person>::new(7);
+        let single = finite_set(&[7]);
+        let mut rng = StdRng::seed_from_u64(42);
+        assert_eq!(
+            as_entity_set(&single).sample_entity_excluding(&mut rng, only),
+            None
+        );
+    }
+
+    #[test]
+    fn sample_entity_excluding_returns_none_on_empty() {
+        let mut rng = StdRng::seed_from_u64(42);
+        assert_eq!(
+            EntitySet::<Person>::empty()
+                .sample_entity_excluding(&mut rng, EntityId::<Person>::new(0)),
+            None
+        );
+    }
+
+    #[test]
+    fn sample_entity_excluding_excluded_not_in_set_uses_first_pick() {
+        // When `excluded` is outside the set, every sample is the first
+        // uniform pick — exercises the no-resample path.
+        let set = EntitySet::from_source(SourceSet::<Person>::PopulationRange(0..10));
+        let mut rng = StdRng::seed_from_u64(42);
+        for _ in 0..200 {
+            let sampled = set
+                .sample_entity_excluding(&mut rng, EntityId::<Person>::new(999))
+                .unwrap();
+            assert!(sampled.0 < 10);
+        }
+    }
+
+    #[test]
+    fn sample_entity_excluding_uniform_over_known_length() {
+        // Chi-square test on PopulationRange (known-length, fast path).
+        let excluded = EntityId::<Person>::new(7);
+        let set = EntitySet::from_source(SourceSet::<Person>::PopulationRange(0..20));
+        let num_runs = 50_000;
+        let mut counts = [0usize; 20];
+        let mut rng = StdRng::seed_from_u64(42);
+        for _ in 0..num_runs {
+            let id = set.sample_entity_excluding(&mut rng, excluded).unwrap();
+            counts[id.0] += 1;
+        }
+        assert_eq!(counts[excluded.0], 0);
+
+        let expected = num_runs as f64 / 19.0;
+        let chi_square: f64 = counts
+            .iter()
+            .enumerate()
+            .filter(|(i, _)| *i != excluded.0)
+            .map(|(_, &obs)| {
+                let diff = obs as f64 - expected;
+                diff * diff / expected
+            })
+            .sum();
+        // df = 18, χ²_{0.999} ≈ 42.31
+        assert!(chi_square < 42.31, "χ² = {chi_square}");
     }
 }

--- a/src/entity/entity_set/entity_set.rs
+++ b/src/entity/entity_set/entity_set.rs
@@ -13,11 +13,15 @@
 use std::borrow::Borrow;
 use std::ops::Range;
 
+use log::warn;
 use rand::Rng;
 
 use super::{EntitySetIterator, SourceSet};
 use crate::entity::{Entity, EntityId};
-use crate::random::sample_single_excluding_l_reservoir;
+use crate::random::{
+    count_and_sample_single_l_reservoir, sample_multiple_from_known_length,
+    sample_multiple_l_reservoir, sample_single_excluding_l_reservoir, sample_single_l_reservoir,
+};
 
 /// Opaque public wrapper around the internal set-expression tree.
 pub struct EntitySet<'a, E: Entity>(EntitySetInner<'a, E>);
@@ -251,6 +255,57 @@ impl<'a, E: Entity> EntitySet<'a, E> {
             return self.try_nth(target);
         }
         sample_single_excluding_l_reservoir(rng, self.clone(), excluded)
+    }
+
+    /// Sample a single entity uniformly from this set. Returns `None` if the
+    /// set is empty.
+    pub fn sample_entity<R>(&self, rng: &mut R) -> Option<EntityId<E>>
+    where
+        R: Rng,
+    {
+        if let Some(n) = self.try_len() {
+            if n == 0 {
+                warn!("Requested a sample entity from an empty population");
+                return None;
+            }
+            // The `u32` cast makes this function 30% faster than `usize`.
+            let index = rng.random_range(0..n as u32) as usize;
+            return self.try_nth(index);
+        }
+        sample_single_l_reservoir(rng, self.clone())
+    }
+
+    /// Count the entities in this set and sample one uniformly from them.
+    ///
+    /// Returns `(count, sample)` where `sample` is `None` iff `count == 0`.
+    pub fn count_and_sample_entity<R>(&self, rng: &mut R) -> (usize, Option<EntityId<E>>)
+    where
+        R: Rng,
+    {
+        if let Some(n) = self.try_len() {
+            if n == 0 {
+                return (0, None);
+            }
+            let index = rng.random_range(0..n as u32) as usize;
+            return (n, self.try_nth(index));
+        }
+        count_and_sample_single_l_reservoir(rng, self.clone())
+    }
+
+    /// Sample up to `requested` entities uniformly from this set. If the set
+    /// has fewer than `requested` entities, the entire set is returned.
+    pub fn sample_entities<R>(&self, rng: &mut R, requested: usize) -> Vec<EntityId<E>>
+    where
+        R: Rng,
+    {
+        match self.try_len() {
+            Some(0) => {
+                warn!("Requested a sample of entities from an empty population");
+                vec![]
+            }
+            Some(_) => sample_multiple_from_known_length(rng, self.clone(), requested),
+            None => sample_multiple_l_reservoir(rng, self.clone(), requested),
+        }
     }
 
     /// Returns `Some(length)` only when the set length is trivially known.

--- a/src/entity/entity_set/entity_set_iterator.rs
+++ b/src/entity/entity_set/entity_set_iterator.rs
@@ -10,18 +10,11 @@
 //!
 //! The iterator is created through `EntitySet::into_iter()`.
 
-use log::warn;
-use rand::Rng;
-
 use crate::entity::entity_set::entity_set::{EntitySet, EntitySetInner};
 use crate::entity::entity_set::source_iterator::{PopulationRangeIterator, SourceIterator};
 use crate::entity::entity_set::source_set::SourceSet;
 use crate::entity::{Entity, EntityId, PopulationIterator};
 use crate::hashing::IndexSet;
-use crate::random::{
-    count_and_sample_single_l_reservoir, sample_multiple_from_known_length,
-    sample_multiple_l_reservoir, sample_single_l_reservoir,
-};
 
 enum EntitySetIteratorInner<'a, E: Entity> {
     Source(SourceIterator<'a, E>),
@@ -271,66 +264,6 @@ impl<'c, E: Entity> EntitySetIterator<'c, E> {
     pub(super) fn new(set: EntitySet<'c, E>) -> Self {
         EntitySetIterator {
             inner: EntitySetIteratorInner::from_entity_set(set),
-        }
-    }
-
-    /// Sample a single entity uniformly from the query results. Returns `None` if the
-    /// query's result set is empty.
-    pub fn sample_entity<R>(mut self, rng: &mut R) -> Option<EntityId<E>>
-    where
-        R: Rng,
-    {
-        // The known length case
-        let (lower, upper) = self.size_hint();
-        if Some(lower) == upper {
-            if lower == 0 {
-                warn!("Requested a sample entity from an empty population");
-                return None;
-            }
-            // This little trick with `u32` makes this function 30% faster.
-            let index = rng.random_range(0..lower as u32);
-            return self.nth(index as usize);
-        }
-
-        // Slow path
-        sample_single_l_reservoir(rng, self)
-    }
-
-    /// Count query results and sample one entity uniformly from them.
-    ///
-    /// Returns `(count, sample)` where `sample` is `None` iff `count == 0`.
-    pub fn count_and_sample_entity<R>(mut self, rng: &mut R) -> (usize, Option<EntityId<E>>)
-    where
-        R: Rng,
-    {
-        let (lower, upper) = self.size_hint();
-        if Some(lower) == upper {
-            if lower == 0 {
-                return (0, None);
-            }
-            let index = rng.random_range(0..lower as u32);
-            return (lower, self.nth(index as usize));
-        }
-
-        count_and_sample_single_l_reservoir(rng, self)
-    }
-
-    /// Sample up to `requested` entities uniformly from the query results. If the
-    /// query's result set has fewer than `requested` entities, the entire result
-    /// set is returned.
-    pub fn sample_entities<R>(self, rng: &mut R, requested: usize) -> Vec<EntityId<E>>
-    where
-        R: Rng,
-    {
-        match self.size_hint() {
-            (lower, Some(upper)) if lower == upper => {
-                if lower == 0 {
-                    warn!("Requested a sample of entities from an empty population");
-                    return vec![];
-                }
-                sample_multiple_from_known_length(rng, self, requested)
-            }
-            _ => sample_multiple_l_reservoir(rng, self, requested),
         }
     }
 }

--- a/src/entity/entity_set/source_set.rs
+++ b/src/entity/entity_set/source_set.rs
@@ -352,6 +352,15 @@ impl<'a, E: Entity> SourceSet<'a, E> {
         }
     }
 
+    /// Random-access lookup. Defined for the same variants as `try_len`.
+    pub(super) fn try_nth(&self, idx: usize) -> Option<EntityId<E>> {
+        match self {
+            SourceSet::PopulationRange(range) => range.clone().nth(idx).map(EntityId::new),
+            SourceSet::IndexSet(source) => source.get_index(idx).copied(),
+            SourceSet::PropertySet(_) => None,
+        }
+    }
+
     /// Ordering key used for source selection.
     pub(super) fn sort_key(&self) -> (usize, u8) {
         match self {

--- a/src/random/mod.rs
+++ b/src/random/mod.rs
@@ -6,8 +6,9 @@ use std::cell::RefCell;
 
 pub use context_ext::ContextRandomExt;
 pub use sampling_algorithms::{
-    count_and_sample_single_l_reservoir, sample_excluding_iteration, sample_excluding_rejection,
-    sample_multiple_from_known_length, sample_multiple_l_reservoir, sample_single_excluding,
+    count_and_sample_single_l_reservoir, sample_multiple_from_known_length,
+    sample_multiple_l_reservoir, sample_single_excluding, sample_single_excluding_iteration,
+    sample_single_excluding_l_reservoir, sample_single_excluding_rejection,
     sample_single_from_known_length, sample_single_l_reservoir,
 };
 

--- a/src/random/mod.rs
+++ b/src/random/mod.rs
@@ -6,8 +6,9 @@ use std::cell::RefCell;
 
 pub use context_ext::ContextRandomExt;
 pub use sampling_algorithms::{
-    count_and_sample_single_l_reservoir, sample_multiple_from_known_length,
-    sample_multiple_l_reservoir, sample_single_from_known_length, sample_single_l_reservoir,
+    count_and_sample_single_l_reservoir, sample_excluding_iteration, sample_excluding_rejection,
+    sample_multiple_from_known_length, sample_multiple_l_reservoir, sample_single_excluding,
+    sample_single_from_known_length, sample_single_l_reservoir,
 };
 
 pub use crate::define_rng;

--- a/src/random/sampling_algorithms.rs
+++ b/src/random/sampling_algorithms.rs
@@ -1,6 +1,8 @@
 //! Algorithms for uniform random sampling from hash sets or iterators. These algorithms are written to be generic
 //! over the container type using zero-cost trait abstractions.
 
+use std::borrow::Borrow;
+
 use crate::rand::seq::index::sample as choose_range;
 use crate::rand::Rng;
 
@@ -194,6 +196,95 @@ where
             None => return reservoir,
         }
     }
+}
+
+/// Samples one element uniformly at random from `slice`, excluding any element
+/// equal to `excluded`. Returns `None` if the slice is empty or every element
+/// equals `excluded`.
+///
+/// `excluded` accepts either an owned `T` or a borrowed `&T` via the
+/// `Borrow<T>` bound. Dispatches to `sample_excluding_iteration` for slices of
+/// length `< 4` and `sample_excluding_rejection` otherwise. Tuned via
+/// `ixa-bench/criterion/sample_single_excluding.rs`.
+pub fn sample_single_excluding<'a, R, T, E>(
+    rng: &mut R,
+    slice: &'a [T],
+    excluded: E,
+) -> Option<&'a T>
+where
+    R: Rng,
+    T: PartialEq,
+    E: Borrow<T>,
+{
+    const SMALL_SLICE: usize = 4;
+    let excluded = excluded.borrow();
+    if slice.len() < SMALL_SLICE {
+        sample_excluding_iteration(rng, slice, excluded)
+    } else {
+        sample_excluding_rejection(rng, slice, excluded)
+    }
+}
+
+/// Linear-scan implementation of `sample_single_excluding`. Counts non-excluded
+/// entries, then picks the k-th. Wins for very small slices (`n <= 3`) where
+/// the per-trial overhead of rejection sampling exceeds the cost of a tiny
+/// filter. Exposed so benchmarks can compare strategies directly.
+pub fn sample_excluding_iteration<'a, R, T, E>(
+    rng: &mut R,
+    slice: &'a [T],
+    excluded: E,
+) -> Option<&'a T>
+where
+    R: Rng,
+    T: PartialEq,
+    E: Borrow<T>,
+{
+    let excluded = excluded.borrow();
+    let valid_count = slice.iter().filter(|&x| x != excluded).count();
+    if valid_count == 0 {
+        return None;
+    }
+    let k = rng.random_range(0..valid_count as u32) as usize;
+    slice.iter().filter(|&x| x != excluded).nth(k)
+}
+
+/// Rejection-sampling implementation of `sample_single_excluding`. Picks a
+/// uniform index, accepts if not equal to `excluded`. Wins at `n >= 4` and is
+/// essentially constant time when `excluded` appears 0 or 1 times. Falls
+/// through to `sample_excluding_iteration` after at most 16 consecutive
+/// matches (or `n`, whichever is smaller), which also returns `None` when
+/// every element matches. Exposed so benchmarks can compare strategies
+/// directly.
+pub fn sample_excluding_rejection<'a, R, T, E>(
+    rng: &mut R,
+    slice: &'a [T],
+    excluded: E,
+) -> Option<&'a T>
+where
+    R: Rng,
+    T: PartialEq,
+    E: Borrow<T>,
+{
+    // The `u32` cast on `random_range` arguments is faster than the `usize`
+    // form (see `sample_single_from_known_length`).
+    //
+    // Cap trials at `min(MAX_REJECTIONS, n)`: once we've drawn `n` indices
+    // and all matched, almost the entire slice equals `excluded` and the
+    // iteration path is cheaper than retrying.
+    const MAX_REJECTIONS: usize = 16;
+    if slice.is_empty() {
+        return None;
+    }
+    let excluded = excluded.borrow();
+    let trials = MAX_REJECTIONS.min(slice.len());
+    for _ in 0..trials {
+        let i = rng.random_range(0..slice.len() as u32) as usize;
+        let candidate = &slice[i];
+        if candidate != excluded {
+            return Some(candidate);
+        }
+    }
+    sample_excluding_iteration(rng, slice, excluded)
 }
 
 #[cfg(test)]
@@ -660,5 +751,155 @@ mod tests {
 
         // Same seed should produce identical samples
         assert_eq!(sample1, sample2);
+    }
+
+    #[test]
+    fn sample_single_excluding_empty_slice_returns_none() {
+        let data: [u32; 0] = [];
+        let mut rng = StdRng::seed_from_u64(42);
+        assert_eq!(sample_single_excluding(&mut rng, &data, 7), None);
+    }
+
+    #[test]
+    fn sample_single_excluding_only_excluded_returns_none() {
+        let data = [9, 9, 9, 9];
+        let mut rng = StdRng::seed_from_u64(42);
+        assert_eq!(sample_single_excluding(&mut rng, &data, 9), None);
+    }
+
+    #[test]
+    fn sample_single_excluding_never_returns_excluded_small() {
+        let data: Vec<u32> = (0..10).collect();
+        let mut rng = StdRng::seed_from_u64(42);
+        for _ in 0..1000 {
+            let v = sample_single_excluding(&mut rng, &data, 3).unwrap();
+            assert_ne!(*v, 3);
+            assert!(*v < 10);
+        }
+    }
+
+    #[test]
+    fn sample_single_excluding_never_returns_excluded_large() {
+        // Large slice: exercises the rejection-sampling path.
+        let data: Vec<u32> = (0..1000).collect();
+        let mut rng = StdRng::seed_from_u64(42);
+        for _ in 0..1000 {
+            let v = sample_single_excluding(&mut rng, &data, 500).unwrap();
+            assert_ne!(*v, 500);
+            assert!(*v < 1000);
+        }
+    }
+
+    #[test]
+    fn sample_single_excluding_excluded_not_in_slice() {
+        let data: Vec<u32> = (0..10).collect();
+        let mut rng = StdRng::seed_from_u64(42);
+        for _ in 0..100 {
+            let v = sample_single_excluding(&mut rng, &data, 999).unwrap();
+            assert!(*v < 10);
+        }
+    }
+
+    #[test]
+    fn sample_single_excluding_falls_back_when_excluded_dominates() {
+        // 99.8% of values equal `excluded`: rejection retries get exhausted
+        // and the scan fallback runs. Both rare non-excluded values must show
+        // up across 200 samples.
+        let mut data = vec![0u32; 1000];
+        data[42] = 1;
+        data[800] = 2;
+        let mut rng = StdRng::seed_from_u64(42);
+        let mut seen: Vec<u32> = (0..200)
+            .map(|_| *sample_single_excluding(&mut rng, &data, 0).unwrap())
+            .collect();
+        seen.sort();
+        seen.dedup();
+        assert_eq!(seen, vec![1, 2]);
+    }
+
+    #[test]
+    fn sample_single_excluding_uniformity_small() {
+        // Small slice → iteration path.
+        let data: Vec<u32> = (0..20).collect();
+        let excluded = 7u32;
+        let num_runs = 50_000;
+        let mut counts = [0usize; 20];
+        let mut rng = StdRng::seed_from_u64(42);
+        for _ in 0..num_runs {
+            let v = sample_single_excluding(&mut rng, &data, excluded).unwrap();
+            counts[*v as usize] += 1;
+        }
+        assert_eq!(counts[excluded as usize], 0);
+
+        let expected = num_runs as f64 / 19.0;
+        let chi_square: f64 = counts
+            .iter()
+            .enumerate()
+            .filter(|(i, _)| *i != excluded as usize)
+            .map(|(_, &obs)| {
+                let diff = obs as f64 - expected;
+                diff * diff / expected
+            })
+            .sum();
+        // df = 18, χ²_{0.999} ≈ 42.31
+        assert!(chi_square < 42.31, "χ² = {chi_square}");
+    }
+
+    #[test]
+    fn sample_single_excluding_uniformity_large() {
+        // Large slice: rejection-sampling path.
+        let data: Vec<u32> = (0..200).collect();
+        let excluded = 99u32;
+        let num_runs = 200_000;
+        let mut counts = vec![0usize; 200];
+        let mut rng = StdRng::seed_from_u64(42);
+        for _ in 0..num_runs {
+            let v = sample_single_excluding(&mut rng, &data, excluded).unwrap();
+            counts[*v as usize] += 1;
+        }
+        assert_eq!(counts[excluded as usize], 0);
+
+        let expected = num_runs as f64 / 199.0;
+        let chi_square: f64 = counts
+            .iter()
+            .enumerate()
+            .filter(|(i, _)| *i != excluded as usize)
+            .map(|(_, &obs)| {
+                let diff = obs as f64 - expected;
+                diff * diff / expected
+            })
+            .sum();
+        // df = 198, χ²_{0.999} ≈ 264.69
+        assert!(chi_square < 264.69, "χ² = {chi_square}");
+    }
+
+    #[test]
+    #[allow(clippy::needless_borrows_for_generic_args)]
+    fn sample_single_excluding_accepts_owned_or_borrowed_excluded() {
+        // The `Borrow<T>` bound on `excluded` lets callers pass either an owned
+        // `T` or a `&T`; both must compile and produce the same answer.
+        let data: Vec<u32> = (0..10).collect();
+        let mut rng_owned = StdRng::seed_from_u64(42);
+        let mut rng_ref = StdRng::seed_from_u64(42);
+        let excluded = 3u32;
+        for _ in 0..50 {
+            let owned = sample_single_excluding(&mut rng_owned, &data, excluded);
+            let borrowed = sample_single_excluding(&mut rng_ref, &data, &excluded);
+            assert_eq!(owned, borrowed);
+        }
+    }
+
+    #[test]
+    fn sample_single_excluding_reproducibility() {
+        let data: Vec<u32> = (0..1000).collect();
+        let seed = 12345u64;
+
+        let mut rng1 = StdRng::seed_from_u64(seed);
+        let mut rng2 = StdRng::seed_from_u64(seed);
+        for _ in 0..100 {
+            let a = sample_single_excluding(&mut rng1, &data, 500);
+            let b = sample_single_excluding(&mut rng2, &data, 500);
+            assert_eq!(a, b);
+        }
     }
 }

--- a/src/random/sampling_algorithms.rs
+++ b/src/random/sampling_algorithms.rs
@@ -203,8 +203,8 @@ where
 /// equals `excluded`.
 ///
 /// `excluded` accepts either an owned `T` or a borrowed `&T` via the
-/// `Borrow<T>` bound. Dispatches to `sample_excluding_iteration` for slices of
-/// length `< 4` and `sample_excluding_rejection` otherwise. Tuned via
+/// `Borrow<T>` bound. Dispatches to `sample_single_excluding_iteration` for slices of
+/// length `< 4` and `sample_single_excluding_rejection` otherwise. Tuned via
 /// `ixa-bench/criterion/sample_single_excluding.rs`.
 pub fn sample_single_excluding<'a, R, T, E>(
     rng: &mut R,
@@ -219,9 +219,9 @@ where
     const SMALL_SLICE: usize = 4;
     let excluded = excluded.borrow();
     if slice.len() < SMALL_SLICE {
-        sample_excluding_iteration(rng, slice, excluded)
+        sample_single_excluding_iteration(rng, slice, excluded)
     } else {
-        sample_excluding_rejection(rng, slice, excluded)
+        sample_single_excluding_rejection(rng, slice, excluded)
     }
 }
 
@@ -229,7 +229,7 @@ where
 /// entries, then picks the k-th. Wins for very small slices (`n <= 3`) where
 /// the per-trial overhead of rejection sampling exceeds the cost of a tiny
 /// filter. Exposed so benchmarks can compare strategies directly.
-pub fn sample_excluding_iteration<'a, R, T, E>(
+pub fn sample_single_excluding_iteration<'a, R, T, E>(
     rng: &mut R,
     slice: &'a [T],
     excluded: E,
@@ -251,11 +251,11 @@ where
 /// Rejection-sampling implementation of `sample_single_excluding`. Picks a
 /// uniform index, accepts if not equal to `excluded`. Wins at `n >= 4` and is
 /// essentially constant time when `excluded` appears 0 or 1 times. Falls
-/// through to `sample_excluding_iteration` after at most 16 consecutive
+/// through to `sample_single_excluding_iteration` after at most 16 consecutive
 /// matches (or `n`, whichever is smaller), which also returns `None` when
 /// every element matches. Exposed so benchmarks can compare strategies
 /// directly.
-pub fn sample_excluding_rejection<'a, R, T, E>(
+pub fn sample_single_excluding_rejection<'a, R, T, E>(
     rng: &mut R,
     slice: &'a [T],
     excluded: E,
@@ -284,7 +284,34 @@ where
             return Some(candidate);
         }
     }
-    sample_excluding_iteration(rng, slice, excluded)
+    sample_single_excluding_iteration(rng, slice, excluded)
+}
+
+/// Sample one element uniformly from an iterator, excluding any element equal
+/// to `excluded`. Returns `None` if the iterator is empty or every element
+/// equals `excluded`.
+///
+/// This is the iterator counterpart to [`sample_single_excluding`]. It runs
+/// in O(n) time and is correct even when the iterator does not report an
+/// exact length. Prefer [`sample_single_excluding`] for slices, which can
+/// dispatch to a faster rejection-sampling strategy backed by random access.
+pub fn sample_single_excluding_l_reservoir<I, R, T, E>(
+    rng: &mut R,
+    iterable: I,
+    excluded: E,
+) -> Option<T>
+where
+    R: Rng,
+    T: PartialEq,
+    I: IntoIterator<Item = T>,
+    E: Borrow<T>,
+{
+    let excluded = excluded.borrow();
+    let (_, chosen) = count_and_sample_single_l_reservoir(
+        rng,
+        iterable.into_iter().filter(|item| item != excluded),
+    );
+    chosen
 }
 
 #[cfg(test)]
@@ -899,6 +926,95 @@ mod tests {
         for _ in 0..100 {
             let a = sample_single_excluding(&mut rng1, &data, 500);
             let b = sample_single_excluding(&mut rng2, &data, 500);
+            assert_eq!(a, b);
+        }
+    }
+
+    #[test]
+    fn sample_single_excluding_l_reservoir_empty_returns_none() {
+        let data: [u32; 0] = [];
+        let mut rng = StdRng::seed_from_u64(42);
+        assert_eq!(
+            sample_single_excluding_l_reservoir(&mut rng, data, 7u32),
+            None
+        );
+    }
+
+    #[test]
+    fn sample_single_excluding_l_reservoir_only_excluded_returns_none() {
+        let data = [9u32, 9, 9, 9];
+        let mut rng = StdRng::seed_from_u64(42);
+        assert_eq!(
+            sample_single_excluding_l_reservoir(&mut rng, data, 9u32),
+            None
+        );
+    }
+
+    #[test]
+    fn sample_single_excluding_l_reservoir_never_returns_excluded() {
+        let data: Vec<u32> = (0..50).collect();
+        let mut rng = StdRng::seed_from_u64(42);
+        for _ in 0..1000 {
+            let v =
+                sample_single_excluding_l_reservoir(&mut rng, data.iter().copied(), 17u32).unwrap();
+            assert_ne!(v, 17);
+            assert!(v < 50);
+        }
+    }
+
+    #[test]
+    fn sample_single_excluding_l_reservoir_uniformity() {
+        let excluded = 7u32;
+        let data: Vec<u32> = (0..20).collect();
+        let num_runs = 50_000;
+        let mut counts = [0usize; 20];
+        let mut rng = StdRng::seed_from_u64(42);
+        for _ in 0..num_runs {
+            let v = sample_single_excluding_l_reservoir(&mut rng, data.iter().copied(), excluded)
+                .unwrap();
+            counts[v as usize] += 1;
+        }
+        assert_eq!(counts[excluded as usize], 0);
+
+        let expected = num_runs as f64 / 19.0;
+        let chi_square: f64 = counts
+            .iter()
+            .enumerate()
+            .filter(|(i, _)| *i != excluded as usize)
+            .map(|(_, &obs)| {
+                let diff = obs as f64 - expected;
+                diff * diff / expected
+            })
+            .sum();
+        // df = 18, χ²_{0.999} ≈ 42.31
+        assert!(chi_square < 42.31, "χ² = {chi_square}");
+    }
+
+    #[test]
+    #[allow(clippy::needless_borrows_for_generic_args)]
+    fn sample_single_excluding_l_reservoir_accepts_owned_or_borrowed_excluded() {
+        let data: Vec<u32> = (0..10).collect();
+        let excluded = 3u32;
+        let mut rng_owned = StdRng::seed_from_u64(42);
+        let mut rng_ref = StdRng::seed_from_u64(42);
+        for _ in 0..50 {
+            let owned =
+                sample_single_excluding_l_reservoir(&mut rng_owned, data.iter().copied(), excluded);
+            let borrowed =
+                sample_single_excluding_l_reservoir(&mut rng_ref, data.iter().copied(), &excluded);
+            assert_eq!(owned, borrowed);
+        }
+    }
+
+    #[test]
+    fn sample_single_excluding_l_reservoir_reproducibility() {
+        let data: Vec<u32> = (0..1000).collect();
+        let seed = 12345u64;
+        let mut rng1 = StdRng::seed_from_u64(seed);
+        let mut rng2 = StdRng::seed_from_u64(seed);
+        for _ in 0..100 {
+            let a = sample_single_excluding_l_reservoir(&mut rng1, data.iter().copied(), 500u32);
+            let b = sample_single_excluding_l_reservoir(&mut rng2, data.iter().copied(), 500u32);
             assert_eq!(a, b);
         }
     }


### PR DESCRIPTION
This adds a `sample_single_excluding` method for sampling a random peer member (determined via `PartialEq`). I guess we could also rename it to `sample_peer`.


```rs
let peers: Vec<PersonId> = /* ... */;
let me: PersonId = /* ... */;

let peer = context
      .sample(PeerRng, |rng| sample_single_excluding(rng, &peers, me))
      .expect("at least one other peer");
 let peer = context.sample(PeerRng, |rng| sample_single_excluding(rng, &peers, &me));
```
It uses iteration at small n and rejection at larger n (>=4). Benchmarks suggest the advantages for iteration are clear at `2` and within noise for `3`. To run benchmarks:

```
cargo bench --bench sample_single_excluding -p ixa-bench
```

Results (3 runs, `sample_size = 200`, `--warm-up-time 2 --measurement-time 5`):
                                                                                                            
  | n | run 1 rej / iter / auto | run 2 rej / iter / auto | run 3 rej / iter / auto | median best | gap |   
  |---:|---|---|---|---|---|                                                                                
  | 2 | 26.0 / 6.2 / 7.1 | 20.0 / 5.8 / 6.9 | 17.9 / 6.8 / 6.8 | iteration ~6.3 | iteration ~3x faster than rejection |                                                                                               
  | 3 | 13.1 / 13.7 / 19.0 | 13.2 / 11.7 / 12.3 | 13.2 / 12.8 / 14.0 | tied ~13 | within noise |          
  | 4 | 10.4 / 15.1 / 11.0 | 11.2 / 21.1 / 9.0 | 12.1 / 15.3 / 11.0 | rejection ~11 | rejection ~30% faster than iteration |   