### PR TITLE
chore: Make rand usage deterministic and disable default features

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,11 @@ authors = ["The Ixa Developers <cfa@cdc.gov>"]
 
 [workspace.dependencies]
 approx = "^0.5.1"
-rand = { version = "^0.9.2", features = ["std", "small_rng"] }
+rand = { version = "^0.9.2", default-features = false, features = [
+    "std",
+    "small_rng",
+    "std_rng",
+] }
 rand_distr = "^0.5.1"
 csv = "^1.3.1"
 serde = { version = "^1.0.217", features = ["derive"] }
@@ -119,7 +123,6 @@ log4rs = { workspace = true, optional = true }
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 fern = { workspace = true, optional = true }
 # Required here only to enable the js backend:
-getrandom = { workspace = true, features = ["wasm_js"] }
 wasm-bindgen = { workspace = true, optional = true }
 web-sys = { workspace = true, optional = true, features = ["console", "Performance", "Window"] }
 

--- a/ixa-bench/criterion/algorithm_benches.rs
+++ b/ixa-bench/criterion/algorithm_benches.rs
@@ -1,13 +1,15 @@
 use std::hint::black_box;
 
 use criterion::{criterion_group, criterion_main, Criterion};
-use ixa::rand::prelude::ThreadRng;
+use ixa::rand::rngs::SmallRng;
 use ixa::rand::seq::IteratorRandom;
-use ixa::rand::{rng, Rng};
+use ixa::rand::{Rng, SeedableRng};
 use ixa::random::{
     sample_multiple_from_known_length, sample_multiple_l_reservoir,
     sample_single_from_known_length, sample_single_l_reservoir,
 };
+
+const SEED: u64 = 42;
 
 /// A wrapper around any iterator that prevents it from exposing `ExactSizeIterator`, `DoubleEndedIterator`, etc.
 /// This is needed to test the "slow path" with `rand`'s implementation, as `rand` has an optimization for when
@@ -34,8 +36,8 @@ where
     }
 }
 
-fn setup() -> (Vec<u8>, Vec<usize>, ThreadRng) {
-    let mut rng: ThreadRng = rng();
+fn setup() -> (Vec<u8>, Vec<usize>, SmallRng) {
+    let mut rng = SmallRng::seed_from_u64(SEED);
     // The number of items to choose out of the data set for multiple sampling
     let mut counts: Vec<usize> = Vec::with_capacity(1000);
     for _ in 0..1000 {

--- a/ixa-bench/src/generate_population.rs
+++ b/ixa-bench/src/generate_population.rs
@@ -1,10 +1,11 @@
 use std::iter::FusedIterator;
 
 use ixa::rand::rngs::StdRng;
-use ixa::rand::{rng, Rng, RngCore, SeedableRng};
+use ixa::rand::{Rng, RngCore, SeedableRng};
 
 const MIN_AGE: u8 = 0;
 const MAX_AGE: u8 = 100;
+const DEFAULT_POPULATION_SEED: u64 = 0;
 const SCHOOL_AGE_MIN: u8 = 5;
 const SCHOOL_AGE_MAX: u8 = 18;
 const WORK_AGE_MIN: u8 = 18;
@@ -51,7 +52,7 @@ impl PopulationIterator {
         let num_homes = usize::max(1, n / HOUSEHOLD_SIZE);
         let rng: Box<dyn RngCore> = match seed {
             Some(s) => Box::new(StdRng::seed_from_u64(s)),
-            None => Box::new(rng()),
+            None => Box::new(StdRng::seed_from_u64(DEFAULT_POPULATION_SEED)),
         };
         PopulationIterator {
             n,

--- a/src/entity/context_extension.rs
+++ b/src/entity/context_extension.rs
@@ -1098,8 +1098,11 @@ mod tests {
 
     #[test]
     fn with_query_results_finds_multi_index() {
+        use crate::rand::rngs::SmallRng;
         use crate::rand::seq::IndexedRandom;
-        let mut rng = crate::rand::rng();
+        use crate::rand::SeedableRng;
+
+        let mut rng = SmallRng::seed_from_u64(42);
         let mut context = Context::new();
 
         for _ in 0..10_000usize {


### PR DESCRIPTION
## Summary

- Disable `rand` default features and explicitly enable only `std`, `small_rng`, and `std_rng`
- Replace remaining `thread_rng` usage with seeded RNGs in tests and benchmarks
- Use a deterministic default seed for benchmark population generation
- Remove the direct wasm `getrandom` dependency entry from the main crate manifest
