### PR TITLE
chore: expand coverage for entity property and query helpers

### DIFF
--- a/src/data_structures/value_vec.rs
+++ b/src/data_structures/value_vec.rs
@@ -287,12 +287,55 @@ mod tests {
     }
 
     #[test]
+    fn capacity_reserve_and_shrink_to_fit() {
+        let v = ValueVec::with_capacity(4);
+        assert!(v.capacity() >= 4);
+
+        v.reserve(16);
+        assert!(v.capacity() >= 16);
+
+        v.extend([1, 2]);
+        v.shrink_to_fit();
+        assert!(v.capacity() >= v.len());
+    }
+
+    #[test]
     fn get_cloned_and_replace() {
         let v = ValueVec::new();
         v.extend([10, 20, 30]);
         assert_eq!(v.get(1), Some(20));
         assert_eq!(v.replace(1, 99), 20);
         assert_eq!(v.get(1), Some(99));
+    }
+
+    #[test]
+    fn set_swap_contains_clear_and_resize() {
+        let v = ValueVec::default();
+        assert!(v.is_empty());
+
+        v.resize(3, 7);
+        assert_eq!(v.to_vec(), vec![7, 7, 7]);
+
+        v.set(1, 9);
+        assert_eq!(v.at(1), 9);
+
+        let mut replacement = 42;
+        v.swap_value(1, &mut replacement);
+        assert_eq!(v.at(1), 42);
+        assert_eq!(replacement, 9);
+
+        assert!(v.contains(&42));
+        assert!(!v.contains(&9));
+
+        let mut next = 0;
+        v.resize_with(5, || {
+            next += 1;
+            next
+        });
+        assert_eq!(v.to_vec(), vec![7, 42, 7, 1, 2]);
+
+        v.clear();
+        assert!(v.is_empty());
     }
 
     #[test]

--- a/src/entity/entity.rs
+++ b/src/entity/entity.rs
@@ -210,6 +210,15 @@ mod tests {
     }
 
     #[test]
+    fn define_entity_helpers_create_and_downcast() {
+        assert_eq!(DummyEntity::new(), DummyEntity);
+
+        let mut entity = DummyEntity::new();
+        assert!(entity.as_any().downcast_ref::<DummyEntity>().is_some());
+        assert!(entity.as_any_mut().downcast_mut::<DummyEntity>().is_some());
+    }
+
+    #[test]
     fn test_entity_iterator_basic() {
         let mut iter = PopulationIterator::<DummyEntity>::new(3);
 

--- a/src/entity/property.rs
+++ b/src/entity/property.rs
@@ -179,3 +179,44 @@ pub trait Property<E: Entity>: AnyProperty {
         get_property_dependents_static::<E>(Self::id())
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use std::any::Any;
+
+    use super::*;
+    use crate::{define_entity, define_property};
+
+    define_entity!(PropertyTestPerson);
+    define_property!(struct PropertyTestAge(u8), PropertyTestPerson);
+
+    #[test]
+    fn const_str_eq_compares_lengths_and_bytes() {
+        assert!(const_str_eq("Age", "Age"));
+        assert!(!const_str_eq("Age", "Ages"));
+        assert!(!const_str_eq("Age", "Axe"));
+    }
+
+    #[test]
+    fn default_property_query_helpers_use_single_value() {
+        let value = PropertyTestAge(42);
+        let parts = [&value as &dyn Any];
+
+        assert_eq!(
+            <PropertyTestAge as Property<PropertyTestPerson>>::canonical_from_sorted_query_parts(
+                &parts
+            ),
+            Some(value)
+        );
+        assert_eq!(
+            <PropertyTestAge as Property<PropertyTestPerson>>::canonical_from_sorted_query_parts(
+                &[]
+            ),
+            None
+        );
+        assert_eq!(
+            <PropertyTestAge as Property<PropertyTestPerson>>::index_id(),
+            <PropertyTestAge as Property<PropertyTestPerson>>::id()
+        );
+    }
+}

--- a/src/entity/property_store.rs
+++ b/src/entity/property_store.rs
@@ -435,6 +435,15 @@ mod tests {
     define_property!(struct Vaccinated(bool), Person, default_const = Vaccinated(false));
 
     #[test]
+    fn property_store_default_matches_new() {
+        let property_store = PropertyStore::<Person>::default();
+        assert_eq!(
+            property_store.items.len(),
+            get_registered_property_count::<Person>()
+        );
+    }
+
+    #[test]
     fn test_get_property_store() {
         let mut property_store = PropertyStore::new();
 

--- a/src/entity/property_value_store_core.rs
+++ b/src/entity/property_value_store_core.rs
@@ -175,4 +175,70 @@ impl<E: Entity, P: Property<E>> PropertyValueStoreCore<E, P> {
     }
 }
 
-// See tests in `property_store.rs`.
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::entity::EntityId;
+    use crate::{define_entity, define_property};
+
+    define_entity!(StoreCorePerson);
+    define_property!(struct RequiredScore(u8), StoreCorePerson);
+    define_property!(struct DefaultScore(u8), StoreCorePerson, default_const = DefaultScore(0));
+
+    #[test]
+    fn capacity_and_reserve_helpers() {
+        let mut store = PropertyValueStoreCore::<StoreCorePerson, RequiredScore>::with_capacity(4);
+
+        assert!(store.data.capacity() >= 4);
+        assert_eq!(store.index_type(), PropertyIndexType::Unindexed);
+        assert!(store.value_change_counters.is_empty());
+
+        store.reserve(16);
+        assert!(store.data.capacity() >= 16);
+    }
+
+    #[test]
+    fn replace_existing_required_value() {
+        let mut store = PropertyValueStoreCore::<StoreCorePerson, RequiredScore>::new();
+        let entity_id = EntityId::new(0);
+
+        store.set(entity_id, RequiredScore(10));
+
+        assert_eq!(
+            store.replace(entity_id, RequiredScore(20)),
+            RequiredScore(10)
+        );
+        assert_eq!(store.get(entity_id), RequiredScore(20));
+    }
+
+    #[test]
+    fn replace_constant_default_value_paths() {
+        let mut store = PropertyValueStoreCore::<StoreCorePerson, DefaultScore>::new();
+        let entity_id = EntityId::new(2);
+
+        assert_eq!(store.replace(entity_id, DefaultScore(0)), DefaultScore(0));
+        assert!(store.data.is_empty());
+
+        assert_eq!(store.replace(entity_id, DefaultScore(7)), DefaultScore(0));
+        assert_eq!(store.data.len(), 3);
+        assert_eq!(store.get(EntityId::new(0)), DefaultScore(0));
+        assert_eq!(store.get(EntityId::new(1)), DefaultScore(0));
+        assert_eq!(store.get(entity_id), DefaultScore(7));
+    }
+
+    #[test]
+    #[should_panic(expected = "Property storage state is inconsistent")]
+    fn set_required_property_skipping_entity_id_panics() {
+        let mut store = PropertyValueStoreCore::<StoreCorePerson, RequiredScore>::new();
+
+        store.set(EntityId::new(1), RequiredScore(10));
+    }
+
+    #[test]
+    #[should_panic(expected = "Property storage state is inconsistent")]
+    fn replace_required_property_skipping_entity_id_panics() {
+        let mut store = PropertyValueStoreCore::<StoreCorePerson, RequiredScore>::new();
+
+        store.replace(EntityId::new(1), RequiredScore(10));
+    }
+}

--- a/src/entity/query/mod.rs
+++ b/src/entity/query/mod.rs
@@ -201,6 +201,7 @@ impl<E: Entity> Query<E> for E {}
 #[cfg(test)]
 mod tests {
 
+    use super::QueryInternal;
     use crate::prelude::*;
     use crate::{
         define_derived_property, define_entity, define_multi_property, define_property, Context,
@@ -220,6 +221,206 @@ mod tests {
     );
 
     define_multi_property!((Age, County), Person);
+
+    #[test]
+    fn empty_tuple_query_internal_matches_all_entities() {
+        let mut context = Context::new();
+        let person1 = context
+            .add_entity(with!(Person, Age(42), RiskCategory::High))
+            .unwrap();
+        let person2 = context
+            .add_entity(with!(Person, Age(30), RiskCategory::Low))
+            .unwrap();
+
+        assert_eq!(<() as QueryInternal<Person>>::get_type_ids(&()), Vec::new());
+        assert!(<() as QueryInternal<Person>>::is_empty_query(&()));
+        assert!(<() as QueryInternal<Person>>::query_parts(&())
+            .as_ref()
+            .is_empty());
+
+        let people = <() as QueryInternal<Person>>::new_query_result_iterator(&(), &context)
+            .collect::<Vec<_>>();
+        assert_eq!(people, vec![person1, person2]);
+        assert!(<() as QueryInternal<Person>>::match_entity(
+            &(),
+            person1,
+            &context
+        ));
+
+        let mut ids = vec![person1, person2];
+        <() as QueryInternal<Person>>::filter_entities(&(), &mut ids, &context);
+        assert_eq!(ids, vec![person1, person2]);
+    }
+
+    #[test]
+    fn entity_query_internal_has_no_type_ids() {
+        let mut context = Context::new();
+        let person1 = context
+            .add_entity(with!(Person, Age(42), RiskCategory::High))
+            .unwrap();
+        let person2 = context
+            .add_entity(with!(Person, Age(30), RiskCategory::Low))
+            .unwrap();
+
+        assert_eq!(
+            <Person as QueryInternal<Person>>::get_type_ids(&Person),
+            Vec::new()
+        );
+        assert_eq!(
+            <Person as QueryInternal<Person>>::multi_property_id(&Person),
+            None
+        );
+        assert!(<Person as QueryInternal<Person>>::query_parts(&Person)
+            .as_ref()
+            .is_empty());
+
+        let people = <Person as QueryInternal<Person>>::new_query_result(&Person, &context)
+            .into_iter()
+            .collect::<Vec<_>>();
+        assert_eq!(people, vec![person1, person2]);
+        assert!(<Person as QueryInternal<Person>>::match_entity(
+            &Person, person1, &context
+        ));
+
+        let mut ids = vec![person1, person2];
+        <Person as QueryInternal<Person>>::filter_entities(&Person, &mut ids, &context);
+        assert_eq!(ids, vec![person1, person2]);
+    }
+
+    #[test]
+    fn singleton_query_result_iterator_uses_indexed_and_unindexed_paths() {
+        let mut context = Context::new();
+        let high = context
+            .add_entity(with!(Person, RiskCategory::High))
+            .unwrap();
+        let _low = context
+            .add_entity(with!(Person, RiskCategory::Low))
+            .unwrap();
+
+        let people = <(RiskCategory,) as QueryInternal<Person>>::new_query_result_iterator(
+            &(RiskCategory::High,),
+            &context,
+        )
+        .collect::<Vec<_>>();
+        assert_eq!(people, vec![high]);
+
+        let mut indexed_context = Context::new();
+        indexed_context.index_property::<Person, RiskCategory>();
+        let indexed_high = indexed_context
+            .add_entity(with!(Person, RiskCategory::High))
+            .unwrap();
+        let _indexed_low = indexed_context
+            .add_entity(with!(Person, RiskCategory::Low))
+            .unwrap();
+
+        let people = <(RiskCategory,) as QueryInternal<Person>>::new_query_result_iterator(
+            &(RiskCategory::High,),
+            &indexed_context,
+        )
+        .collect::<Vec<_>>();
+        assert_eq!(people, vec![indexed_high]);
+
+        let mut empty_index_context = Context::new();
+        empty_index_context.index_property::<Person, Age>();
+        let _ = empty_index_context
+            .add_entity(with!(Person, Age(42), RiskCategory::Low))
+            .unwrap();
+
+        let people = <(Age,) as QueryInternal<Person>>::new_query_result_iterator(
+            &(Age(99),),
+            &empty_index_context,
+        )
+        .collect::<Vec<_>>();
+        assert!(people.is_empty());
+    }
+
+    #[test]
+    fn tuple_query_result_iterator_uses_indexed_and_unindexed_paths() {
+        let mut context = Context::new();
+        let matching1 = context
+            .add_entity(with!(Person, Age(28), County(0), RiskCategory::High))
+            .unwrap();
+        let _wrong_county = context
+            .add_entity(with!(Person, Age(28), County(1), RiskCategory::Low))
+            .unwrap();
+        let _wrong_age = context
+            .add_entity(with!(Person, Age(30), County(0), RiskCategory::Low))
+            .unwrap();
+        let matching2 = context
+            .add_entity(with!(Person, Age(28), County(0), RiskCategory::Low))
+            .unwrap();
+
+        let people = <(Age, County) as QueryInternal<Person>>::new_query_result_iterator(
+            &(Age(28), County(0)),
+            &context,
+        )
+        .collect::<Vec<_>>();
+        assert_eq!(people, vec![matching1, matching2]);
+
+        let mut indexed_context = Context::new();
+        indexed_context.index_property::<Person, (Age, County)>();
+        let indexed_matching = indexed_context
+            .add_entity(with!(Person, Age(28), County(0), RiskCategory::High))
+            .unwrap();
+        let _indexed_nonmatching = indexed_context
+            .add_entity(with!(Person, Age(28), County(1), RiskCategory::Low))
+            .unwrap();
+
+        let people = <(Age, County) as QueryInternal<Person>>::new_query_result_iterator(
+            &(Age(28), County(0)),
+            &indexed_context,
+        )
+        .collect::<Vec<_>>();
+        assert_eq!(people, vec![indexed_matching]);
+
+        let people = <(Age, County) as QueryInternal<Person>>::new_query_result_iterator(
+            &(Age(99), County(99)),
+            &indexed_context,
+        )
+        .collect::<Vec<_>>();
+        assert!(people.is_empty());
+    }
+
+    #[test]
+    fn singleton_filter_entities_keeps_matching_entities() {
+        let mut context = Context::new();
+        let high1 = context
+            .add_entity(with!(Person, RiskCategory::High))
+            .unwrap();
+        let low = context
+            .add_entity(with!(Person, RiskCategory::Low))
+            .unwrap();
+        let high2 = context
+            .add_entity(with!(Person, RiskCategory::High))
+            .unwrap();
+
+        let mut people = vec![high1, low, high2];
+        context.filter_entities(&mut people, with!(Person, RiskCategory::High));
+
+        assert_eq!(people, vec![high1, high2]);
+    }
+
+    #[test]
+    fn tuple_filter_entities_falls_through_after_unsupported_multi_index_lookup() {
+        let mut context = Context::new();
+        let matching1 = context
+            .add_entity(with!(Person, Age(28), County(0), RiskCategory::High))
+            .unwrap();
+        let wrong_county = context
+            .add_entity(with!(Person, Age(28), County(1), RiskCategory::Low))
+            .unwrap();
+        let wrong_age = context
+            .add_entity(with!(Person, Age(30), County(0), RiskCategory::Low))
+            .unwrap();
+        let matching2 = context
+            .add_entity(with!(Person, Age(28), County(0), RiskCategory::Low))
+            .unwrap();
+
+        let mut people = vec![matching1, wrong_county, wrong_age, matching2];
+        context.filter_entities(&mut people, with!(Person, County(0), Age(28)));
+
+        assert_eq!(people, vec![matching1, matching2]);
+    }
 
     #[test]
     fn with_query_results() {


### PR DESCRIPTION
## Summary

This PR adds focused unit coverage for previously missed helper paths across the entity/query and storage layers.

## Changes

- Added `ValueVec` tests for capacity, reserve, shrink, set, swap, contains, clear, resize, and default construction.
- Added entity macro helper coverage for `new`, `as_any`, and `as_any_mut`.
- Added property helper coverage for `const_str_eq`, default query canonicalization, and default `index_id`.
- Added `PropertyStore::default` coverage.
- Added direct `PropertyValueStoreCore` tests for:
  - `with_capacity`
  - `reserve`
  - `replace` for required values
  - sparse constant-default replacement
  - skipped entity ID panic invariants
- Added `QueryInternal` tests for:
  - empty tuple queries
  - entity-as-empty-query behavior
  - singleton query result iterator indexed/unindexed paths
  - tuple query result iterator indexed/unindexed paths
  - singleton and tuple `filter_entities` paths

## Notes

- This is test-only coverage work.
- No production behavior was changed.