### PR TITLE
feat: Compare `sample_entity_whole_population` relative to "sentinel" CPU-bound benchmark

### DIFF
--- a/ixa-bench/criterion/sample_entity_scaling.rs
+++ b/ixa-bench/criterion/sample_entity_scaling.rs
@@ -5,6 +5,7 @@ use std::time::Instant;
 
 use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion};
 use ixa::prelude::*;
+use ixa::rand::Rng;
 
 define_rng!(SampleScalingRng);
 
@@ -16,6 +17,9 @@ define_multi_property!((Species, Region), Mosquito);
 define_property!(struct Unindexed10(u8), Mosquito);
 
 const POPULATION_SIZES: [usize; 3] = [1_000, 10_000, 100_000];
+const WHOLE_POPULATION_SENTINEL: &str = "sentinel";
+const WHOLE_POPULATION_SENTINEL_UPPER: u32 = 100_000;
+const WHOLE_POPULATION_SENTINEL_RESULTS_SIZE: usize = 0;
 
 // Shared place to stash "ns per sample" per (bench_name, size)
 type Results = Arc<Mutex<BTreeMap<(String, usize), f64>>>;
@@ -69,6 +73,28 @@ fn print_scaling_summary(results: &BTreeMap<(String, usize), f64>, bench_name: &
     }
 }
 
+fn print_whole_population_sentinel_summary(
+    results: &BTreeMap<(String, usize), f64>,
+    bench_name: &str,
+) {
+    let sentinel_name = format!("{bench_name}/{WHOLE_POPULATION_SENTINEL}");
+    let Some(sentinel_ns) = results.get(&(sentinel_name, WHOLE_POPULATION_SENTINEL_RESULTS_SIZE))
+    else {
+        return;
+    };
+
+    eprintln!("\n=== Sentinel-relative summary: {bench_name} ===");
+    for &size in &POPULATION_SIZES {
+        let Some(sample_ns) = results.get(&(bench_name.to_string(), size)) else {
+            continue;
+        };
+        eprintln!(
+            "  n={size:>7}: sample={sample_ns:.2} ns/sample, sentinel={sentinel_ns:.2} ns/sample, ratio={:.3}x",
+            sample_ns / sentinel_ns,
+        );
+    }
+}
+
 // This is so we can do an O_n analysis of the benchmark
 fn bench_ns_per_sample<F>(bencher: &mut criterion::Bencher, mut f: F) -> f64
 where
@@ -102,8 +128,9 @@ pub fn bench_sample_entity_whole_population(c: &mut Criterion, results: Results)
 
         group.bench_with_input(BenchmarkId::from_parameter(size), &size, |b, _| {
             let ns = bench_ns_per_sample(b, || {
-                let _: Option<EntityId<Mosquito>> =
+                let sampled: Option<EntityId<Mosquito>> =
                     context.sample_entity(SampleScalingRng, Mosquito);
+                black_box(sampled);
             });
 
             results
@@ -112,6 +139,24 @@ pub fn bench_sample_entity_whole_population(c: &mut Criterion, results: Results)
                 .insert((bench_name.to_string(), size), ns);
         });
     }
+
+    let sentinel_context = setup_context(WHOLE_POPULATION_SENTINEL_UPPER as usize);
+    group.bench_function(WHOLE_POPULATION_SENTINEL, |b| {
+        let ns = bench_ns_per_sample(b, || {
+            let sampled = sentinel_context.sample(SampleScalingRng, |rng| {
+                rng.random_range(0..WHOLE_POPULATION_SENTINEL_UPPER)
+            });
+            black_box(sampled);
+        });
+
+        results.lock().unwrap().insert(
+            (
+                format!("{bench_name}/{WHOLE_POPULATION_SENTINEL}"),
+                WHOLE_POPULATION_SENTINEL_RESULTS_SIZE,
+            ),
+            ns,
+        );
+    });
 
     group.finish();
 }
@@ -205,6 +250,7 @@ fn sample_entity_scaling(c: &mut Criterion) {
     print_scaling_summary(&results, "sample_entity_single_property_indexed");
     print_scaling_summary(&results, "sample_entity_multi_property_indexed");
     print_scaling_summary(&results, "sample_entity_single_property_unindexed");
+    print_whole_population_sentinel_summary(&results, "sample_entity_whole_population");
 }
 
 criterion_group!(benches, sample_entity_scaling);

--- a/scripts/bench_results.mjs
+++ b/scripts/bench_results.mjs
@@ -25,6 +25,9 @@ import { fileURLToPath } from 'node:url';
 const __filename = fileURLToPath(import.meta.url);
 
 const DEFAULT_MAX_INPUT_BYTES = 100 * 1024 * 1024; // 100 MiB
+const SAMPLE_ENTITY_WHOLE_POPULATION_PREFIX = 'sample_entity_whole_population/';
+const SAMPLE_ENTITY_WHOLE_POPULATION_SENTINEL = 'sample_entity_whole_population/sentinel';
+const SAMPLE_ENTITY_WHOLE_POPULATION_SIZES = ['1000', '10000', '100000'];
 
 function maxInputBytes() {
   const raw = process.env.BENCH_RESULTS_MAX_INPUT_BYTES;
@@ -150,6 +153,48 @@ function parseCriterionCompareLog(text) {
   return Array.from(resultsByName.values());
 }
 
+function hasFinitePositiveTriple(values) {
+  return (
+    Array.isArray(values) &&
+    values.length >= 3 &&
+    values.slice(0, 3).every((value) => Number.isFinite(value) && value > 0)
+  );
+}
+
+function ratioText(value) {
+  return `${value.toFixed(3)}x`;
+}
+
+function addSampleEntityWholePopulationSentinelRatios(criterionTimings) {
+  const byName = new Map(criterionTimings.map((entry) => [entry.name, entry]));
+  const sentinel = byName.get(SAMPLE_ENTITY_WHOLE_POPULATION_SENTINEL);
+  if (!hasFinitePositiveTriple(sentinel?.time_sec)) return criterionTimings;
+
+  for (const size of SAMPLE_ENTITY_WHOLE_POPULATION_SIZES) {
+    const sampleName = `${SAMPLE_ENTITY_WHOLE_POPULATION_PREFIX}${size}`;
+    const sample = byName.get(sampleName);
+    if (!hasFinitePositiveTriple(sample?.time_sec)) continue;
+
+    const ratio = [
+      sample.time_sec[0] / sentinel.time_sec[2],
+      sample.time_sec[1] / sentinel.time_sec[1],
+      sample.time_sec[2] / sentinel.time_sec[0],
+    ];
+    if (!ratio.every((value) => Number.isFinite(value) && value > 0)) continue;
+
+    sample.relative_to_sentinel = {
+      kind: 'sentinel_ratio',
+      sentinel: SAMPLE_ENTITY_WHOLE_POPULATION_SENTINEL,
+      ratio,
+      ratio_text: ratio.map(ratioText),
+      method:
+        'sample_time / sentinel_time; lower=sample_lower/sentinel_upper; estimate=sample_estimate/sentinel_estimate; upper=sample_upper/sentinel_lower',
+    };
+  }
+
+  return criterionTimings;
+}
+
 function parseHyperfineJson(hyperfineJson) {
   if (!hyperfineJson || !Array.isArray(hyperfineJson.results)) return [];
 
@@ -224,7 +269,9 @@ function main() {
   const hyperfineTimings = parseHyperfineJson(hyperfineJson);
 
   const criterionCompareLog = readTextIfExists(criterionLogPath);
-  const criterionTimings = parseCriterionCompareLog(criterionCompareLog);
+  const criterionTimings = addSampleEntityWholePopulationSentinelRatios(
+    parseCriterionCompareLog(criterionCompareLog)
+  );
 
   const payload = {
     schema: 1,

--- a/scripts/format_bench_pr_comment.mjs
+++ b/scripts/format_bench_pr_comment.mjs
@@ -27,6 +27,7 @@ const CHANGE_SECTION_TITLES = ['Regressions', 'Improvements', 'Unchanged'];
 const NOT_COMPARED_SECTION_TITLE = 'Not Compared';
 const ALL_SECTION_TITLES = [...CHANGE_SECTION_TITLES, NOT_COMPARED_SECTION_TITLE];
 const SAMPLE_ENTITY_PREFIX = 'sample_entity_';
+const SAMPLE_ENTITY_WHOLE_POPULATION_SENTINEL = 'sample_entity_whole_population/sentinel';
 
 function readTextIfExists(filePath) {
   if (!filePath) return '';
@@ -106,6 +107,17 @@ function parseCriterionBodyToRows(body) {
   }
 
   return rows;
+}
+
+function criterionBenchmarkNameForRow(row) {
+  if (row.group === 'sample_entity') {
+    return row.param ? `${row.bench}/${row.param}` : row.bench;
+  }
+  return row.param ? `${row.group}/${row.bench}/${row.param}` : `${row.group}/${row.bench}`;
+}
+
+function isInternalCriterionBenchmarkName(name) {
+  return name === SAMPLE_ENTITY_WHOLE_POPULATION_SENTINEL;
 }
 
 function parseNotComparedBodyToRows(body) {
@@ -250,7 +262,9 @@ function buildMarkdown({ hyperfineMd, criterionDir, groups }) {
     for (const t of CHANGE_SECTION_TITLES) {
       const body = extracted[t];
       if (body == null) continue;
-      const rows = parseCriterionBodyToRows(body);
+      const rows = parseCriterionBodyToRows(body).filter(
+        (row) => !isInternalCriterionBenchmarkName(criterionBenchmarkNameForRow(row)),
+      );
       bySection[t].push(...rows);
     }
 

--- a/scripts/index.html
+++ b/scripts/index.html
@@ -215,6 +215,11 @@
           Show band
         </label>
 
+        <label class="checkbox" title="Overlay ratio to the same-job sentinel when available">
+          <input id="showRelative" type="checkbox" checked />
+          Show sentinel-relative line
+        </label>
+
         <label class="checkbox" title="Start the time-series y-axis at 0.0">
           <input id="yAxisZero" type="checkbox" checked />
           y-axis starts at 0.0
@@ -292,6 +297,8 @@
       const MAD_CLIP_MIN_POINTS = 8;
       const MAD_CLIP_PADDING = 1.05;
       const MAD_CLIP_MIN_SEPARATION_RATIO = 2.0;
+      const SAMPLE_ENTITY_WHOLE_POPULATION_SENTINEL =
+        "sample_entity_whole_population/sentinel";
 
       const $ = (id) => document.getElementById(id);
 
@@ -407,11 +414,21 @@
         return map;
       }
 
+      function isInternalCriterionBenchmarkName(name) {
+        return name === SAMPLE_ENTITY_WHOLE_POPULATION_SENTINEL;
+      }
+
       function listBenchmarks(suiteRuns) {
         const set = new Set();
         for (const r of suiteRuns) {
           for (const e of r.entries) {
-            if (e && typeof e.name === "string") set.add(e.name);
+            if (
+              e &&
+              typeof e.name === "string" &&
+              !isInternalCriterionBenchmarkName(e.name)
+            ) {
+              set.add(e.name);
+            }
           }
         }
         return [...set].sort((a, b) => a.localeCompare(b));
@@ -473,6 +490,29 @@
         return { lower, upper };
       }
 
+      function readRelativeRatio(entry, metric) {
+        const ratio = entry?.relative_to_sentinel?.ratio;
+        if (!Array.isArray(ratio) || ratio.length < 3) return null;
+        const lower = Number(ratio[0]);
+        const estimate = Number(ratio[1]);
+        const upper = Number(ratio[2]);
+        if (![lower, estimate, upper].every((value) => Number.isFinite(value))) {
+          return null;
+        }
+        if (metric === "lower") return lower;
+        if (metric === "upper") return upper;
+        return estimate;
+      }
+
+      function readRelativeBand(entry) {
+        const ratio = entry?.relative_to_sentinel?.ratio;
+        if (!Array.isArray(ratio) || ratio.length < 3) return null;
+        const lower = Number(ratio[0]);
+        const upper = Number(ratio[2]);
+        if (!Number.isFinite(lower) || !Number.isFinite(upper)) return null;
+        return { lower, upper };
+      }
+
       function makeLabels(suiteRuns) {
         return suiteRuns.map((r) => {
           const sha = safeSha(r?.head?.sha);
@@ -502,12 +542,17 @@
         benchmarkName,
         metric,
         showBand,
+        showRelative,
         yAxisZero,
         madClip,
       }) {
         const allPoints = [];
         const lowerBand = [];
         const upperBand = [];
+        const relativePoints = [];
+        const relativeLowerBand = [];
+        const relativeUpperBand = [];
+        const canShowRelative = suite === "criterion" && showRelative;
 
         for (const r of suiteRuns) {
           const byName = indexByName(r.entries);
@@ -516,9 +561,17 @@
           const band = showBand ? readBandSeconds(suite, entry) : null;
           lowerBand.push(band ? band.lower : null);
           upperBand.push(band ? band.upper : null);
+
+          const relativeValue = canShowRelative ? readRelativeRatio(entry, metric) : null;
+          relativePoints.push(relativeValue);
+          const relativeBand = canShowRelative && showBand ? readRelativeBand(entry) : null;
+          relativeLowerBand.push(relativeBand ? relativeBand.lower : null);
+          relativeUpperBand.push(relativeBand ? relativeBand.upper : null);
         }
 
         const vals = allPoints.filter((x) => Number.isFinite(x));
+        const relativeVals = relativePoints.filter((x) => Number.isFinite(x));
+        const hasRelative = relativeVals.length > 0;
         const unit = vals.length
           ? bestUnit(vals.slice().sort((a, b) => a - b)[Math.floor(vals.length / 2)])
           : { scale: 1, unit: "s" };
@@ -533,6 +586,8 @@
             borderWidth: 0,
             tension: 0.15,
             spanGaps: true,
+            yAxisID: "y",
+            showInLegend: false,
           });
           datasets.push({
             label: "upper",
@@ -544,6 +599,8 @@
             fill: "-1",
             tension: 0.15,
             spanGaps: true,
+            yAxisID: "y",
+            showInLegend: false,
           });
         }
 
@@ -556,12 +613,90 @@
           borderWidth: 2,
           tension: 0.15,
           spanGaps: true,
+          yAxisID: "y",
+          showInLegend: true,
         });
+
+        if (hasRelative && showBand) {
+          datasets.push({
+            label: "relative lower",
+            data: relativeLowerBand,
+            borderColor: "rgba(0,0,0,0)",
+            pointRadius: 0,
+            borderWidth: 0,
+            tension: 0.15,
+            spanGaps: true,
+            yAxisID: "yRelative",
+            showInLegend: false,
+          });
+          datasets.push({
+            label: "relative upper",
+            data: relativeUpperBand,
+            borderColor: "rgba(0,0,0,0)",
+            pointRadius: 0,
+            borderWidth: 0,
+            backgroundColor: "rgba(219, 111, 35, 0.14)",
+            fill: "-1",
+            tension: 0.15,
+            spanGaps: true,
+            yAxisID: "yRelative",
+            showInLegend: false,
+          });
+        }
+
+        if (hasRelative) {
+          datasets.push({
+            label: "Relative to sentinel",
+            data: relativePoints,
+            yAxisID: "yRelative",
+            borderColor: "rgba(219, 111, 35, 0.95)",
+            backgroundColor: "rgba(219, 111, 35, 0.15)",
+            pointRadius: 2,
+            borderWidth: 2,
+            tension: 0.15,
+            spanGaps: true,
+            showInLegend: true,
+          });
+        }
 
         const clipMaxSeconds = madClip
           ? madClipMaxSeconds([...allPoints, ...lowerBand, ...upperBand])
           : null;
         const clipMax = clipMaxSeconds == null ? undefined : clipMaxSeconds * unit.scale;
+        const relativeClipMax =
+          madClip && hasRelative
+            ? madClipMaxSeconds([...relativePoints, ...relativeLowerBand, ...relativeUpperBand])
+            : null;
+
+        const scales = {
+          y: {
+            min: yAxisZero ? 0 : undefined,
+            max: clipMax,
+            title: { display: true, text: `Time (${unit.unit})` },
+            ticks: { callback: (v) => `${v} ${unit.unit}` },
+          },
+          x: {
+            ticks: {
+              maxRotation: 0,
+              autoSkip: true,
+              maxTicksLimit: 6,
+            },
+          },
+        };
+
+        if (hasRelative) {
+          scales.yRelative = {
+            type: "linear",
+            position: "right",
+            grid: { drawOnChartArea: false },
+            min: yAxisZero ? 0 : undefined,
+            max: relativeClipMax == null ? undefined : relativeClipMax,
+            title: { display: true, text: "Relative (x sentinel)" },
+            ticks: {
+              callback: (value) => `${Number(value).toFixed(2)}x`,
+            },
+          };
+        }
 
         return new Chart(canvas, {
           type: "line",
@@ -571,35 +706,29 @@
             maintainAspectRatio: false,
             interaction: { mode: "index", intersect: false },
             plugins: {
-              legend: { display: false },
+              legend: {
+                display: hasRelative,
+                labels: {
+                  filter: (item, data) => {
+                    const dataset = data?.datasets?.[item.datasetIndex];
+                    return dataset?.showInLegend !== false;
+                  },
+                },
+              },
               tooltip: {
                 callbacks: {
                   label: (item) => {
-                    const scaled = item.parsed.y;
-                    if (scaled == null) return "(missing)";
-                    return `${item.dataset.label}: ${fmtSeconds(
-                      scaled / unit.scale,
-                      unit
-                    )}`;
+                    const value = item.parsed.y;
+                    if (value == null) return "(missing)";
+                    if (item.dataset.yAxisID === "yRelative") {
+                      return `${item.dataset.label}: ${Number(value).toFixed(3)}x sentinel`;
+                    }
+                    return `${item.dataset.label}: ${fmtSeconds(value / unit.scale, unit)}`;
                   },
                 },
               },
             },
-            scales: {
-              y: {
-                min: yAxisZero ? 0 : undefined,
-                max: clipMax,
-                title: { display: true, text: `Time (${unit.unit})` },
-                ticks: { callback: (v) => `${v} ${unit.unit}` },
-              },
-              x: {
-                ticks: {
-                  maxRotation: 0,
-                  autoSkip: true,
-                  maxTicksLimit: 6,
-                },
-              },
-            },
+            scales,
           },
         });
       }
@@ -610,6 +739,7 @@
         benchmarkName,
         metric,
         showBand,
+        showRelative,
         yAxisZero,
         madClip,
       }) {
@@ -642,6 +772,7 @@
             benchmarkName,
             metric,
             showBand,
+            showRelative,
             yAxisZero,
             madClip,
           });
@@ -687,6 +818,7 @@
                 benchmarkName: name,
                 metric,
                 showBand,
+                showRelative,
                 yAxisZero,
                 madClip,
               })
@@ -740,6 +872,7 @@
         /** @type {{name: string, pct: number}[]} */
         const changes = [];
         for (const [name, nextEntry] of nextMap.entries()) {
+          if (isInternalCriterionBenchmarkName(name)) continue;
           const prevEntry = prevMap.get(name);
           const a = readValueSeconds(suite, prevEntry, metric);
           const b = readValueSeconds(suite, nextEntry, metric);
@@ -931,6 +1064,7 @@
         const benchEl = $("benchmark");
         const metricEl = $("metric");
         const showBandEl = $("showBand");
+        const showRelativeEl = $("showRelative");
         const yAxisZeroEl = $("yAxisZero");
         const madClipEl = $("madClip");
 
@@ -948,6 +1082,7 @@
           const bench = benchEl.value;
           const metric = metricEl.value;
           const showBand = showBandEl.checked;
+          const showRelative = showRelativeEl.checked;
           const yAxisZero = yAxisZeroEl.checked;
           const madClip = madClipEl.checked;
 
@@ -959,6 +1094,7 @@
             benchmarkName: bench,
             metric,
             showBand,
+            showRelative,
             yAxisZero,
             madClip,
           });
@@ -1040,6 +1176,7 @@
         benchEl.addEventListener("change", rerender);
         metricEl.addEventListener("change", rerender);
         showBandEl.addEventListener("change", rerender);
+        showRelativeEl.addEventListener("change", rerender);
         yAxisZeroEl.addEventListener("change", rerender);
         madClipEl.addEventListener("change", rerender);
 

--- a/scripts/test_bench_results.sh
+++ b/scripts/test_bench_results.sh
@@ -29,6 +29,16 @@ cat >"$workdir/criterion-compare.txt" <<'TXT'
 Benchmarking sample_people/sampling_multiple_l_reservoir
 Benchmarking sample_people/another_bench
   time:   [10.771 ms 10.811 ms 10.866 ms]
+
+Benchmarking sample_entity_whole_population/1000
+Benchmarking sample_entity_whole_population/1000: Analyzing
+sample_entity_whole_population/1000
+  time:   [10.000 ns 11.000 ns 12.000 ns]
+
+Benchmarking sample_entity_whole_population/sentinel
+Benchmarking sample_entity_whole_population/sentinel: Analyzing
+sample_entity_whole_population/sentinel
+  time:   [4.000 ns 5.000 ns 6.000 ns]
 TXT
 
 cat >"$workdir/bench-history.json" <<'JSON'
@@ -100,5 +110,17 @@ if [[ "$low_ms" != "10.771 ms" ]]; then
   echo "Expected criterion low time 10.771 ms, got: $low_ms" >&2
   exit 1
 fi
+
+jq -e '
+  def abs: if . < 0 then -. else . end;
+  def close_to($expected): ((. - $expected) | abs) < 0.000000001;
+  .criterion.results[]
+  | select(.name=="sample_entity_whole_population/1000")
+  | .relative_to_sentinel.sentinel=="sample_entity_whole_population/sentinel"
+    and (.relative_to_sentinel.ratio[0] | close_to(10 / 6))
+    and (.relative_to_sentinel.ratio[1] | close_to(11 / 5))
+    and (.relative_to_sentinel.ratio[2] | close_to(12 / 4))
+    and (.relative_to_sentinel.ratio_text==["1.667x","2.200x","3.000x"])
+' "$workdir/bench-current.json" >/dev/null
 
 echo "OK: bench_results.mjs test passed"

--- a/scripts/test_format_bench_pr_comment.sh
+++ b/scripts/test_format_bench_pr_comment.sh
@@ -33,6 +33,7 @@ Regressions:
   sample_entity_multi_property_indexed     1000                                               0.774%    0.193%    1.318%
   sampling                                 sampling_multiple_unindexed_entities               2.509%    1.929%    3.084%
   sample_entity_whole_population           100000                                             2.338%    1.628%    3.068%
+  sample_entity_whole_population           sentinel                                           99.000%   98.000%  100.000%
 
 Improvements:
   Group                                    Bench                                              Change  CI Lower  CI Upper


### PR DESCRIPTION
Motivated by #874, this PR adds a CPU-bound "sentinel" benchmark and compares the _relative_ performance of `sample_entity_whole_population` in `sample_entity_scaling`. The idea is, even on different CPUs this relative performance will be stable.

Updated benchmark result processing to record `relative_to_sentinel` metadata for `sample_entity_whole_population/{1000,10000,100000}` when the sentinel is present. The dashboard now overlays that relative series on the same chart as absolute timing, with a right-side `x sentinel` axis, while hiding the sentinel as a standalone benchmark. PR benchmark comments also filter out the internal sentinel row.

Added test coverage for the result parser and PR comment formatter, including sentinel ratio recording and sentinel-row filtering.