### PR TITLE
chore: update mdbook (0.5.3) versions

### DIFF
--- a/docs/book/src/cli-usage.md
+++ b/docs/book/src/cli-usage.md
@@ -4,7 +4,7 @@ This document contains the help content for the `ixa` command-line program.
 
 ## `ixa`
 
-Default cli arguments for ixa runner
+Default cli arguments for Ixa runner
 
 **Usage:** `ixa [OPTIONS]`
 

--- a/docs/book/src/migration_guide.md
+++ b/docs/book/src/migration_guide.md
@@ -67,7 +67,7 @@ pub enum InfectionStatus {
     Recovered,
 }
 
-// Implements `Property\<Person>` for an existing type.
+// Implements `Property<Person>` for an existing type.
 impl_property!(
     InfectionStatus,
     Person,
@@ -80,7 +80,7 @@ traits and `pub` visibility to the type definition and then call
 `impl_property!` as above.)
 
 The crucial thing to understand is that the value type _is_ the property type.
-The `impl Property\<Person> for InfectionStatus`, which the macros give you, is
+The <code>impl Property&lt;Person&gt; for InfectionStatus</code>, which the macros give you, is
 the thing that ties the `InfectionStatus` type to the `Person` entity.
 
 For details about defining properties, see the `property_impl` module-level docs
@@ -93,16 +93,16 @@ and API docs for the macros `define_property!`, `impl_property!`,
 | Concept                     | Old System                                                                                                                     | New System                                                                                                           | Notes / Implications                                                                |
 | --------------------------- | ------------------------------------------------------------------------------------------------------------------------------ | -------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------- |
 | **Property Type Structure** | Two separate types: (1) value type, and (2) property-identifier ZST.                                                           | A single type represents both the value and identifies the property.                                                 | Simplified to a single type                                                         |
-| **Defining Properties**     | Define a normal Rust type (or use an existing primitive, e.g. `u8`), then use a macro to define the identifying property type. | Define a normal Rust type, then use `impl_property` to declare it a `Property\<E>` for a particular `Entity` `E`.     |                                                                                     |
+| **Defining Properties**     | Define a normal Rust type (or use an existing primitive, e.g. `u8`), then use a macro to define the identifying property type. | Define a normal Rust type, then use `impl_property` to declare it a <code>Property&lt;E&gt;</code> for a particular `Entity` `E`.     |                                                                                     |
 | **Entity Association**      | Implicit—only one entity ("person")                                                                                            | Every property must explicitly specify the `Entity` it belongs to (e.g., `Person`); Entities are defined separately. |                                                                                     |
-| **Default Values**          | Provided in the macro creating the property-identifier type.                                                                   | Same but with updated syntax; default values are per `Property\<E>` implementation.                                   |                                                                                     |
+| **Default Values**          | Provided in the macro creating the property-identifier type.                                                                   | Same but with updated syntax; default values are per <code>Property&lt;E&gt;</code> implementation.                                   |                                                                                     |
 | **Using Existing Types**    | A single _value_ type can be used in multiple properties—including primitive types like `u8`                                   | Only one property per type (per `Entity`); primitive types must be wrapped in a newtype.                             | Both systems require that the existing type implement the required property traits. |
 | **Macro Behavior**          | Macros define the property’s ZST and connect it to the value type via trait impls.                                             | Macros define "is a property of entity `E`" relationship via trait impl. No additional synthesized types.            | Both enforce correctness via macro                                                  |
 
 ## Global property validator errors
 
 Global-property validators are client code, so they should return
-`Result<(), Box<dyn std::error::Error + 'static>>` instead of constructing
+<code>Result&lt;(), Box&lt;dyn std::error::Error + 'static&gt;&gt;</code> instead of constructing
 `IxaError` values directly. Ixa wraps any returned validator error in
 `IxaError::IllegalGlobalPropertyValue` when a global property is set or loaded.
 
@@ -131,8 +131,8 @@ impl_entity!(Person);
 ```
 
 These macros automatically create a type alias of the form
-`MyEntityId = EntityId\<MyEntity>`. In our case, it defines the type alias
-`PersonId = EntityId\<Person>`.
+<code>MyEntityId = EntityId&lt;MyEntity&gt;</code>. In our case, it defines the type alias
+<code>PersonId = EntityId&lt;Person&gt;</code>.
 
 ### Adding a new entity (e.g. a new person)
 
@@ -214,8 +214,8 @@ calls after the first one will just be ignored.
 ### Subscribe to events
 
 The only difference is that now we use the
-`PropertyChangeEvent\<E: Entity, P: Property<E>>` and
-`EntityCreatedEvent\<E: Entity>` types.
+<code>PropertyChangeEvent&lt;E: Entity, P: Property&lt;E&gt;&gt;</code> and
+<code>EntityCreatedEvent&lt;E: Entity&gt;</code> types.
 
 ```rust
 pub fn init(context: &mut Context) {

--- a/docs/book/src/migration_guide.md
+++ b/docs/book/src/migration_guide.md
@@ -80,7 +80,7 @@ traits and `pub` visibility to the type definition and then call
 `impl_property!` as above.)
 
 The crucial thing to understand is that the value type _is_ the property type.
-The <code>impl Property&lt;Person&gt; for InfectionStatus</code>, which the macros give you, is
+The `impl Property\<Person> for InfectionStatus`, which the macros give you, is
 the thing that ties the `InfectionStatus` type to the `Person` entity.
 
 For details about defining properties, see the `property_impl` module-level docs
@@ -93,16 +93,16 @@ and API docs for the macros `define_property!`, `impl_property!`,
 | Concept                     | Old System                                                                                                                     | New System                                                                                                           | Notes / Implications                                                                |
 | --------------------------- | ------------------------------------------------------------------------------------------------------------------------------ | -------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------- |
 | **Property Type Structure** | Two separate types: (1) value type, and (2) property-identifier ZST.                                                           | A single type represents both the value and identifies the property.                                                 | Simplified to a single type                                                         |
-| **Defining Properties**     | Define a normal Rust type (or use an existing primitive, e.g. `u8`), then use a macro to define the identifying property type. | Define a normal Rust type, then use `impl_property` to declare it a <code>Property&lt;E&gt;</code> for a particular `Entity` `E`.     |                                                                                     |
+| **Defining Properties**     | Define a normal Rust type (or use an existing primitive, e.g. `u8`), then use a macro to define the identifying property type. | Define a normal Rust type, then use `impl_property` to declare it a `Property\<E>` for a particular `Entity` `E`.     |                                                                                     |
 | **Entity Association**      | Implicit—only one entity ("person")                                                                                            | Every property must explicitly specify the `Entity` it belongs to (e.g., `Person`); Entities are defined separately. |                                                                                     |
-| **Default Values**          | Provided in the macro creating the property-identifier type.                                                                   | Same but with updated syntax; default values are per <code>Property&lt;E&gt;</code> implementation.                                   |                                                                                     |
+| **Default Values**          | Provided in the macro creating the property-identifier type.                                                                   | Same but with updated syntax; default values are per `Property\<E>` implementation.                                   |                                                                                     |
 | **Using Existing Types**    | A single _value_ type can be used in multiple properties—including primitive types like `u8`                                   | Only one property per type (per `Entity`); primitive types must be wrapped in a newtype.                             | Both systems require that the existing type implement the required property traits. |
 | **Macro Behavior**          | Macros define the property’s ZST and connect it to the value type via trait impls.                                             | Macros define "is a property of entity `E`" relationship via trait impl. No additional synthesized types.            | Both enforce correctness via macro                                                  |
 
 ## Global property validator errors
 
 Global-property validators are client code, so they should return
-<code>Result&lt;(), Box&lt;dyn std::error::Error + 'static&gt;&gt;</code> instead of constructing
+`Result\<(), Box\<dyn std::error::Error + 'static>>` instead of constructing
 `IxaError` values directly. Ixa wraps any returned validator error in
 `IxaError::IllegalGlobalPropertyValue` when a global property is set or loaded.
 
@@ -131,8 +131,8 @@ impl_entity!(Person);
 ```
 
 These macros automatically create a type alias of the form
-<code>MyEntityId = EntityId&lt;MyEntity&gt;</code>. In our case, it defines the type alias
-<code>PersonId = EntityId&lt;Person&gt;</code>.
+`MyEntityId = EntityId\<MyEntity>`. In our case, it defines the type alias
+`PersonId = EntityId\<Person>`.
 
 ### Adding a new entity (e.g. a new person)
 
@@ -214,8 +214,8 @@ calls after the first one will just be ignored.
 ### Subscribe to events
 
 The only difference is that now we use the
-<code>PropertyChangeEvent&lt;E: Entity, P: Property&lt;E&gt;&gt;</code> and
-<code>EntityCreatedEvent&lt;E: Entity&gt;</code> types.
+`PropertyChangeEvent\<E: Entity, P: Property\<E>>` and
+`EntityCreatedEvent\<E: Entity>` types.
 
 ```rust
 pub fn init(context: &mut Context) {

--- a/docs/book/src/topics/handling-errors.md
+++ b/docs/book/src/topics/handling-errors.md
@@ -19,7 +19,7 @@ Use [`thiserror`](https://docs.rs/thiserror/latest/thiserror/) to help you easil
 ## Creating your own error types
 
 You might want your own error type if you want to generate structured errors from your own code or want your own
-structured error handling code. For example, you might want to have functions that return `Result<U, V>` to indicate
+structured error handling code. For example, you might want to have functions that return <code>Result&lt;U, V&gt;</code> to indicate
 that they might fail:
 
 ```rust
@@ -84,12 +84,12 @@ pub enum ModelError {
 
 - `impl std::error::Error for ModelError`
 - `impl Display for ModelError`
-- `From<IxaError>`, `From<std::string::FromUtf8Error>`, `From<std::num::ParseIntError>`, and `From<ixa::csv::Error>`
+- <code>From&lt;IxaError&gt;</code>, <code>From&lt;std::string::FromUtf8Error&gt;</code>, <code>From&lt;std::num::ParseIntError&gt;</code>, and <code>From&lt;ixa::csv::Error&gt;</code>
   (because of `#[from]`)
 - `source()` wiring for error chaining
 
 That last item is what lets one error wrap another: The `std::error::Error`
-trait has a `source(&self) -> Option<&(dyn Error + 'static)>` method. When an
+trait has a <code>source(&self) -&gt; Option&lt;&amp;(dyn Error + 'static)&gt;</code> method. When an
 error returns another error from `source()`, it is saying "this error happened
 because of that other error." Error reporters can then walk the chain and show
 both the top-level message and the underlying cause.
@@ -98,7 +98,7 @@ You can implement all of this without the [`thiserror`](https://docs.rs/thiserro
 [`thiserror`](https://docs.rs/thiserror/latest/thiserror/) saves you a lot of boilerplate. With
 [`thiserror`](https://docs.rs/thiserror/latest/thiserror/), you usually do not write `source()` yourself. A field
 marked with `#[from]` or `#[source]` is treated as the underlying cause and returned from `source()` automatically.
-`#[from]` also generates the corresponding `From<...>` impl, while `#[source]` only marks the wrapped error as the
+`#[from]` also generates the corresponding <code>From&lt;...&gt;</code> impl, while `#[source]` only marks the wrapped error as the
 cause.
 
 This shows several useful patterns:

--- a/docs/book/src/topics/handling-errors.md
+++ b/docs/book/src/topics/handling-errors.md
@@ -19,7 +19,7 @@ Use [`thiserror`](https://docs.rs/thiserror/latest/thiserror/) to help you easil
 ## Creating your own error types
 
 You might want your own error type if you want to generate structured errors from your own code or want your own
-structured error handling code. For example, you might want to have functions that return <code>Result&lt;U, V&gt;</code> to indicate
+structured error handling code. For example, you might want to have functions that return `Result\<U, V>` to indicate
 that they might fail:
 
 ```rust
@@ -84,12 +84,12 @@ pub enum ModelError {
 
 - `impl std::error::Error for ModelError`
 - `impl Display for ModelError`
-- <code>From&lt;IxaError&gt;</code>, <code>From&lt;std::string::FromUtf8Error&gt;</code>, <code>From&lt;std::num::ParseIntError&gt;</code>, and <code>From&lt;ixa::csv::Error&gt;</code>
+- `From\<IxaError>`, `From\<std::string::FromUtf8Error>`, `From\<std::num::ParseIntError>`, and `From\<ixa::csv::Error>`
   (because of `#[from]`)
 - `source()` wiring for error chaining
 
 That last item is what lets one error wrap another: The `std::error::Error`
-trait has a <code>source(&self) -&gt; Option&lt;&amp;(dyn Error + 'static)&gt;</code> method. When an
+trait has a `source(&self) -> Option\<&(dyn Error + 'static)>` method. When an
 error returns another error from `source()`, it is saying "this error happened
 because of that other error." Error reporters can then walk the chain and show
 both the top-level message and the underlying cause.
@@ -98,7 +98,7 @@ You can implement all of this without the [`thiserror`](https://docs.rs/thiserro
 [`thiserror`](https://docs.rs/thiserror/latest/thiserror/) saves you a lot of boilerplate. With
 [`thiserror`](https://docs.rs/thiserror/latest/thiserror/), you usually do not write `source()` yourself. A field
 marked with `#[from]` or `#[source]` is treated as the underlying cause and returned from `source()` automatically.
-`#[from]` also generates the corresponding <code>From&lt;...&gt;</code> impl, while `#[source]` only marks the wrapped error as the
+`#[from]` also generates the corresponding `From\<...>` impl, while `#[source]` only marks the wrapped error as the
 cause.
 
 This shows several useful patterns:

--- a/docs/book/src/topics/indexing.md
+++ b/docs/book/src/topics/indexing.md
@@ -24,7 +24,7 @@ Best practices:
 - The cost of creating indexes is increased memory use, which can be significant
   for large populations. So it is best to only create indexes / multi-indexes
   that actually improve model performance.
-- It may be best to call `context.index_property::\<Entity, Property<Entity>>()`
+- It may be best to call <code>context.index_property::&lt;Entity, Property&lt;Entity&gt;&gt;()</code>
   in the `init()` method of the module in which the property is defined, or you
   can put all of your `Context::index_property` calls together in a main
   initialization function if you prefer.

--- a/docs/book/src/topics/indexing.md
+++ b/docs/book/src/topics/indexing.md
@@ -24,7 +24,7 @@ Best practices:
 - The cost of creating indexes is increased memory use, which can be significant
   for large populations. So it is best to only create indexes / multi-indexes
   that actually improve model performance.
-- It may be best to call <code>context.index_property::&lt;Entity, Property&lt;Entity&gt;&gt;()</code>
+- It may be best to call `context.index_property::\<Entity, Property\<Entity>>()`
   in the `init()` method of the module in which the property is defined, or you
   can put all of your `Context::index_property` calls together in a main
   initialization function if you prefer.

--- a/mise.toml
+++ b/mise.toml
@@ -7,9 +7,9 @@ pnpm = "latest"
 "npm:@commitlint/config-conventional" = "19.7.1"
 "cargo:wasm-pack" = "latest"
 "cargo:hyperfine" = "latest"
-"cargo:mdbook" = "0.4.52"
-"cargo:mdbook-callouts" = "0.2.2"
-"cargo:mdbook-inline-highlighting" = "1.0.0"
+"cargo:mdbook" = "0.5.3"
+"cargo:mdbook-callouts" = "0.3.0"
+"cargo:mdbook-inline-highlighting" = "2.0.0"
 "cargo:rumdl" = "0.1.18"
 
 


### PR DESCRIPTION
## Summary

Fix mdBook HTML checker warnings caused by inline code spans containing angle-bracket placeholders or Rust generics, and update the mdBook-related tooling versions in `mise.toml`.

## Changes

- Updated mdBook tooling:
  - `mdbook`: `0.4.52` -> `0.5.3`
  - `mdbook-callouts`: `0.2.2` -> `0.3.0`
  - `mdbook-inline-highlighting`: `1.0.0` -> `2.0.0`
- Escaped inline generic examples in:
  - `docs/book/src/topics/indexing.md`
  - `docs/book/src/topics/handling-errors.md`
  - `docs/book/src/migration_guide.md`
