### PR TITLE
chore: add mise command to generate test coverage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 # Criterion.rs output file.
 profile.json
 profiling.json
+*.profraw
 
 .vscode/*
 .idea

--- a/mise.toml
+++ b/mise.toml
@@ -24,6 +24,12 @@ run = [
   "rustup component add --toolchain nightly-x86_64-unknown-linux-gnu rustfmt clippy",
 ]
 
+[tasks.'install-coverage']
+description = "Install Rust coverage tools"
+run = [
+  "rustup component add llvm-tools-preview",
+]
+
 [tasks.build]
 description = "Build default targets. Run with --release for a release build."
 run = "cargo build --workspace"
@@ -86,8 +92,8 @@ run = "cargo test --no-default-features"
 
 [tasks.coverage]
 description = "Generate local Rust test coverage reports"
+depends = ["install-coverage"]
 run = [
-  "rustup component add llvm-tools-preview",
   "cargo llvm-cov clean --workspace",
   "cargo llvm-cov --workspace --all-targets --no-report",
   "cargo llvm-cov report --summary-only",

--- a/mise.toml
+++ b/mise.toml
@@ -92,8 +92,6 @@ run = [
   "cargo llvm-cov --workspace --all-targets --no-report",
   "cargo llvm-cov report --summary-only",
   "cargo llvm-cov report --html",
-  "cargo clean -p ixa-integration-tests",
-  "find . -name '*.profraw' ! -path './target/*' -delete",
 ]
 
 [tasks.'wasm:pnpm']

--- a/mise.toml
+++ b/mise.toml
@@ -7,6 +7,7 @@ pnpm = "latest"
 "npm:@commitlint/config-conventional" = "19.7.1"
 "cargo:wasm-pack" = "latest"
 "cargo:hyperfine" = "latest"
+"cargo:cargo-llvm-cov" = "latest"
 "cargo:mdbook" = "0.4.52"
 "cargo:mdbook-callouts" = "0.2.2"
 "cargo:mdbook-inline-highlighting" = "1.0.0"
@@ -82,6 +83,18 @@ run = "pnpm exec playwright test"
 [tasks.'test:features']
 description = "Run just the core Ixa tests (much faster)"
 run = "cargo test --no-default-features"
+
+[tasks.coverage]
+description = "Generate local Rust test coverage reports"
+run = [
+  "rustup component add llvm-tools-preview",
+  "cargo llvm-cov clean --workspace",
+  "cargo llvm-cov --workspace --all-targets --no-report",
+  "cargo llvm-cov report --summary-only",
+  "cargo llvm-cov report --html",
+  "cargo clean -p ixa-integration-tests",
+  "find . -name '*.profraw' ! -path './target/*' -delete",
+]
 
 [tasks.'wasm:pnpm']
 dir = "integration-tests/ixa-wasm-tests"


### PR DESCRIPTION
## Summary

- Add `cargo-llvm-cov` as a mise-managed tool.
- Add a `mise run coverage` task for local Rust coverage generation across the workspace and all targets.
- Generate both summary and HTML coverage reports, with HTML output available under `target/llvm-cov/html/`.
- Ignore `*.profraw` coverage artifacts so raw profiling files do not show up as untracked files.
