### PR TITLE
chore: Update several dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ serde_json = "^1.0.135"
 ixa-derive = { version = "2.0.0-beta.2", path = "ixa-derive" }
 seq-macro = "^0.3.5"
 paste = "^1.0.15"
-ctor = "^0.5.0"
+ctor = "^1.0.1"
 clap = { version = "^4.5.26", features = ["derive"] }
 clap-markdown = "0.1.5"
 log = "^0.4.22"
@@ -54,7 +54,6 @@ anyhow = "^1.0.28"
 sysinfo = "^0.37.0"
 humantime = "^2.2.0"
 bytesize = "^2.0.1"
-hashbrown = "^0.16.0"
 ouroboros = "^0.18.5"
 thiserror = "^2.0.11"
 smallbox = "^0.8.8"
@@ -99,7 +98,6 @@ delegate.workspace = true
 sysinfo = { workspace = true, optional = true }
 humantime.workspace = true
 bytesize = { workspace = true, optional = true }
-hashbrown.workspace = true
 xxhash-rust.workspace = true
 rustc-hash.workspace = true
 thiserror.workspace = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,9 +38,9 @@ xxhash-rust = { version = "^0.8.15", features = ["const_xxh3", "xxh3"] }
 rustc-hash = "^2.1.1"
 tempfile = "^3.15.0"
 assert_cmd = "^2.0.16"
-criterion = "^0.7.0"
+criterion = "^0.8.2"
 assert_approx_eq = "^1.1.0"
-strum = { version = "^0.27.1", features = ["derive"] }
+strum = { version = "^0.28.0", features = ["derive"] }
 quote = "^1.0.38"
 syn = { version = "^2.0.95" }
 proc-macro2 = "1.0.93"
@@ -51,7 +51,7 @@ getrandom = "0.3.4"
 fern = "^0.7.1"
 wasm-bindgen = "^0.2.100"
 anyhow = "^1.0.28"
-sysinfo = "^0.37.0"
+sysinfo = "^0.38.4"
 humantime = "^2.2.0"
 bytesize = "^2.0.1"
 ouroboros = "^0.18.5"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,8 @@ serde_json = "^1.0.135"
 ixa-derive = { version = "2.0.0-beta.2", path = "ixa-derive" }
 seq-macro = "^0.3.5"
 paste = "^1.0.15"
-ctor = "^1.0.1"
+# We avoid the `priority` feature of `ctor`. See https://github.com/mmastrac/linktime/issues/454.
+ctor = { version = "^1.0.1", default-features = false, features = ["std", "proc_macro"] }
 clap = { version = "^4.5.26", features = ["derive"] }
 clap-markdown = "0.1.5"
 log = "^0.4.22"

--- a/ixa-bench/src/bench_utils/macros.rs
+++ b/ixa-bench/src/bench_utils/macros.rs
@@ -20,7 +20,7 @@ macro_rules! hyperfine_group {
                     Ok(())
                 }
 
-                #[ctor::ctor]
+                #[ctor::ctor(unsafe)]
                 fn [<_register_group_$group_name:snake>]() {
                     registry::register_group(stringify!($group_name), registry::BenchGroupEntry {
                         name: stringify!($group_name),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -106,28 +106,3 @@ pub mod execution_stats;
 pub mod profiling;
 
 pub mod data_structures;
-
-// The following is a workaround for an ICE involving wasm-bindgen:
-// https://github.com/CDCgov/ixa/actions/runs/16283417455/job/45977349528?pr=464
-#[cfg(target_family = "wasm")]
-use wasm_bindgen::prelude::wasm_bindgen;
-
-// See: https://github.com/rustwasm/wasm-bindgen/issues/4446
-#[cfg(target_family = "wasm")]
-mod wasm_workaround {
-    extern "C" {
-        pub(super) fn __wasm_call_ctors();
-    }
-}
-
-// See: https://github.com/rustwasm/wasm-bindgen/issues/4446
-#[cfg(target_family = "wasm")]
-#[wasm_bindgen(start)]
-fn start() {
-    // fix:
-    // Error: Read a negative address value from the stack. Did we run out of memory?
-    #[cfg(target_family = "wasm")]
-    unsafe {
-        wasm_workaround::__wasm_call_ctors()
-    };
-}

--- a/src/macros/define_data_plugin.rs
+++ b/src/macros/define_data_plugin.rs
@@ -31,7 +31,7 @@ macro_rules! __define_data_plugin {
 
         $crate::paste::paste! {
             $crate::ctor::declarative::ctor!{
-                #[ctor]
+                #[ctor(unsafe)]
                 fn [<_register_plugin_$data_plugin:snake>]() {
                     $crate::add_data_plugin_to_registry::<$data_plugin>()
                 }

--- a/src/macros/define_global_property.rs
+++ b/src/macros/define_global_property.rs
@@ -50,7 +50,7 @@ macro_rules! define_global_property {
 
         $crate::paste::paste! {
             $crate::ctor::declarative::ctor!{
-                #[ctor]
+                #[ctor(unsafe)]
                 fn [<$global_property:snake _register>]() {
                     let module = module_path!();
                     let mut name = module.split("::").next().unwrap().to_string();

--- a/src/macros/edge_impl.rs
+++ b/src/macros/edge_impl.rs
@@ -71,7 +71,7 @@ macro_rules! impl_edge_type {
 
         $crate::paste::paste! {
             $crate::ctor::declarative::ctor!{
-                #[ctor]
+                #[ctor(unsafe)]
                 fn [<_register_edge_type_ $edge_type:snake _for_ $entity:snake>]() {
                     $crate::network::edge::add_to_edge_type_to_registry::<$entity, $edge_type>();
                 }

--- a/src/macros/entity_impl.rs
+++ b/src/macros/entity_impl.rs
@@ -70,7 +70,7 @@ macro_rules! impl_entity {
         // if we were willing to have a mechanism for interior mutability for `EntityStore`.
         $crate::paste::paste! {
             $crate::ctor::declarative::ctor!{
-                #[ctor]
+                #[ctor(unsafe)]
                 fn [<_register_entity_$entity_name:snake>]() {
                     $crate::entity::entity_store::add_to_entity_registry::<$entity_name>();
                 }

--- a/src/macros/property_impl.rs
+++ b/src/macros/property_impl.rs
@@ -797,7 +797,7 @@ macro_rules! impl_property {
 
         $crate::paste::paste! {
             $crate::ctor::declarative::ctor!{
-                #[ctor]
+                #[ctor(unsafe)]
                 fn [<_register_property_ $entity:snake _ $property:snake>]() {
                     $ctor_registration
                 }

--- a/src/plugin_context.rs
+++ b/src/plugin_context.rs
@@ -8,9 +8,8 @@ use crate::{
 /// for plugins implementing [`Context`] extensions.
 ///
 /// Usage:
-// This example triggers the error "#[ctor]/#[dtor] is not supported
-// on the current target," which appears to be spurious, so we
-// ignore it.
+// This example uses ctor-based registration, which is not supported
+// on every rustdoc target, so we ignore it.
 /// ```ignore
 /// use ixa::prelude_for_plugins::*;
 /// define_data_plugin!(MyData, bool, false);


### PR DESCRIPTION
This PR updates the following dependencies:

- `ctor@0.5.1` -> `ctor@1.0.1`
- `criterion@0.7.0` -> `criterion@0.8.2`
- `strum@0.27.1` -> `strum@0.28.0`
- `sysinfo@0.37.0` -> `sysinfo@0.38.4`

Also removed the unused `hashbrown` crate.

The only one requiring any source changes is `ctor`. The new version allows us to get rid of the `#[cfg(target_family = "wasm")]` stuff we have littering `lib.rs`. I separated it into its own commit.