### PR TITLE
docs: Consistent Ixa capitalization

### DIFF
--- a/.devcontainer/terminal-welcome.txt
+++ b/.devcontainer/terminal-welcome.txt
@@ -1,3 +1,3 @@
-🦀 Your ixa codespace is ready!
+🦀 Your Ixa codespace is ready!
 🚀 Try `mise test:core` to run the core unit tests.
 📋 `mise task` will show you a list of all available tasks!

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-# Dockerfile for running Rust bench tests in the ixa project
+# Dockerfile for running Rust bench tests in the Ixa project
 FROM rust:slim
 
 # make sure we have the latest CA certificates, including CDC ones

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
-# ixa
+# Ixa
 
 Ixa (Interactive eXecution of ABMs) is a framework for building modular
 agent-based models in Rust.
 
-<img align="left" alt="ixa crab" src="website/ixa_logo.svg" width="200px" />
+<img align="left" alt="Ixa crab" src="website/ixa_logo.svg" width="200px" />
 
 It's named after the
 [Ixa crab](https://www.crabdatabase.info/en/crabs/brachyura/eubrachyura/heterotremata/leucosioidea/leucosiidae/ixa/ixa-cylindrus-5874),

--- a/docs/book/src/SUMMARY.md
+++ b/docs/book/src/SUMMARY.md
@@ -20,7 +20,7 @@
   - [`random` module](topics/random-module.md)
   - [Reports](topics/reports.md)
 - [Examples](examples.md)
-- [Migrating to ixa 2.0](migration_guide.md)
+- [Migrating to Ixa 2.0](migration_guide.md)
 - [Appendix: Rust](appendix_rust/appendix-rust.md)
   - [Specifying Generic Types and the Turbo Fish](appendix_rust/turbo-fish.md)
   - [Rust Learning Resources](appendix_rust/rust-resources.md)

--- a/docs/book/src/appendix_rust/turbo-fish.md
+++ b/docs/book/src/appendix_rust/turbo-fish.md
@@ -1,6 +1,6 @@
 # Specifying Generic Types and the Turbo Fish
 
-Rust and ixa in particular make heavy use of type generics, a way of writing a
+Rust and Ixa in particular make heavy use of type generics, a way of writing a
 single piece of code, a function for example, for a whole family of types at
 once. A nice feature of Rust is that the compiler can often infer the generic
 types at the point the function is used instead of relying on the programmer to

--- a/docs/book/src/examples.md
+++ b/docs/book/src/examples.md
@@ -8,7 +8,7 @@ The following examples are included in the [`examples/`](https://github.com/CDCg
 
 A minimal example that creates a `Context`, schedules a single plan, and prints
 the current simulation time. Good starting point for understanding the basic
-structure of an ixa model.
+structure of an Ixa model.
 
 ```sh
 cargo run --example basic
@@ -56,7 +56,7 @@ cargo run --example births-deaths
 
 ### `network-hhmodel`
 
-A network module (using ixa's `network` extentension) which loads a population
+A network module (using Ixa's `network` extentension) which loads a population
 with household structure from CSV files and spreads infection along network edges
 with different transmission rates by edge type.
 

--- a/docs/book/src/first_model/transmission.md
+++ b/docs/book/src/first_model/transmission.md
@@ -45,7 +45,7 @@ There are at least three ways to implement this model:
    the total number of people.
 
 These three approaches are mathematically equivalent. Here we demonstrate the third
-approach because it is the simplest to implement in ixa.
+approach because it is the simplest to implement in Ixa.
 
 We have already dealt with constants when we defined the constant `POPULATION`
 in `main.rs`. Let's define `FORCE_OF_INFECTION` right next to it. We also cap

--- a/docs/book/src/get-started.md
+++ b/docs/book/src/get-started.md
@@ -1,7 +1,7 @@
 # Get Started
 
 If you are new to Rust, we suggest taking some time to learn the parts of Rust
-that are most useful for ixa development. We've compiled some resources
+that are most useful for Ixa development. We've compiled some resources
 [in rust-resources.md](appendix_rust/rust-resources.md).
 
 Execute the following commands to create a new Rust project called `ixa_model`.

--- a/docs/book/src/migration_guide.md
+++ b/docs/book/src/migration_guide.md
@@ -1,9 +1,9 @@
-# Migration to ixa 2.0
+# Migration to Ixa 2.0
 
 ## Properties in the new Entity system
 
 In the new Entity system, properties work a little differently. We now have a
-[chapter devoted to properties in the ixa book](topics/properties.md). This section
+[chapter devoted to properties in the Ixa Book](topics/properties.md). This section
 of the migration guide describes the changes in the new system relative to the
 old system.
 

--- a/docs/book/src/topics/handling-errors.md
+++ b/docs/book/src/topics/handling-errors.md
@@ -66,7 +66,7 @@ pub enum ModelError {
     #[error("model error: {0}")]
     ModelError(String),
 
-    #[error("ixa error")]
+    #[error("Ixa error")]
     IxaError(#[from] IxaError),
 
     #[error("string error")]
@@ -75,7 +75,7 @@ pub enum ModelError {
     #[error("parse int error")]
     ParseIntError(#[from] std::num::ParseIntError),
 
-    #[error("ixa csv error")]
+    #[error("Ixa csv error")]
     CsvError(#[from] ixa::csv::Error),
 }
 ```

--- a/docs/book/src/topics/reports.md
+++ b/docs/book/src/topics/reports.md
@@ -9,7 +9,7 @@ struct ReportItem {
     // Arbitrary (serializable) data fields.
 }
 
-// Define the report item in ixa.
+// Define the report item in Ixa.
 define_report!(ReportItem);
 
 // Somewhere during context initialization, initialize the report:
@@ -50,7 +50,7 @@ The report API takes care of a lot of details so you don't have to.
 - **Automatic headers** - Column names are derived from your report structure
 - **Hook into global configuration** - Control file names, prefixes, output
   directories, and whether existing output files are overwritten using a
-  configuration file or ixa's command line arguments
+  configuration file or Ixa's command line arguments
 - **Streaming output** - Data is written incrementally during simulation
   execution
 
@@ -104,7 +104,7 @@ few rows might look like this:
 | 0.02187737003255150  | 879       | I                |
 | &vellip;             | &vellip;  | &vellip;         |
 
-As far as ixa's report system is concerned, we really only need four ingredients
+As far as Ixa's report system is concerned, we really only need four ingredients
 for a simple report:
 
 1. A _report item_ type that will represent one row of data in our report,
@@ -139,7 +139,7 @@ struct IncidenceReportItem {
     infection_status: InfectionStatusValue,
 }
 
-/// 2. Tell ixa that we want a report for `IncidenceReportItem`.
+/// 2. Tell Ixa that we want a report for `IncidenceReportItem`.
 define_report!(IncidenceReportItem);
 
 /// This and other auxiliary types would typically live in a different
@@ -379,7 +379,7 @@ struct AggregateSIRReportItem {
     infected_count: usize,
     recovered_count: usize,
 }
-// Tell ixa it is a report item.
+// Tell Ixa it is a report item.
 define_report!(AggregateSIRReportItem);
 ```
 

--- a/integration-tests/ixa-runner-tests/Cargo.toml
+++ b/integration-tests/ixa-runner-tests/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "ixa-integration-tests"
 version = "0.0.1"
-description = "Integration tests for ixa"
+description = "Integration tests for Ixa"
 publish = false
 repository.workspace = true
 license.workspace = true

--- a/ixa-bench/Cargo.toml
+++ b/ixa-bench/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "ixa-bench"
 version = "0.0.1"
-description = "Benchmarks for ixa"
+description = "Benchmarks for Ixa"
 publish = false
 repository.workspace = true
 license.workspace = true
@@ -15,7 +15,7 @@ release = false
 [features]
 default = []
 
-# This option includes benchmarks for algorithms we do not use in ixa.
+# This option includes benchmarks for algorithms we do not use in Ixa.
 # This allows us to compare our implementations to alternatives.
 alternative_algorithm_benches = []
 

--- a/mise.toml
+++ b/mise.toml
@@ -62,11 +62,11 @@ description = "Run all unit tests"
 run = "cargo test --all-targets --workspace"
 
 [tasks.'test:core']
-description = "Run just the core ixa tests (much faster)"
+description = "Run just the core Ixa tests (much faster)"
 run = "cargo test -p ixa"
 
 [tasks.'test:book']
-description = "Build and run the Ixa Book disease model example against local ixa"
+description = "Build and run the Ixa Book disease model example against local Ixa"
 dir = "docs/book/models/disease_model"
 run = '''
   cargo run \
@@ -80,7 +80,7 @@ depends = ["wasm:pnpm", "wasm:compile"]
 run = "pnpm exec playwright test"
 
 [tasks.'test:features']
-description = "Run just the core ixa tests (much faster)"
+description = "Run just the core Ixa tests (much faster)"
 run = "cargo test --no-default-features"
 
 [tasks.'wasm:pnpm']

--- a/scripts/index.html
+++ b/scripts/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <title>IXA Bench History</title>
+    <title>Ixa Bench History</title>
     <style>
       :root {
         color-scheme: light dark;
@@ -169,7 +169,7 @@
 
   <body>
     <header>
-      <h1>IXA benchmark history</h1>
+      <h1>Ixa benchmark history</h1>
       <div class="meta" id="meta">Loading…</div>
     </header>
 

--- a/scripts/ixa_setup.sh
+++ b/scripts/ixa_setup.sh
@@ -1,10 +1,10 @@
 #!/bin/sh
-# ixa_setup.sh: Download latest ixa code to current directory without git
+# ixa_setup.sh: Download latest Ixa code to current directory without git
 
 ZIP_URL="https://github.com/CDCgov/ixa/archive/refs/heads/main.zip"
 TARGET_DIR="ixa"
 
-echo "Downloading latest ixa code..."
+echo "Downloading latest Ixa code..."
 curl -L "$ZIP_URL" -o ixa.zip
 
 echo "Unzipping..."
@@ -19,4 +19,4 @@ fi
 
 rm ixa.zip
 
-echo "Latest ixa code downloaded to ./$TARGET_DIR"
+echo "Latest Ixa code downloaded to ./$TARGET_DIR"

--- a/scripts/setup_new_ixa_project.sh
+++ b/scripts/setup_new_ixa_project.sh
@@ -2,7 +2,7 @@
 # curl -s -f -L https://raw.githubusercontent.com/CDCgov/ixa/main/scripts/setup_new_ixa_project.sh | sh
 # or if you want to use a specific branch and not the cargo release
 # curl -s -f -L https://raw.githubusercontent.com/CDCgov/ixa/main/scripts/setup_new_ixa_project.sh | sh -s <ixa-branch>
-# ixa-branch: the branch of ixa to use, default is main
+# ixa-branch: the branch of Ixa to use, default is main
 ixa_branch="main"
 
 urlencode() {
@@ -33,7 +33,7 @@ check_success() {
     fi
 }
 
-echo "Setting up new ixa project with branch $ixa_branch"
+echo "Setting up new Ixa project with branch $ixa_branch"
 
 # check if cargo is installed
 if [ -z "$(command -v cargo)" ]; then
@@ -54,18 +54,18 @@ else
     cargo add --git "https://github.com/CDCgov/ixa" ixa --branch $ixa_branch
 fi
 
-# add .gitignore from ixa
+# add .gitignore from Ixa
 curl -s -f -o .gitignore "https://raw.githubusercontent.com/CDCgov/ixa/$ixa_branch/.gitignore"
-check_success "Failed to download .gitignore from ixa"
+check_success "Failed to download .gitignore from Ixa"
 
-# add the clippy.toml from ixa
+# add the clippy.toml from Ixa
 curl -s -f -o clippy.toml https://raw.githubusercontent.com/CDCgov/ixa/$ixa_branch/clippy.toml
-check_success "Failed to download clippy.toml from ixa"
+check_success "Failed to download clippy.toml from Ixa"
 
-# override main.rs with ixa basic example
+# override main.rs with Ixa basic example
 curl -s -f -o src/main.rs https://raw.githubusercontent.com/CDCgov/ixa/$ixa_branch/examples/basic/main.rs
-check_success "Failed to download main.rs from ixa"
+check_success "Failed to download main.rs from Ixa"
 
 echo "Project setup complete from branch $ixa_branch"
 echo "Run 'cargo run' to test the example code"
-echo "Check out the ixa documentation for more examples and usage: https://ixa.rs/"
+echo "Check out the Ixa documentation for more examples and usage: https://ixa.rs/"

--- a/src/entity/entity.rs
+++ b/src/entity/entity.rs
@@ -137,7 +137,7 @@ pub struct PopulationIterator<E: Entity> {
 }
 
 impl<E: Entity> PopulationIterator<E> {
-    // Only internal ixa code can create a new `PopulationIterator<E>` in order to guarantee only valid
+    // Only internal Ixa code can create a new `PopulationIterator<E>` in order to guarantee only valid
     // `EntityId<E>` values are ever created.
     pub(crate) fn new(population: usize) -> Self {
         PopulationIterator::<E> {

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -32,7 +32,7 @@ fn parse_log_levels(s: &str) -> Result<Vec<(String, LevelFilter)>, IxaError> {
         .collect()
 }
 
-/// Default cli arguments for ixa runner
+/// Default cli arguments for Ixa runner
 #[derive(Args, Debug)]
 pub struct BaseArgs {
     #[cfg(feature = "write_cli_usage")]

--- a/website/index.html
+++ b/website/index.html
@@ -4,7 +4,7 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>IXA - A Rust framework for building modular agent-based models</title>
+  <title>Ixa - A Rust framework for building modular agent-based models</title>
   <link rel="preconnect" href="https://fonts.googleapis.com" />
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
   <link href="https://fonts.googleapis.com/css2?family=Lilex:wght@400;500;600;700&display=swap" rel="stylesheet" />
@@ -200,7 +200,7 @@
   <main>
     <div class="hero">
       <img src="ixa_logo.svg" alt="Ixa crab logo" class="logo" />
-      <h1>ixa</h1>
+      <h1>Ixa</h1>
       <p class="tagline">
         A Rust framework for building modular agent-based models.
       </p>


### PR DESCRIPTION
Normalized the capitalization of Ixa across project files. The word Ixa is now capitalized in prose. It remains lowercase in contexts where convention dictates lowercase, like when it refers to the name of a Rust crate or module.