### PR TITLE
fix: config lookup for hyphenated package names

### DIFF
--- a/integration-tests/ixa-runner-tests/Cargo.toml
+++ b/integration-tests/ixa-runner-tests/Cargo.toml
@@ -12,10 +12,10 @@ authors.workspace = true
 [dependencies]
 ixa = { path = "../../", features = ["logging", "profiling"] }
 clap.workspace = true
+serde = { version = "1.0", features = ["derive"] }
 
 [dev-dependencies]
 assert_cmd = "^2.1.1"
-serde = { version = "1.0", features = ["derive"] }
 serde_json = "1"
 tempfile = "3"
 
@@ -35,4 +35,9 @@ bench = false
 [[bin]]
 name = "runner_test_profiling"
 path = "bin/runner_test_profiling.rs"
+bench = false
+
+[[bin]]
+name = "ixa-integration-tests"
+path = "bin/runner_config_hyphen_package.rs"
 bench = false

--- a/integration-tests/ixa-runner-tests/bin/runner_config_hyphen_package.rs
+++ b/integration-tests/ixa-runner-tests/bin/runner_config_hyphen_package.rs
@@ -1,0 +1,23 @@
+use ixa::prelude::*;
+use ixa::runner::run_with_args;
+use serde::{Deserialize, Serialize};
+
+#[derive(Serialize, Deserialize)]
+pub struct RunnerPropertyType {
+    field_int: u32,
+}
+
+define_global_property!(RunnerProperty, RunnerPropertyType);
+
+fn main() {
+    run_with_args(|context, _args, _| {
+        let property = context
+            .get_global_property_value(RunnerProperty)
+            .ok_or_else(|| IxaError::PropertyNotSet {
+                name: "RunnerProperty".to_string(),
+            })?;
+        println!("{}", property.field_int);
+        Ok(())
+    })
+    .unwrap();
+}

--- a/integration-tests/ixa-runner-tests/tests/runner.rs
+++ b/integration-tests/ixa-runner-tests/tests/runner.rs
@@ -1,5 +1,8 @@
 #[cfg(test)]
 mod tests {
+    use std::fs;
+
+    use tempfile::tempdir;
 
     #[test]
     fn test_cli_invocation_with_custom_args() {
@@ -16,6 +19,33 @@ mod tests {
 Run runner_test_custom_args --help -v to see more options
 42\n",
             );
+    }
+
+    #[test]
+    fn test_cli_config_accepts_hyphenated_package_name() {
+        let temp_dir = tempdir().unwrap();
+        let config_path = temp_dir.path().join("config.json");
+        fs::write(
+            &config_path,
+            r#"{
+  "ixa-integration-tests.RunnerProperty": {
+    "field_int": 7
+  }
+}
+"#,
+        )
+        .unwrap();
+
+        assert_cmd::cargo::cargo_bin_cmd!("ixa-integration-tests")
+            .arg("--config")
+            .arg(config_path)
+            .arg("--no-stats")
+            .assert()
+            .success()
+            .stdout(format!(
+                "Loading global properties from: {:?}\nCurrent log levels enabled: ERROR\nRun ixa-integration-tests --help -v to see more options\n7\n",
+                temp_dir.path().join("config.json")
+            ));
     }
 
     #[test]

--- a/src/global_properties.rs
+++ b/src/global_properties.rs
@@ -110,6 +110,16 @@ fn get_global_property_setter(name: &str) -> Option<Arc<PropertySetterFn>> {
     tmp.get(name).map(Arc::clone)
 }
 
+fn get_global_property_setter_for_config_key(name: &str) -> Option<Arc<PropertySetterFn>> {
+    get_global_property_setter(name).or_else(|| {
+        if name.contains('-') {
+            get_global_property_setter(&name.replace('-', "_"))
+        } else {
+            None
+        }
+    })
+}
+
 /// The trait representing a global property. Do not use this
 /// directly, but instead define global properties with
 /// [`define_global_property!`](crate::define_global_property!).
@@ -177,7 +187,9 @@ pub trait ContextGlobalPropertiesExt: ContextBase {
     /// The expected structure is a dictionary with each name being
     /// the name of the struct prefixed with the crate name, as in:
     /// `ixa.NumFluVariants` and the value being an object which can
-    /// serde deserialize into the relevant struct.
+    /// serde deserialize into the relevant struct. If a package name contains
+    /// hyphens, either the package spelling or Rust's underscore-normalized
+    /// crate spelling can be used.
     ///
     /// # Errors
     /// Will return an [`IxaError`] if:
@@ -251,7 +263,7 @@ impl ContextGlobalPropertiesExt for Context {
         let val: serde_json::Map<String, serde_json::Value> = serde_json::from_reader(reader)?;
 
         for (k, v) in val {
-            if let Some(setter) = get_global_property_setter(&k) {
+            if let Some(setter) = get_global_property_setter_for_config_key(&k) {
                 setter(self, &k, v)?;
             } else {
                 return Err(IxaError::NoGlobalProperty { name: k });


### PR DESCRIPTION
## Summary

- Allow global-property config keys to use hyphenated package names
- Keep existing underscore-normalized crate-name keys working
- Add a CLI regression test for loading config via `--config` with a hyphenated package key

## Details

Rust normalizes Cargo package names with hyphens into crate identifiers with underscores. Global properties are registered from `module_path!()`, so a package like `network-hhmodel` registers config keys under `network_hhmodel.Parameters`.

This made `--config` surprising because users naturally wrote the Cargo package spelling, such as `network-hhmodel.Parameters`, but the loader only accepted `network_hhmodel.Parameters`.

The loader now first checks the exact config key, then retries with hyphens replaced by underscores.
