### PR TITLE
chore: handle new Criterion benchmarks in CI

### DIFF
--- a/.github/workflows/bench-compare.yaml
+++ b/.github/workflows/bench-compare.yaml
@@ -49,25 +49,35 @@ jobs:
           target="${{ matrix.criterion_target }}"
 
           base_status=0
+          base_missing_target=0
           compare_status=0
           regress_status=0
 
           git checkout --force "origin/${{ github.event.pull_request.base.ref }}"
-          cargo bench -p ixa-bench --bench "$target" -- --save-baseline base 2>&1 | tee "criterion-base-${group}.txt" || base_status=$?
+          if cargo bench -p ixa-bench --bench "$target" -- --save-baseline base 2>&1 | tee "criterion-base-${group}.txt"; then
+            base_status=0
+          else
+            base_status=$?
+            if grep -F "no bench target named" "criterion-base-${group}.txt" >/dev/null && grep -F "$target" "criterion-base-${group}.txt" >/dev/null; then
+              base_missing_target=1
+              base_status=0
+              echo "Note: bench target '${target}' does not exist on the base branch; head benchmarks will be recorded without baseline comparison." | tee -a "criterion-base-${group}.txt"
+            fi
+          fi
 
           git checkout --force "${{ github.event.pull_request.head.sha }}"
-          if cargo bench -p ixa-bench --bench "$target" -- --baseline base 2>&1 | tee "criterion-compare-${group}.txt"; then
-            cargo run -q -p ixa-bench --bin check_criterion_regressions 2>&1 | tee "criterion-regressions-${group}.txt" || regress_status=$?
+          if cargo bench -p ixa-bench --bench "$target" -- --baseline-lenient base 2>&1 | tee "criterion-compare-${group}.txt"; then
+            cargo run -q -p ixa-bench --bin check_criterion_regressions -- --allow-empty --baseline base 2>&1 | tee "criterion-regressions-${group}.txt" || regress_status=$?
           else
             compare_status=$?
-            echo "Note: A comparison could not be generated. Maybe you added new benchmarks?" | tee "criterion-regressions-${group}.txt"
-            cargo bench -p ixa-bench --bench "$target" 2>&1 | tee -a "criterion-compare-${group}.txt" || true
+            echo "Criterion benchmark run failed for '${target}'." | tee "criterion-regressions-${group}.txt"
           fi
 
           {
             echo "group=${group}"
             echo "target=${target}"
             echo "base_status=${base_status}"
+            echo "base_missing_target=${base_missing_target}"
             echo "compare_status=${compare_status}"
             echo "regress_status=${regress_status}"
             echo "base_ref=${{ github.event.pull_request.base.ref }}"
@@ -92,6 +102,7 @@ jobs:
             source "status-${group}.env"
           else
             base_status="unknown"
+            base_missing_target="unknown"
             compare_status="unknown"
             regress_status="unknown"
             base_ref="${{ github.event.pull_request.base.ref }}"
@@ -105,7 +116,7 @@ jobs:
             echo
             printf -- '- Base: `%s` (`%s`)\n' "$base_ref" "$base_sha"
             printf -- '- Head: `%s` (`%s`)\n' "$head_ref" "$head_sha"
-            printf -- '- Statuses: baseline=`%s`, compare=`%s`, regressions=`%s`\n' "$base_status" "$compare_status" "$regress_status"
+            printf -- '- Statuses: baseline=`%s`, base_missing_target=`%s`, compare=`%s`, regressions=`%s`\n' "$base_status" "$base_missing_target" "$compare_status" "$regress_status"
             echo
             echo '```'
             if [ -f "criterion-regressions-${group}.txt" ]; then

--- a/.github/workflows/bench-compare.yaml
+++ b/.github/workflows/bench-compare.yaml
@@ -67,7 +67,7 @@ jobs:
 
           git checkout --force "${{ github.event.pull_request.head.sha }}"
           if cargo bench -p ixa-bench --bench "$target" -- --baseline-lenient base 2>&1 | tee "criterion-compare-${group}.txt"; then
-            cargo run -q -p ixa-bench --bin check_criterion_regressions -- --allow-empty --baseline base 2>&1 | tee "criterion-regressions-${group}.txt" || regress_status=$?
+            cargo run -q -p ixa-bench --bin check_criterion_regressions -- --baseline base 2>&1 | tee "criterion-regressions-${group}.txt" || regress_status=$?
           else
             compare_status=$?
             echo "Criterion benchmark run failed for '${target}'." | tee "criterion-regressions-${group}.txt"

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # Criterion.rs output file.
 profile.json
+profiling.json
 
 .vscode/*
 .idea

--- a/ixa-bench/src/check_criterion_regressions.rs
+++ b/ixa-bench/src/check_criterion_regressions.rs
@@ -1,4 +1,4 @@
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::{env, fs};
 
 use serde_json::Value;
@@ -13,6 +13,45 @@ struct Est {
 }
 
 type TableRow = (String, String, String, String, String);
+type NotComparedRow = (String, String, String);
+
+#[derive(Debug)]
+struct Args {
+    allow_empty: bool,
+    baseline: String,
+    filter_group: Option<String>,
+}
+
+impl Default for Args {
+    fn default() -> Self {
+        Self {
+            allow_empty: false,
+            baseline: "base".to_string(),
+            filter_group: None,
+        }
+    }
+}
+
+#[derive(Debug)]
+struct BenchOutput {
+    group: String,
+    bench: String,
+    dir: PathBuf,
+}
+
+struct NotCompared {
+    group: String,
+    bench: String,
+    reason: String,
+}
+
+#[derive(Default)]
+struct Results {
+    regressions: Vec<Est>,
+    improvements: Vec<Est>,
+    unchanged: Vec<Est>,
+    not_compared: Vec<NotCompared>,
+}
 
 #[derive(Clone, Copy, Debug)]
 enum Verdict {
@@ -57,53 +96,91 @@ enum ReadVerdictError {
     },
     #[error("could not determine criterion verdict from report {path}")]
     MissingVerdict { path: String },
-    #[error("invalid report path for change file {path}")]
-    InvalidReportPath { path: String },
 }
 
-fn find_change_files(base: &Path) -> Vec<(String, String, std::path::PathBuf)> {
+fn parse_args<I, S>(args: I) -> Result<Args, String>
+where
+    I: IntoIterator<Item = S>,
+    S: Into<String>,
+{
+    let mut parsed = Args::default();
+    let mut args = args.into_iter().map(Into::into);
+
+    while let Some(arg) = args.next() {
+        match arg.as_str() {
+            "--allow-empty" => parsed.allow_empty = true,
+            "--baseline" => {
+                let baseline = args
+                    .next()
+                    .ok_or_else(|| "--baseline requires a value".to_string())?;
+                if baseline.is_empty() {
+                    return Err("--baseline requires a non-empty value".to_string());
+                }
+                parsed.baseline = baseline;
+            }
+            _ if arg.starts_with("--") => return Err(format!("unknown option: {arg}")),
+            _ => {
+                if parsed.filter_group.is_some() {
+                    return Err(format!("unexpected extra positional argument: {arg}"));
+                }
+                parsed.filter_group = Some(arg);
+            }
+        }
+    }
+
+    Ok(parsed)
+}
+
+fn is_benchmark_output_dir(dir: &Path) -> bool {
+    dir.join("change").join("estimates.json").exists()
+        || dir.join("new").join("estimates.json").exists()
+}
+
+fn find_benchmark_outputs(base: &Path) -> Vec<BenchOutput> {
     let mut results = Vec::new();
     if !base.exists() {
         return results;
     }
     if let Ok(groups) = fs::read_dir(base) {
-        for g in groups.flatten() {
-            let gpath = g.path();
-            if !gpath.is_dir() {
+        for group_entry in groups.flatten() {
+            let group_path = group_entry.path();
+            if !group_path.is_dir() {
                 continue;
             }
-            // If this directory itself contains a change/estimates.json then it's a bench with no group
-            let self_change = gpath.join("change").join("estimates.json");
-            if self_change.exists() {
-                if let Some(bs) = gpath.file_name() {
-                    results.push((
-                        String::new(),
-                        bs.to_string_lossy().into_owned(),
-                        self_change,
-                    ));
+
+            // A directory with criterion outputs directly under it is a benchmark with no group.
+            if is_benchmark_output_dir(&group_path) {
+                if let Some(bench_name) = group_path.file_name() {
+                    results.push(BenchOutput {
+                        group: String::new(),
+                        bench: bench_name.to_string_lossy().into_owned(),
+                        dir: group_path,
+                    });
                 }
                 continue;
             }
-            if let Ok(benches) = fs::read_dir(&gpath) {
-                for b in benches.flatten() {
-                    let bpath = b.path();
-                    if !bpath.is_dir() {
+
+            if let Ok(benches) = fs::read_dir(&group_path) {
+                for bench_entry in benches.flatten() {
+                    let bench_path = bench_entry.path();
+                    if !bench_path.is_dir() || !is_benchmark_output_dir(&bench_path) {
                         continue;
                     }
-                    let change_file = bpath.join("change").join("estimates.json");
-                    if change_file.exists() {
-                        if let (Some(gs), Some(bs)) = (gpath.file_name(), bpath.file_name()) {
-                            results.push((
-                                gs.to_string_lossy().into_owned(),
-                                bs.to_string_lossy().into_owned(),
-                                change_file,
-                            ));
-                        }
+
+                    if let (Some(group_name), Some(bench_name)) =
+                        (group_path.file_name(), bench_path.file_name())
+                    {
+                        results.push(BenchOutput {
+                            group: group_name.to_string_lossy().into_owned(),
+                            bench: bench_name.to_string_lossy().into_owned(),
+                            dir: bench_path,
+                        });
                     }
                 }
             }
         }
     }
+    results.sort_by(|a, b| a.group.cmp(&b.group).then_with(|| a.bench.cmp(&b.bench)));
     results
 }
 
@@ -198,6 +275,36 @@ fn print_table(
     println!();
 }
 
+fn print_not_compared_table(title: &str, rows: &[NotComparedRow], widths: &[usize; 3]) {
+    if rows.is_empty() {
+        println!("{}: (none)", title);
+        return;
+    }
+
+    println!("{}:", title);
+    println!(
+        "  {}  {}  {}",
+        "Group".pad_to_width(widths[0]),
+        "Bench".pad_to_width(widths[1]),
+        "Reason".pad_to_width(widths[2]),
+    );
+    println!(
+        "  {}  {}  {}",
+        "-".repeat(widths[0]),
+        "-".repeat(widths[1]),
+        "-".repeat(widths[2])
+    );
+    for row in rows {
+        println!(
+            "  {}  {}  {}",
+            row.0.pad_to_width(widths[0]),
+            row.1.pad_to_width(widths[1]),
+            row.2.pad_to_width(widths[2])
+        );
+    }
+    println!();
+}
+
 trait Pad {
     fn pad_to_width(&self, w: usize) -> String;
     fn pad_left_to_width(&self, w: usize) -> String;
@@ -232,90 +339,78 @@ impl Pad for String {
     }
 }
 
-fn main() {
-    let args: Vec<String> = env::args().collect();
-    let filter_group = if args.len() > 1 {
-        Some(args[1].clone())
-    } else {
-        None
-    };
-
-    let base = Path::new("target/criterion");
-    let change_files = find_change_files(base);
-    if change_files.is_empty() {
-        eprintln!("No criterion change outputs found under target/criterion");
-        std::process::exit(1);
+fn collect_results(base: &Path, args: &Args) -> Result<Results, String> {
+    let outputs = find_benchmark_outputs(base);
+    if outputs.is_empty() && !args.allow_empty {
+        return Err(format!(
+            "No criterion outputs found under {}",
+            base.display()
+        ));
     }
 
-    let mut regressions: Vec<Est> = Vec::new();
-    let mut improvements: Vec<Est> = Vec::new();
-    let mut unchanged: Vec<Est> = Vec::new();
+    let mut results = Results::default();
 
-    for (group, bench, path) in change_files {
-        // filtering
-        if let Some(ref fg) = filter_group {
-            if fg != &group {
+    for output in outputs {
+        if let Some(ref filter_group) = args.filter_group {
+            if filter_group != &output.group {
                 continue;
             }
         }
-        match read_est(&path) {
-            Ok((pe, lb, ub)) => {
-                let report_path = match path
-                    .parent()
-                    .and_then(|p| p.parent())
-                    .map(|p| p.join("report").join("index.html"))
-                {
-                    Some(p) => p,
-                    None => {
-                        eprintln!(
-                            "Error parsing {}: {}",
-                            path.display(),
-                            ReadVerdictError::InvalidReportPath {
-                                path: path.display().to_string(),
-                            }
-                        );
-                        std::process::exit(1);
-                    }
-                };
-                let verdict = match read_verdict(&report_path) {
-                    Ok(v) => v,
-                    Err(err) => {
-                        eprintln!("Error parsing {}: {}", report_path.display(), err);
-                        std::process::exit(1);
-                    }
-                };
 
-                let e = Est {
-                    group: group.clone(),
-                    bench: bench.clone(),
-                    pe,
-                    lb,
-                    ub,
-                };
-                match verdict {
-                    Verdict::Regressed => regressions.push(e),
-                    Verdict::Improved => improvements.push(e),
-                    Verdict::Unchanged => unchanged.push(e),
-                }
+        let change_path = output.dir.join("change").join("estimates.json");
+        if change_path.exists() {
+            let (pe, lb, ub) = read_est(&change_path)
+                .map_err(|err| format!("Error parsing {}: {err}", change_path.display()))?;
+            let report_path = output.dir.join("report").join("index.html");
+            let verdict = read_verdict(&report_path)
+                .map_err(|err| format!("Error parsing {}: {err}", report_path.display()))?;
+
+            let est = Est {
+                group: output.group,
+                bench: output.bench,
+                pe,
+                lb,
+                ub,
+            };
+            match verdict {
+                Verdict::Regressed => results.regressions.push(est),
+                Verdict::Improved => results.improvements.push(est),
+                Verdict::Unchanged => results.unchanged.push(est),
             }
-            Err(err) => {
-                eprintln!("Error parsing {}: {}", path.display(), err);
-                std::process::exit(1);
-            }
+        } else if output.dir.join("new").join("estimates.json").exists() {
+            let baseline_path = output.dir.join(&args.baseline).join("estimates.json");
+            let reason = if baseline_path.exists() {
+                "No comparison output generated".to_string()
+            } else {
+                format!("No baseline named '{}'", args.baseline)
+            };
+            results.not_compared.push(NotCompared {
+                group: output.group,
+                bench: output.bench,
+                reason,
+            });
         }
     }
 
-    // Prepare rows
+    Ok(results)
+}
+
+fn display_group(group: &str) -> String {
+    if group.is_empty() {
+        "(no group)".to_string()
+    } else {
+        group.to_string()
+    }
+}
+
+fn print_results(results: &Results) {
     let format_pct = |v: f64| format!("{:.3}%", v * 100.0);
-    let reg_rows: Vec<TableRow> = regressions
+    let reg_rows: Vec<TableRow> = results
+        .regressions
         .iter()
         .map(|e| {
             (
-                if e.group.is_empty() {
-                    "(no group)".to_string()
-                } else {
-                    e.group.clone()
-                },
+                display_group(&e.group),
                 e.bench.clone(),
                 format_pct(e.pe),
                 format_pct(e.lb),
@@ -323,15 +418,12 @@ fn main() {
             )
         })
         .collect();
-    let imp_rows: Vec<TableRow> = improvements
+    let imp_rows: Vec<TableRow> = results
+        .improvements
         .iter()
         .map(|e| {
             (
-                if e.group.is_empty() {
-                    "(no group)".to_string()
-                } else {
-                    e.group.clone()
-                },
+                display_group(&e.group),
                 e.bench.clone(),
                 format_pct(e.pe),
                 format_pct(e.lb),
@@ -339,27 +431,53 @@ fn main() {
             )
         })
         .collect();
-    let un_rows: Vec<TableRow> = unchanged
+    let un_rows: Vec<TableRow> = results
+        .unchanged
         .iter()
         .map(|e| {
             (
-                if e.group.is_empty() {
-                    "(no group)".to_string()
-                } else {
-                    e.group.clone()
-                },
+                display_group(&e.group),
                 e.bench.clone(),
                 format_pct(e.pe),
                 format_pct(e.lb),
                 format_pct(e.ub),
             )
         })
+        .collect();
+    let not_compared_rows: Vec<NotComparedRow> = results
+        .not_compared
+        .iter()
+        .map(|e| (display_group(&e.group), e.bench.clone(), e.reason.clone()))
         .collect();
 
     let widths = compute_global_widths(&[&reg_rows, &imp_rows, &un_rows]);
     print_table("Regressions", &reg_rows, &widths);
     print_table("Improvements", &imp_rows, &widths);
     print_table("Unchanged", &un_rows, &widths);
+
+    let not_compared_widths = compute_not_compared_widths(&not_compared_rows);
+    print_not_compared_table("Not Compared", &not_compared_rows, &not_compared_widths);
+}
+
+fn main() {
+    let args = match parse_args(env::args().skip(1)) {
+        Ok(args) => args,
+        Err(err) => {
+            eprintln!("{err}");
+            eprintln!(
+                "Usage: check_criterion_regressions [--allow-empty] [--baseline NAME] [group]"
+            );
+            std::process::exit(2);
+        }
+    };
+
+    match collect_results(Path::new("target/criterion"), &args) {
+        Ok(results) => print_results(&results),
+        Err(err) => {
+            eprintln!("{err}");
+            std::process::exit(1);
+        }
+    }
 }
 
 fn compute_global_widths(tables: &[&[TableRow]]) -> [usize; 5] {
@@ -382,4 +500,122 @@ fn compute_global_widths(tables: &[&[TableRow]]) -> [usize; 5] {
     }
 
     widths
+}
+
+fn compute_not_compared_widths(rows: &[NotComparedRow]) -> [usize; 3] {
+    let mut widths = ["Group".len(), "Bench".len(), "Reason".len()];
+
+    for row in rows {
+        widths[0] = widths[0].max(row.0.len());
+        widths[1] = widths[1].max(row.1.len());
+        widths[2] = widths[2].max(row.2.len());
+    }
+
+    widths
+}
+
+#[cfg(test)]
+mod tests {
+    use std::fs;
+    use std::path::Path;
+
+    use tempfile::tempdir;
+
+    use super::{collect_results, parse_args, Args};
+
+    fn write_estimates(path: &Path, point_estimate: f64, lower: f64, upper: f64) {
+        fs::create_dir_all(path.parent().unwrap()).unwrap();
+        fs::write(
+            path,
+            format!(
+                r#"{{
+  "mean": {{
+    "point_estimate": {point_estimate},
+    "confidence_interval": {{
+      "lower_bound": {lower},
+      "upper_bound": {upper}
+    }}
+  }}
+}}"#
+            ),
+        )
+        .unwrap();
+    }
+
+    fn write_report(path: &Path, verdict: &str) {
+        fs::create_dir_all(path.parent().unwrap()).unwrap();
+        fs::write(path, verdict).unwrap();
+    }
+
+    #[test]
+    fn parse_args_accepts_flags_and_optional_group() {
+        let args = parse_args(["--allow-empty", "--baseline", "main", "sampling"]).unwrap();
+
+        assert!(args.allow_empty);
+        assert_eq!(args.baseline, "main");
+        assert_eq!(args.filter_group.as_deref(), Some("sampling"));
+    }
+
+    #[test]
+    fn collect_results_reads_change_outputs() {
+        let dir = tempdir().unwrap();
+        let bench_dir = dir.path().join("sampling").join("sample_one");
+        write_estimates(
+            &bench_dir.join("change").join("estimates.json"),
+            0.1,
+            0.05,
+            0.15,
+        );
+        write_report(
+            &bench_dir.join("report").join("index.html"),
+            "Performance has regressed.",
+        );
+
+        let results = collect_results(dir.path(), &Args::default()).unwrap();
+
+        assert_eq!(results.regressions.len(), 1);
+        assert_eq!(results.regressions[0].group, "sampling");
+        assert_eq!(results.regressions[0].bench, "sample_one");
+        assert_eq!(results.regressions[0].pe, 0.1);
+        assert!(results.improvements.is_empty());
+        assert!(results.unchanged.is_empty());
+        assert!(results.not_compared.is_empty());
+    }
+
+    #[test]
+    fn collect_results_reports_new_benchmarks_without_baseline() {
+        let dir = tempdir().unwrap();
+        let bench_dir = dir.path().join("sampling").join("new_sample");
+        write_estimates(
+            &bench_dir.join("new").join("estimates.json"),
+            123.0,
+            100.0,
+            140.0,
+        );
+
+        let results = collect_results(dir.path(), &Args::default()).unwrap();
+
+        assert_eq!(results.not_compared.len(), 1);
+        assert_eq!(results.not_compared[0].group, "sampling");
+        assert_eq!(results.not_compared[0].bench, "new_sample");
+        assert_eq!(results.not_compared[0].reason, "No baseline named 'base'");
+        assert!(results.regressions.is_empty());
+    }
+
+    #[test]
+    fn collect_results_empty_requires_allow_empty() {
+        let dir = tempdir().unwrap();
+
+        assert!(collect_results(dir.path(), &Args::default()).is_err());
+
+        let args = Args {
+            allow_empty: true,
+            ..Args::default()
+        };
+        let results = collect_results(dir.path(), &args).unwrap();
+        assert!(results.regressions.is_empty());
+        assert!(results.improvements.is_empty());
+        assert!(results.unchanged.is_empty());
+        assert!(results.not_compared.is_empty());
+    }
 }

--- a/mise.toml
+++ b/mise.toml
@@ -111,7 +111,7 @@ run = "cargo bench -p ixa-bench {{arg(name='name', default='')}} -- --save-basel
 [tasks.'bench:compare']
 description = "Compare benchmarks against a Criterion baseline"
 run = [
-  "cargo bench -p ixa-bench {{arg(name='name', default='')}} -- --baseline {{arg(name='baseline')}}",
+  "cargo bench -p ixa-bench {{arg(name='name', default='')}} -- --baseline-lenient {{arg(name='baseline')}}",
   "cargo run -q -p ixa-bench --bin check_criterion_regressions",
 ]
 

--- a/mise.toml
+++ b/mise.toml
@@ -1,6 +1,6 @@
 [tools]
-node = "latest"
-pnpm = "latest"
+node = "22.20.0"
+pnpm = "10.33.0"
 "cargo:prek" = "latest"
 "prettier" = "3.6.2"
 "npm:@commitlint/cli" = "19.7.1"

--- a/scripts/format_bench_pr_comment.mjs
+++ b/scripts/format_bench_pr_comment.mjs
@@ -2,7 +2,8 @@
 /*
 Builds a single PR comment markdown from benchmark artifacts.
 
-It consolidates Criterion output into 3 sections (Regressions/Improvements/Unchanged)
+It consolidates Criterion output into sections for regressions, improvements,
+unchanged results, and benchmarks that could not be compared yet.
 that each include all groups.
 
 Inputs:
@@ -22,7 +23,9 @@ import path from 'node:path';
 import { parseArgs } from 'node:util';
 import { pathToFileURL } from 'node:url';
 
-const SECTION_TITLES = ['Regressions', 'Improvements', 'Unchanged'];
+const CHANGE_SECTION_TITLES = ['Regressions', 'Improvements', 'Unchanged'];
+const NOT_COMPARED_SECTION_TITLE = 'Not Compared';
+const ALL_SECTION_TITLES = [...CHANGE_SECTION_TITLES, NOT_COMPARED_SECTION_TITLE];
 const SAMPLE_ENTITY_PREFIX = 'sample_entity_';
 
 function readTextIfExists(filePath) {
@@ -59,6 +62,14 @@ function isHeaderOrDividerLine(line) {
   return false;
 }
 
+function isNotComparedHeaderOrDividerLine(line) {
+  const t = String(line || '').trim();
+  if (!t) return true;
+  if (/^Group\s+Bench\s+Reason\s*$/i.test(t)) return true;
+  if (/^-{3,}(\s+-{3,})+\s*$/.test(t)) return true;
+  return false;
+}
+
 function parseCriterionBodyToRows(body) {
   const lines = String(body || '').split(/\r?\n/);
   const rows = [];
@@ -91,6 +102,26 @@ function parseCriterionBodyToRows(body) {
       changePct,
       ciLowerPct,
       ciUpperPct,
+    });
+  }
+
+  return rows;
+}
+
+function parseNotComparedBodyToRows(body) {
+  const lines = String(body || '').split(/\r?\n/);
+  const rows = [];
+
+  for (const line of lines) {
+    if (isNotComparedHeaderOrDividerLine(line)) continue;
+    const parts = String(line).trim().split(/\s{2,}/);
+    if (parts.length < 3) continue;
+
+    const [group, bench, ...reasonParts] = parts;
+    rows.push({
+      group,
+      bench,
+      reason: reasonParts.join('  '),
     });
   }
 
@@ -140,10 +171,28 @@ function buildMarkdownTable(rows) {
   return lines.join('\n');
 }
 
+function buildNotComparedMarkdownTable(rows) {
+  const lines = [];
+  lines.push('| Group | Bench | Reason |');
+  lines.push('|:--|:--|:--|');
+
+  for (const row of rows) {
+    lines.push(
+      `| ${escapePipeCell(row.group)} | ${formatBenchCell(row.bench)} | ${escapePipeCell(row.reason)} |`,
+    );
+  }
+
+  if (rows.length === 0) {
+    lines.push('| (none) |  |  |');
+  }
+
+  return lines.join('\n');
+}
+
 function extractNamedSection(text, title) {
   const lines = String(text || '').split(/\r?\n/);
   const headerRe = new RegExp(`^${title}:`);
-  const anyHeaderRe = /^(Regressions|Improvements|Unchanged):/;
+  const anyHeaderRe = /^(Regressions|Improvements|Unchanged|Not Compared):/;
 
   let start = -1;
   for (let i = 0; i < lines.length; i += 1) {
@@ -184,6 +233,7 @@ function buildMarkdown({ hyperfineMd, criterionDir, groups }) {
     Improvements: [],
     Unchanged: [],
   };
+  const notCompared = [];
 
   for (const group of groups) {
     if (!isSafeGroupName(group)) {
@@ -194,12 +244,19 @@ function buildMarkdown({ hyperfineMd, criterionDir, groups }) {
     const p = safeJoinWithin(criterionDir, `criterion-regressions-${group}.txt`);
     const raw = readTextIfExists(p).trimEnd();
 
-    const extracted = Object.fromEntries(SECTION_TITLES.map((t) => [t, extractNamedSectionBody(raw, t)]));
-    for (const t of SECTION_TITLES) {
+    const extracted = Object.fromEntries(
+      ALL_SECTION_TITLES.map((t) => [t, extractNamedSectionBody(raw, t)]),
+    );
+    for (const t of CHANGE_SECTION_TITLES) {
       const body = extracted[t];
       if (body == null) continue;
       const rows = parseCriterionBodyToRows(body);
       bySection[t].push(...rows);
+    }
+
+    const notComparedBody = extracted[NOT_COMPARED_SECTION_TITLE];
+    if (notComparedBody != null) {
+      notCompared.push(...parseNotComparedBodyToRows(notComparedBody));
     }
   }
 
@@ -215,7 +272,7 @@ function buildMarkdown({ hyperfineMd, criterionDir, groups }) {
 
   lines.push('#### Criterion', '');
 
-  for (const title of SECTION_TITLES) {
+  for (const title of CHANGE_SECTION_TITLES) {
     const heading =
       title === 'Regressions'
         ? '##### Regressions (slower)'
@@ -227,6 +284,12 @@ function buildMarkdown({ hyperfineMd, criterionDir, groups }) {
     lines.push(heading, '');
     lines.push(buildMarkdownTable(rows), '');
   }
+
+  notCompared.sort(
+    (a, b) => a.group.localeCompare(b.group) || a.bench.localeCompare(b.bench),
+  );
+  lines.push('##### Not Compared (no baseline yet)', '');
+  lines.push(buildNotComparedMarkdownTable(notCompared), '');
 
   while (lines.length > 0 && lines[lines.length - 1] === '') lines.pop();
   return lines.join('\n') + '\n';

--- a/scripts/test_format_bench_pr_comment.sh
+++ b/scripts/test_format_bench_pr_comment.sh
@@ -60,6 +60,11 @@ Unchanged:
   large_dataset                            bench_query_population_derived_property_entities   0.011%   -0.529%    0.545%
   large_dataset                            bench_query_population_indexed_property_entities  -0.466%   -0.992%    0.018%
   sample_entity_whole_population           1000                                              -1.203%   -2.912%    0.150%
+
+Not Compared:
+  Group      Bench             Reason
+  ---------  ----------------  ------------------------
+  sampling   new_sampling_fn   No baseline named 'base'
 TXT
 
 # Group 2: empty output to ensure concatenation has no blank line between groups
@@ -122,6 +127,12 @@ _Hyperfine output missing._
 | large_dataset | `bench_query_population_multi_indexed_entities` |  | 0.191% | -0.490% | 0.849% |
 | large_dataset | `bench_match_entity` |  | 0.144% | -1.151% | 1.235% |
 | large_dataset | `bench_query_population_derived_property_entities` |  | 0.011% | -0.529% | 0.545% |
+
+##### Not Compared (no baseline yet)
+
+| Group | Bench | Reason |
+|:--|:--|:--|
+| sampling | `new_sampling_fn` | No baseline named 'base' |
 MD
 
 # Normalize CRLF if any


### PR DESCRIPTION
## Summary

- Use Criterion's `--baseline-lenient` mode so newly added benchmarks do not fail PR benchmark CI.
- Report benchmarks without a saved baseline in a new `Not Compared` section.
- Keep real benchmark, parser, and regression failures failing CI.
- pinned node and pnpm in mise.toml, since we do not want every update to break our tests.

