### PR TITLE
chore: add gated MSRV verification

### DIFF
--- a/.github/workflows/check-test.yaml
+++ b/.github/workflows/check-test.yaml
@@ -89,61 +89,6 @@ jobs:
       - name: Build docs
         run: mise run docs
 
-  cargo-toml-changes:
-    runs-on: ubuntu-latest
-    outputs:
-      changed: ${{ steps.changed.outputs.changed }}
-
-    steps:
-      - uses: actions/checkout@v6
-        with:
-          fetch-depth: 0
-
-      - name: Check for Cargo.toml changes
-        id: changed
-        shell: bash
-        run: |
-          set -euo pipefail
-
-          case "${{ github.event_name }}" in
-            pull_request)
-              base="${{ github.event.pull_request.base.sha }}"
-              head="${{ github.sha }}"
-              ;;
-            push)
-              base="${{ github.event.before }}"
-              head="${{ github.sha }}"
-              ;;
-            *)
-              echo "changed=true" >> "${GITHUB_OUTPUT}"
-              exit 0
-              ;;
-          esac
-
-          if [[ "${base}" == "0000000000000000000000000000000000000000" ]]; then
-            echo "changed=true" >> "${GITHUB_OUTPUT}"
-          else
-            changed_files="$(git diff --name-only "${base}" "${head}" -- 'Cargo.toml' '**/Cargo.toml')"
-            if [[ -n "${changed_files}" ]]; then
-              echo "changed=true" >> "${GITHUB_OUTPUT}"
-            else
-              echo "changed=false" >> "${GITHUB_OUTPUT}"
-            fi
-          fi
-
-  msrv:
-    runs-on: ubuntu-latest
-    needs: cargo-toml-changes
-    if: ${{ needs.cargo-toml-changes.outputs.changed == 'true' }}
-
-    steps:
-      - uses: actions/checkout@v6
-      - name: Setup environment
-        uses: ./.github/actions/setup-env
-
-      - name: Verify MSRV
-        run: mise run check:msrv
-
   setup-new-project:
     uses: ./.github/workflows/test-setup-new-project.yaml
 
@@ -157,8 +102,6 @@ jobs:
       - examples
       - book-example
       - docs
-      - cargo-toml-changes
-      - msrv
       - setup-new-project
     if: ${{ always() }}
     steps:
@@ -174,8 +117,6 @@ jobs:
             examples:${{ needs.examples.result }}
             book-example:${{ needs.book-example.result }}
             docs:${{ needs.docs.result }}
-            cargo-toml-changes:${{ needs.cargo-toml-changes.result }}
-            msrv:${{ needs.msrv.result }}
             setup-new-project:${{ needs.setup-new-project.result }}
           )
 
@@ -184,9 +125,6 @@ jobs:
             job="${pair%%:*}"
             result="${pair#*:}"
             echo "${job}: ${result}"
-            if [ "${job}" = "msrv" ] && [ "${result}" = "skipped" ]; then
-              continue
-            fi
             if [ "${result}" != "success" ]; then
               failed=1
             fi

--- a/.github/workflows/check-test.yaml
+++ b/.github/workflows/check-test.yaml
@@ -92,6 +92,61 @@ jobs:
       - name: Build docs
         run: mise run docs
 
+  cargo-toml-changes:
+    runs-on: ubuntu-latest
+    outputs:
+      changed: ${{ steps.changed.outputs.changed }}
+
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Check for Cargo.toml changes
+        id: changed
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          case "${{ github.event_name }}" in
+            pull_request)
+              base="${{ github.event.pull_request.base.sha }}"
+              head="${{ github.sha }}"
+              ;;
+            push)
+              base="${{ github.event.before }}"
+              head="${{ github.sha }}"
+              ;;
+            *)
+              echo "changed=true" >> "${GITHUB_OUTPUT}"
+              exit 0
+              ;;
+          esac
+
+          if [[ "${base}" == "0000000000000000000000000000000000000000" ]]; then
+            echo "changed=true" >> "${GITHUB_OUTPUT}"
+          else
+            changed_files="$(git diff --name-only "${base}" "${head}" -- 'Cargo.toml' '**/Cargo.toml')"
+            if [[ -n "${changed_files}" ]]; then
+              echo "changed=true" >> "${GITHUB_OUTPUT}"
+            else
+              echo "changed=false" >> "${GITHUB_OUTPUT}"
+            fi
+          fi
+
+  msrv:
+    runs-on: ubuntu-latest
+    needs: cargo-toml-changes
+    if: ${{ needs.cargo-toml-changes.outputs.changed == 'true' }}
+
+    steps:
+      - uses: actions/checkout@v6
+      - name: Setup environment
+        uses: ./.github/actions/setup-env
+
+      - name: Verify MSRV
+        run: mise run check:msrv
+
   setup-new-project:
     uses: ./.github/workflows/test-setup-new-project.yaml
 
@@ -105,6 +160,8 @@ jobs:
       - examples
       - book-example
       - docs
+      - cargo-toml-changes
+      - msrv
       - setup-new-project
     if: ${{ always() }}
     steps:
@@ -120,6 +177,8 @@ jobs:
             examples:${{ needs.examples.result }}
             book-example:${{ needs.book-example.result }}
             docs:${{ needs.docs.result }}
+            cargo-toml-changes:${{ needs.cargo-toml-changes.result }}
+            msrv:${{ needs.msrv.result }}
             setup-new-project:${{ needs.setup-new-project.result }}
           )
 
@@ -128,6 +187,9 @@ jobs:
             job="${pair%%:*}"
             result="${pair#*:}"
             echo "${job}: ${result}"
+            if [ "${job}" = "msrv" ] && [ "${result}" = "skipped" ]; then
+              continue
+            fi
             if [ "${result}" != "success" ]; then
               failed=1
             fi

--- a/.github/workflows/msrv.yaml
+++ b/.github/workflows/msrv.yaml
@@ -1,0 +1,30 @@
+name: MSRV
+
+on:
+  push:
+    branches: main
+    paths:
+      - Cargo.toml
+      - "**/Cargo.toml"
+  pull_request:
+    paths:
+      - Cargo.toml
+      - "**/Cargo.toml"
+  workflow_dispatch:
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  msrv:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v6
+      - name: Setup environment
+        uses: ./.github/actions/setup-env
+
+      - name: Verify MSRV
+        env:
+          XDG_CACHE_HOME: ${{ github.workspace }}/target/msrv-cache
+        run: mise run msrv

--- a/mise.toml
+++ b/mise.toml
@@ -7,6 +7,7 @@ pnpm = "latest"
 "npm:@commitlint/config-conventional" = "19.7.1"
 "cargo:wasm-pack" = "latest"
 "cargo:hyperfine" = "latest"
+"cargo:cargo-msrv" = "0.19.3"
 "cargo:mdbook" = "0.5.3"
 "cargo:mdbook-callouts" = "0.3.0"
 "cargo:mdbook-inline-highlighting" = "2.0.0"
@@ -133,7 +134,7 @@ depends = "build:hyperfine"
 run = './target/release/hyperfine'
 
 [tasks.check-all]
-run = ["mise run check:*"]
+run = ["mise run check:rust", "mise run check:markdown"]
 
 [tasks.check]
 description = "Run rust checks. Faster than check-all"
@@ -148,6 +149,10 @@ run = [
   "cargo +nightly fmt --check",
   "cargo +nightly clippy --workspace --all-targets --all-features -- -D warnings",
 ]
+
+[tasks.'check:msrv']
+description = "Verify the declared minimum supported Rust version"
+run = 'XDG_CACHE_HOME="$PWD/target/msrv-cache" cargo msrv --no-log verify --all-features'
 
 [tasks.prettier]
 description = "Run prettier on all supported files"
@@ -198,7 +203,7 @@ depends = ['check-all']
 [tasks.prepush]
 description = "Check everything before pushing"
 env.RUSTFLAGS = "-D warnings"
-run = ["mise precommit", "mise examples", "mise docs", "mise test-all"]
+run = ["mise precommit", "mise run check:msrv", "mise examples", "mise docs", "mise test-all"]
 
 [tasks.'docker:build']
 run = "docker build -t ixa-bench ."

--- a/mise.toml
+++ b/mise.toml
@@ -169,7 +169,7 @@ depends = "build:hyperfine"
 run = './target/release/hyperfine'
 
 [tasks.check-all]
-run = ["mise run check:rust", "mise run check:markdown"]
+run = ["mise run check:*"]
 
 [tasks.check]
 description = "Run rust checks. Faster than check-all"
@@ -186,9 +186,9 @@ run = [
   "cargo +nightly clippy --workspace --all-targets --all-features -- -D warnings",
 ]
 
-[tasks.'check:msrv']
+[tasks.msrv]
 description = "Verify the declared minimum supported Rust version"
-run = 'XDG_CACHE_HOME="$PWD/target/msrv-cache" cargo msrv --no-log verify --all-features'
+run = "cargo msrv --no-log verify --all-features"
 
 [tasks.prettier]
 description = "Run prettier on all supported files"
@@ -241,7 +241,7 @@ depends = ['check-all']
 [tasks.prepush]
 description = "Check everything before pushing"
 env.RUSTFLAGS = "-D warnings"
-run = ["mise precommit", "mise run check:msrv", "mise examples", "mise docs", "mise test-all"]
+run = ["mise precommit", "mise run msrv", "mise examples", "mise docs", "mise test-all"]
 
 [tasks.'docker:build']
 run = "docker build -t ixa-bench ."

--- a/src/macros/property_impl.rs
+++ b/src/macros/property_impl.rs
@@ -1573,27 +1573,18 @@ mod tests {
             .add_entity(with!(Person, POu32(Some(42)), Pu32(22)))
             .unwrap();
         assert_eq!(
-            format!(
-                "{:}",
-                POu32::get_display(&context.get_property::<_, POu32>(person))
-            ),
+            POu32::get_display(&context.get_property::<_, POu32>(person)).to_string(),
             "42"
         );
         assert_eq!(
-            format!(
-                "{:}",
-                Pu32::get_display(&context.get_property::<_, Pu32>(person))
-            ),
+            Pu32::get_display(&context.get_property::<_, Pu32>(person)).to_string(),
             "Pu32(22)"
         );
         let person2 = context
             .add_entity(with!(Person, POu32(None), Pu32(11)))
             .unwrap();
         assert_eq!(
-            format!(
-                "{:}",
-                POu32::get_display(&context.get_property::<_, POu32>(person2))
-            ),
+            POu32::get_display(&context.get_property::<_, POu32>(person2)).to_string(),
             "None"
         );
     }


### PR DESCRIPTION
## Summary

- Add `cargo-msrv` to the mise toolchain and define `mise run check:msrv` to verify the declared `rust-version`.
- Add a CI job that detects `Cargo.toml` changes and runs the MSRV check only when package metadata changes.
- Wire the MSRV job into `all-green`, while allowing it to be skipped when no `Cargo.toml` files changed.
- Keep `check-all`/precommit fast by excluding MSRV there, but include MSRV in `prepush`.
- Update display assertions in `property_impl.rs` to use `.to_string()`.
