### PR TITLE
feat: `schedule_relative!` macro

### DIFF
--- a/integration-tests/ixa-runner-tests/tests/macros.rs
+++ b/integration-tests/ixa-runner-tests/tests/macros.rs
@@ -161,6 +161,26 @@ mod tests {
 
     fn macro_named_value_change_handler<C>(_context: &mut Context, _counter: &mut C) {}
 
+    fn record_sum(
+        context: &mut Context,
+        records: Rc<RefCell<Vec<(f64, u32)>>>,
+        arg1: u32,
+        arg2: u32,
+        arg3: u32,
+    ) {
+        records
+            .borrow_mut()
+            .push((context.get_current_time(), arg1 + arg2 + arg3));
+    }
+
+    fn record_current_time(context: &mut Context, records: Rc<RefCell<Vec<f64>>>) {
+        records.borrow_mut().push(context.get_current_time());
+    }
+
+    fn passthrough_context(context: &mut Context) -> &mut Context {
+        context
+    }
+
     #[test]
     fn compile_and_run_macros() {
         let mut ctx = Context::new();
@@ -369,5 +389,57 @@ mod tests {
         assert_eq!(*empty_strata.borrow(), vec![0, 1]);
         assert_eq!(*singleton_strata.borrow(), vec![0, 1]);
         assert_eq!(*multiple_strata.borrow(), vec![0, 1]);
+    }
+
+    #[test]
+    fn schedule_relative_accepts_function_name_with_arguments() {
+        let mut context = Context::new();
+        let records = Rc::new(RefCell::new(Vec::new()));
+        let observed_records = records.clone();
+
+        schedule_relative!(&mut context, 2.5, record_sum, records, 1, 2, 3);
+
+        context.execute();
+        assert_eq!(*observed_records.borrow(), vec![(2.5, 6)]);
+    }
+
+    #[test]
+    fn schedule_relative_accepts_closure_action() {
+        let mut context = Context::new();
+        let records = Rc::new(RefCell::new(Vec::new()));
+        let observed_records = records.clone();
+
+        schedule_relative!(
+            &mut context,
+            1.25,
+            |context: &mut Context, records: Rc<RefCell<Vec<(f64, u32)>>>, value: u32| {
+                records
+                    .borrow_mut()
+                    .push((context.get_current_time(), value));
+            },
+            records,
+            42
+        );
+
+        context.execute();
+        assert_eq!(*observed_records.borrow(), vec![(1.25, 42)]);
+    }
+
+    #[test]
+    fn schedule_relative_accepts_context_expression_and_no_action_arguments() {
+        let mut context = Context::new();
+        let records = Rc::new(RefCell::new(Vec::new()));
+        let observed_records = records.clone();
+
+        schedule_relative!(
+            passthrough_context(&mut context),
+            0.75,
+            record_current_time,
+            records
+        );
+        schedule_relative!(passthrough_context(&mut context), 1.5, Context::shutdown);
+
+        context.execute();
+        assert_eq!(*observed_records.borrow(), vec![0.75]);
     }
 }

--- a/src/macros/mod.rs
+++ b/src/macros/mod.rs
@@ -6,5 +6,6 @@ mod define_rng;
 mod edge_impl;
 mod entity_impl;
 mod property_impl;
+mod schedule_relative;
 mod value_change_counts;
 mod with;

--- a/src/macros/property_impl.rs
+++ b/src/macros/property_impl.rs
@@ -1573,27 +1573,18 @@ mod tests {
             .add_entity(with!(Person, POu32(Some(42)), Pu32(22)))
             .unwrap();
         assert_eq!(
-            format!(
-                "{:}",
-                POu32::get_display(&context.get_property::<_, POu32>(person))
-            ),
+            POu32::get_display(&context.get_property::<_, POu32>(person)).to_string(),
             "42"
         );
         assert_eq!(
-            format!(
-                "{:}",
-                Pu32::get_display(&context.get_property::<_, Pu32>(person))
-            ),
+            Pu32::get_display(&context.get_property::<_, Pu32>(person)).to_string(),
             "Pu32(22)"
         );
         let person2 = context
             .add_entity(with!(Person, POu32(None), Pu32(11)))
             .unwrap();
         assert_eq!(
-            format!(
-                "{:}",
-                POu32::get_display(&context.get_property::<_, POu32>(person2))
-            ),
+            POu32::get_display(&context.get_property::<_, POu32>(person2)).to_string(),
             "None"
         );
     }

--- a/src/macros/schedule_relative.rs
+++ b/src/macros/schedule_relative.rs
@@ -1,0 +1,32 @@
+/// Schedules an action after a delay relative to the context's current time.
+///
+/// The scheduled action is called with the executing `context: &mut Context` as
+/// its first argument, followed by each remaining macro argument in the same
+/// order.
+///
+/// For example:
+///
+/// ```ignore
+/// schedule_relative!(context, my_delay, my_handler, arg1, arg2, arg3);
+/// ```
+///
+/// expands to code like:
+///
+/// ```ignore
+/// {
+///     let time = context.get_current_time() + my_delay;
+///     context.add_plan(time, move |context| {
+///         my_handler(context, arg1, arg2, arg3)
+///     })
+/// }
+/// ```
+#[macro_export]
+macro_rules! schedule_relative {
+    ($context:expr, $delay:expr, $action:expr $(, $arg:expr)* $(,)?) => {{
+        let context = ($context);
+        let time = context.get_current_time() + $delay;
+        context.add_plan(time, move |context| {
+            ($action)(context $(, $arg)*)
+        })
+    }};
+}

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -11,6 +11,6 @@ pub use crate::report::ContextReportExt;
 pub use crate::{
     define_data_plugin, define_derived_property, define_edge_type, define_entity,
     define_global_property, define_multi_property, define_property, define_report, define_rng,
-    impl_edge_type, impl_entity, impl_property, track_periodic_value_change_counts, with,
-    PluginContext,
+    impl_edge_type, impl_entity, impl_property, schedule_relative,
+    track_periodic_value_change_counts, with, PluginContext,
 };


### PR DESCRIPTION
Implemented a convenience macro:

```
schedule_relative!(context, my_delay, my_action, arg1, arg2, arg3);
```

expands to:

```rust
context.add_plan(context.get_current_time() + my_delay, move |context| {
    my_action(context, arg1, arg2, arg3)
});
```

The point of the macro is:

1. The convenience of scheduling at a relative future time instead of an absolute future time.
1. Capturing the concrete parameter values passed to the handler without having to manually write the closure syntax.


# Open Questions / Issues

- A similar macro `track_periodic_value_change_counts` (#917) mirrors the name of the method, so maybe we want to name this `add_plan_relative!` instead?
- The "relative" bit is just because the macro adds the `my_delay` parameter to `context.get_current_time()` for you. Maybe we should have "relative" versions of the methods for convenience as suggested by #836? Likewise, should there be an _absolute time_ version of this `schedule_relative!` macro, maybe called `schedule!` or just `add_plan!`?