### PR TITLE
fix: Use schedule_relative!

### DIFF
--- a/docs/book/models/disease_model/src/infection_manager.rs
+++ b/docs/book/models/disease_model/src/infection_manager.rs
@@ -1,8 +1,8 @@
 use ixa::prelude::*;
 use rand_distr::Exp;
 
-use crate::INFECTION_DURATION;
 use crate::people::{InfectionStatus, Person, PersonId};
+use crate::INFECTION_DURATION;
 
 // ANCHOR: infection_status_event
 pub type InfectionStatusEvent = PropertyChangeEvent<Person, InfectionStatus>;
@@ -13,14 +13,14 @@ define_rng!(InfectionRng);
 // ANCHOR: schedule_recovery
 fn schedule_recovery(context: &mut Context, person_id: PersonId) {
     trace!("Scheduling recovery");
-    let current_time = context.get_current_time();
     let sampled_infection_duration =
         context.sample_distr(InfectionRng, Exp::new(1.0 / INFECTION_DURATION).unwrap());
-    let recovery_time = current_time + sampled_infection_duration;
 
-    context.add_plan(recovery_time, move |context| {
-        context.set_property(person_id, InfectionStatus::R);
-    });
+    schedule_relative!(
+        context,
+        sampled_infection_duration,
+        |context: &mut Context| context.set_property(person_id, InfectionStatus::R)
+    );
 }
 // ANCHOR_END: schedule_recovery
 
@@ -28,7 +28,9 @@ fn schedule_recovery(context: &mut Context, person_id: PersonId) {
 fn handle_infection_status_change(context: &mut Context, event: InfectionStatusEvent) {
     trace!(
         "Handling infection status change from {:?} to {:?} for {:?}",
-        event.previous, event.current, event.entity_id
+        event.previous,
+        event.current,
+        event.entity_id
     );
     if event.current == InfectionStatus::I {
         schedule_recovery(context, event.entity_id);

--- a/examples/basic-infection/src/infection_manager.rs
+++ b/examples/basic-infection/src/infection_manager.rs
@@ -16,8 +16,11 @@ fn schedule_recovery(context: &mut Context, person_id: PersonId) {
     trace!("Scheduling recovery");
     let infection_duration =
         context.sample_distr(InfectionRng, Exp::new(1.0 / INFECTION_DURATION).unwrap());
-    schedule_relative!(context, infection_duration, |context: &mut Context| context
-        .set_property(person_id, InfectionStatus::R));
+    schedule_relative!(context, infection_duration, recover, person_id);
+}
+
+fn recover(context: &mut Context, person_id: PersonId) {
+    context.set_property(person_id, InfectionStatus::R)
 }
 
 fn handle_infection_status_change(context: &mut Context, event: InfectionStatusEvent) {

--- a/examples/basic-infection/src/infection_manager.rs
+++ b/examples/basic-infection/src/infection_manager.rs
@@ -14,11 +14,10 @@ define_rng!(InfectionRng);
 
 fn schedule_recovery(context: &mut Context, person_id: PersonId) {
     trace!("Scheduling recovery");
-    let recovery_time = context.get_current_time()
-        + context.sample_distr(InfectionRng, Exp::new(1.0 / INFECTION_DURATION).unwrap());
-    context.add_plan(recovery_time, move |context| {
-        context.set_property(person_id, InfectionStatus::R);
-    });
+    let infection_duration =
+        context.sample_distr(InfectionRng, Exp::new(1.0 / INFECTION_DURATION).unwrap());
+    schedule_relative!(context, infection_duration, |context: &mut Context| context
+        .set_property(person_id, InfectionStatus::R));
 }
 
 fn handle_infection_status_change(context: &mut Context, event: InfectionStatusEvent) {

--- a/examples/births-deaths/src/infection_manager.rs
+++ b/examples/births-deaths/src/infection_manager.rs
@@ -34,9 +34,7 @@ fn schedule_recovery(context: &mut Context, person_id: PersonId) {
     let is_alive: Alive = context.get_property(person_id);
 
     if is_alive.0 {
-        let plan_id =
-            schedule_relative!(context, infection_duration, |context: &mut Context| context
-                .set_property(person_id, InfectionStatus::R));
+        let plan_id = schedule_relative!(context, infection_duration, recover, person_id);
         let plans_data_container = context.get_data_mut(InfectionPlansPlugin);
         plans_data_container
             .plans_map
@@ -44,6 +42,10 @@ fn schedule_recovery(context: &mut Context, person_id: PersonId) {
             .or_default()
             .insert(plan_id);
     }
+}
+
+fn recover(context: &mut Context, person_id: PersonId) {
+    context.set_property(person_id, InfectionStatus::R);
 }
 
 fn remove_recovery_plan_data(context: &mut Context, person_id: PersonId) {

--- a/examples/births-deaths/src/infection_manager.rs
+++ b/examples/births-deaths/src/infection_manager.rs
@@ -26,15 +26,17 @@ fn schedule_recovery(context: &mut Context, person_id: PersonId) {
         .get_global_property_value(Parameters)
         .unwrap()
         .clone();
-    let infection_duration = parameters.infection_duration;
-    let recovery_time = context.get_current_time()
-        + context.sample_distr(InfectionRng1, Exp::new(1.0 / infection_duration).unwrap());
+    let mean_infection_duration = parameters.infection_duration;
+    let infection_duration = context.sample_distr(
+        InfectionRng1,
+        Exp::new(1.0 / mean_infection_duration).unwrap(),
+    );
     let is_alive: Alive = context.get_property(person_id);
 
     if is_alive.0 {
-        let plan_id = context.add_plan(recovery_time, move |context| {
-            context.set_property(person_id, InfectionStatus::R);
-        });
+        let plan_id =
+            schedule_relative!(context, infection_duration, |context: &mut Context| context
+                .set_property(person_id, InfectionStatus::R));
         let plans_data_container = context.get_data_mut(InfectionPlansPlugin);
         plans_data_container
             .plans_map

--- a/examples/births-deaths/src/population_manager.rs
+++ b/examples/births-deaths/src/population_manager.rs
@@ -55,29 +55,29 @@ impl fmt::Display for AgeGroupRisk {
     }
 }
 
-fn schedule_aging(context: &mut Context, person_id: PersonId) {
+fn do_age(context: &mut Context, person_id: PersonId) {
     let is_alive: Alive = context.get_property(person_id);
     if is_alive.0 {
         let prev_age: Age = context.get_property(person_id);
         context.set_property(person_id, Age(prev_age.0 + 1));
-        schedule_relative!(context, 365.0, schedule_aging, person_id);
+        schedule_relative!(context, 365.0, do_age, person_id);
     }
 }
 
-fn schedule_birth(context: &mut Context) {
+fn do_birth(context: &mut Context) {
     let parameters = context
         .get_global_property_value(Parameters)
         .unwrap()
         .clone();
     let person = context.add_entity(with!(Person, Age(0))).unwrap();
-    schedule_relative!(context, 365.0, schedule_aging, person);
+    schedule_relative!(context, 365.0, do_age, person);
 
     let next_birth_delay =
         context.sample_distr(PeopleRng, Exp::new(parameters.birth_rate).unwrap());
-    schedule_relative!(context, next_birth_delay, schedule_birth);
+    schedule_relative!(context, next_birth_delay, do_birth);
 }
 
-fn schedule_death(context: &mut Context) {
+fn do_death(context: &mut Context) {
     let parameters = context
         .get_global_property_value(Parameters)
         .unwrap()
@@ -89,7 +89,7 @@ fn schedule_death(context: &mut Context) {
         let next_death_delay =
             context.sample_distr(PeopleRng, Exp::new(parameters.death_rate).unwrap());
 
-        schedule_relative!(context, next_death_delay, schedule_death);
+        schedule_relative!(context, next_death_delay, do_death);
     }
 }
 
@@ -103,21 +103,15 @@ pub fn init(context: &mut Context) {
         let age: u8 = context.sample_range(PeopleRng, 0..MAX_AGE);
         let person = context.add_entity(with!(Person, Age(age))).unwrap();
         let birthday = context.sample_distr(PeopleRng, Uniform::new(0.0, 365.0).unwrap());
-        context.add_plan(365.0 + birthday, move |context| {
-            schedule_aging(context, person);
-        });
+        context.add_plan(365.0 + birthday, move |context| do_age(context, person));
     }
 
     // Plan for births and deaths
     if parameters.birth_rate > 0.0 {
-        context.add_plan(0.0, |context| {
-            schedule_birth(context);
-        });
+        context.add_plan(0.0, |context| do_birth(context));
     }
     if parameters.death_rate > 0.0 {
-        context.add_plan(0.0, |context| {
-            schedule_death(context);
-        });
+        context.add_plan(0.0, |context| do_death(context));
     }
 }
 
@@ -189,7 +183,7 @@ mod test {
             .unwrap();
         context.init_random(p_values.seed);
 
-        schedule_birth(&mut context);
+        do_birth(&mut context);
     }
 
     #[test]
@@ -213,7 +207,7 @@ mod test {
             .unwrap();
         context.init_random(p_values.seed);
         let _person = context.add_entity(with!(Person, Age(0))).unwrap();
-        schedule_death(&mut context);
+        do_death(&mut context);
     }
 
     #[test]
@@ -235,7 +229,7 @@ mod test {
         for i in 0..people.len() {
             let person = people[i];
             context.add_plan(365.0, move |context| {
-                schedule_aging(context, person);
+                do_age(context, person);
             });
             let age_group = age_groups[i];
             assert_eq!(

--- a/examples/births-deaths/src/population_manager.rs
+++ b/examples/births-deaths/src/population_manager.rs
@@ -60,10 +60,7 @@ fn schedule_aging(context: &mut Context, person_id: PersonId) {
     if is_alive.0 {
         let prev_age: Age = context.get_property(person_id);
         context.set_property(person_id, Age(prev_age.0 + 1));
-        let next_age_event = context.get_current_time() + 365.0;
-        context.add_plan(next_age_event, move |context| {
-            schedule_aging(context, person_id);
-        });
+        schedule_relative!(context, 365.0, schedule_aging, person_id);
     }
 }
 
@@ -73,15 +70,11 @@ fn schedule_birth(context: &mut Context) {
         .unwrap()
         .clone();
     let person = context.add_entity(with!(Person, Age(0))).unwrap();
-    context.add_plan(context.get_current_time() + 365.0, move |context| {
-        schedule_aging(context, person);
-    });
+    schedule_relative!(context, 365.0, schedule_aging, person);
 
-    let next_birth_event = context.get_current_time()
-        + context.sample_distr(PeopleRng, Exp::new(parameters.birth_rate).unwrap());
-    context.add_plan(next_birth_event, move |context| {
-        schedule_birth(context);
-    });
+    let next_birth_delay =
+        context.sample_distr(PeopleRng, Exp::new(parameters.birth_rate).unwrap());
+    schedule_relative!(context, next_birth_delay, schedule_birth);
 }
 
 fn schedule_death(context: &mut Context) {
@@ -93,12 +86,10 @@ fn schedule_death(context: &mut Context) {
     if let Some(person) = context.sample_entity(PeopleRng, with!(Person, Alive(true))) {
         context.set_property(person, Alive(false));
 
-        let next_death_event = context.get_current_time()
-            + context.sample_distr(PeopleRng, Exp::new(parameters.death_rate).unwrap());
+        let next_death_delay =
+            context.sample_distr(PeopleRng, Exp::new(parameters.death_rate).unwrap());
 
-        context.add_plan(next_death_event, |context| {
-            schedule_death(context);
-        });
+        schedule_relative!(context, next_death_delay, schedule_death);
     }
 }
 

--- a/examples/births-deaths/src/population_manager.rs
+++ b/examples/births-deaths/src/population_manager.rs
@@ -108,10 +108,10 @@ pub fn init(context: &mut Context) {
 
     // Plan for births and deaths
     if parameters.birth_rate > 0.0 {
-        context.add_plan(0.0, |context| do_birth(context));
+        context.add_plan(0.0, do_birth);
     }
     if parameters.death_rate > 0.0 {
-        context.add_plan(0.0, |context| do_death(context));
+        context.add_plan(0.0, do_death);
     }
 }
 

--- a/examples/network-hhmodel/seir.rs
+++ b/examples/network-hhmodel/seir.rs
@@ -50,9 +50,9 @@ fn schedule_waiting_event(
     mean_period: f64,
     new_status: DiseaseStatus,
 ) {
-    let t = context.get_current_time() + calculate_waiting_time(context, shape, mean_period);
+    let delay = calculate_waiting_time(context, shape, mean_period);
 
-    context.add_plan(t, move |context| {
+    schedule_relative!(context, delay, |context| {
         trace!("{person_id:?} changed to disease state {new_status:?} at t={t:?}");
         context.set_property(person_id, new_status);
     });

--- a/examples/network-hhmodel/seir.rs
+++ b/examples/network-hhmodel/seir.rs
@@ -52,7 +52,7 @@ fn schedule_waiting_event(
 ) {
     let delay = calculate_waiting_time(context, shape, mean_period);
 
-    schedule_relative!(context, delay, |context| {
+    schedule_relative!(context, delay, |context: &mut Context| {
         trace!("{person_id:?} changed to disease state {new_status:?}");
         context.set_property(person_id, new_status);
     });

--- a/examples/network-hhmodel/seir.rs
+++ b/examples/network-hhmodel/seir.rs
@@ -53,7 +53,7 @@ fn schedule_waiting_event(
     let delay = calculate_waiting_time(context, shape, mean_period);
 
     schedule_relative!(context, delay, |context| {
-        trace!("{person_id:?} changed to disease state {new_status:?} at t={t:?}");
+        trace!("{person_id:?} changed to disease state {new_status:?}");
         context.set_property(person_id, new_status);
     });
 }

--- a/integration-tests/ixa-wasm-tests/src/infection_manager.rs
+++ b/integration-tests/ixa-wasm-tests/src/infection_manager.rs
@@ -14,11 +14,11 @@ define_rng!(InfectionRng);
 
 fn schedule_recovery(context: &mut Context, person_id: PersonId) {
     trace!("Scheduling recovery");
-    let recovery_time = context.get_current_time()
-        + context.sample_distr(InfectionRng, Exp::new(1.0 / INFECTION_DURATION).unwrap());
-    context.add_plan(recovery_time, move |context| {
-        context.set_property(person_id, InfectionStatus::R);
-    });
+    let infection_duration =
+        context.sample_distr(InfectionRng, Exp::new(1.0 / INFECTION_DURATION).unwrap());
+
+    schedule_relative!(context, infection_duration, |context: &mut Context| context
+        .set_property(person_id, InfectionStatus::R));
 }
 
 fn handle_infection_status_change(context: &mut Context, event: InfectionStatusEvent) {

--- a/src/macros/schedule_relative.rs
+++ b/src/macros/schedule_relative.rs
@@ -22,11 +22,12 @@
 /// ```
 #[macro_export]
 macro_rules! schedule_relative {
-    ($context:expr, $delay:expr, $action:expr $(, $arg:expr)* $(,)?) => {{
-        let context = ($context);
-        let time = context.get_current_time() + $delay;
-        context.add_plan(time, move |context| {
-            ($action)(context $(, $arg)*)
-        })
-    }};
+    ($context:expr, $delay:expr, $action:expr $(, $arg:expr)* $(,)?) => {
+        {
+            let time = ($context).get_current_time() + $delay;
+            ($context).add_plan(time, move |context| {
+                ($action)(context $(, $arg)*)
+            })
+        }
+    };
 }


### PR DESCRIPTION
- Use `schedule_relative!` in docs
- Incorporate @RobertJacobsonCDC's fix of `schedule_relative!` macro from #954

I set out to use the fruits of #921. Overall, I think it's a nice improvement. I find it easier to avoid the `get_current_time()`, for example.

When there was a well-established handler, things look really slick, like in `examples/births-deaths/src/population_manager.rs`. (It also clarifies now that you're "scheduling" a function to "do" something.)

Perhaps not surprisingly, there are a number of places where the `add_plan` closure had a `context.do_something` form, so `schedule_relative!` also needs a closure (eg, [this line](https://github.com/CDCgov/ixa/compare/swo_schedule_relative?expand=1#diff-55f1d1e67b694b7f9385b5ec5bae2eb44f7d746efa684b9e939922f6c479204cR22)).

I think this is OK, since it encourages a practice where you have `schedule_relative!` call the handler, which is a `do_something(context, ...)` function. And that's a nice place to put the traces.

I'm calling this draft because there are some compilation errors that made me scratch my head. There's some problem with using `schedule_relative!` twice in a row, maybe?