### PR TITLE
chore: Ks 935 fix println

### DIFF
--- a/src/data_plugin.rs
+++ b/src/data_plugin.rs
@@ -110,7 +110,6 @@ mod tests {
         }
 
         let context = Context::new();
-        let container = context.get_data(MyDataPlugin);
     }
 
     // We attempt a collision with a plugin
@@ -143,7 +142,7 @@ mod tests {
         let _ = context.get_data(LegitDataPlugin);
 
         // Panics here:
-        let container = context.get_data(MyOtherDataPlugin);
+        // let container = context.get_data(MyOtherDataPlugin);
         // Some arbitrary code involving `container`
     }
 

--- a/src/data_plugin.rs
+++ b/src/data_plugin.rs
@@ -142,7 +142,7 @@ mod tests {
         let _ = context.get_data(LegitDataPlugin);
 
         // Panics here:
-        // let container = context.get_data(MyOtherDataPlugin);
+        let container = context.get_data(MyOtherDataPlugin);
         // Some arbitrary code involving `container`
     }
 

--- a/src/data_plugin.rs
+++ b/src/data_plugin.rs
@@ -111,7 +111,6 @@ mod tests {
 
         let context = Context::new();
         let container = context.get_data(MyDataPlugin);
-        // println!("{}", container.len());
     }
 
     // We attempt a collision with a plugin
@@ -146,7 +145,6 @@ mod tests {
         // Panics here:
         let container = context.get_data(MyOtherDataPlugin);
         // Some arbitrary code involving `container`
-        // println!("{}", container.len());
     }
 
     // Test thread safety of `initialize_data_plugin_index`.

--- a/src/data_plugin.rs
+++ b/src/data_plugin.rs
@@ -111,7 +111,7 @@ mod tests {
 
         let context = Context::new();
         let container = context.get_data(MyDataPlugin);
-        println!("{}", container.len());
+        // println!("{}", container.len());
     }
 
     // We attempt a collision with a plugin
@@ -146,7 +146,7 @@ mod tests {
         // Panics here:
         let container = context.get_data(MyOtherDataPlugin);
         // Some arbitrary code involving `container`
-        println!("{}", container.len());
+        // println!("{}", container.len());
     }
 
     // Test thread safety of `initialize_data_plugin_index`.

--- a/src/data_plugin.rs
+++ b/src/data_plugin.rs
@@ -110,6 +110,7 @@ mod tests {
         }
 
         let context = Context::new();
+        let container = context.get_data(MyDataPlugin);
     }
 
     // We attempt a collision with a plugin

--- a/src/data_plugin.rs
+++ b/src/data_plugin.rs
@@ -110,7 +110,7 @@ mod tests {
         }
 
         let context = Context::new();
-        let container = context.get_data(MyDataPlugin);
+        let _container = context.get_data(MyDataPlugin);
     }
 
     // We attempt a collision with a plugin
@@ -143,7 +143,7 @@ mod tests {
         let _ = context.get_data(LegitDataPlugin);
 
         // Panics here:
-        let container = context.get_data(MyOtherDataPlugin);
+        let _container = context.get_data(MyOtherDataPlugin);
         // Some arbitrary code involving `container`
     }
 

--- a/src/data_structures/value_vec.rs
+++ b/src/data_structures/value_vec.rs
@@ -342,7 +342,6 @@ mod tests {
     fn debug_impl() {
         let v = ValueVec::from(vec![1, 2, 3]);
         let s = format!("{v:?}");
-        // println!("{}", s);
         assert!(!s.contains("ValueVec"));
         assert!(s.contains("[1, 2, 3]"));
     }

--- a/src/data_structures/value_vec.rs
+++ b/src/data_structures/value_vec.rs
@@ -342,7 +342,7 @@ mod tests {
     fn debug_impl() {
         let v = ValueVec::from(vec![1, 2, 3]);
         let s = format!("{v:?}");
-        println!("{}", s);
+        // println!("{}", s);
         assert!(!s.contains("ValueVec"));
         assert!(s.contains("[1, 2, 3]"));
     }

--- a/src/entity/entity_set/entity_set_iterator.rs
+++ b/src/entity/entity_set/entity_set_iterator.rs
@@ -667,11 +667,11 @@ mod tests {
         }
 
         let results = context.query_result_iterator(Person).collect::<Vec<_>>();
-        for person in results {
-            let explicit_prop = context.get_property::<Person, ExplicitProp>(person);
-            let explicit_prop2 = context.get_property::<Person, ExplicitProp2>(person);
-            println!("({:?} {:?} {:?})", person, explicit_prop, explicit_prop2);
-        }
+        // for person in results {
+            // let explicit_prop = context.get_property::<Person, ExplicitProp>(person);
+            // let explicit_prop2 = context.get_property::<Person, ExplicitProp2>(person);
+            // println!("({:?} {:?} {:?})", person, explicit_prop, explicit_prop2);
+        // }
 
         // ExplicitProp2 has only 2 values, so it will be the smaller source
         let results = context

--- a/src/entity/entity_set/entity_set_iterator.rs
+++ b/src/entity/entity_set/entity_set_iterator.rs
@@ -666,13 +666,6 @@ mod tests {
                 .unwrap();
         }
 
-        // let results = context.query_result_iterator(Person).collect::<Vec<_>>();
-        // for person in results {
-            // let explicit_prop = context.get_property::<Person, ExplicitProp>(person);
-            // let explicit_prop2 = context.get_property::<Person, ExplicitProp2>(person);
-            // println!("({:?} {:?} {:?})", person, explicit_prop, explicit_prop2);
-        // }
-
         // ExplicitProp2 has only 2 values, so it will be the smaller source
         let results = context
             .query_result_iterator(with!(Person, ExplicitProp(5), ExplicitProp2(false)))

--- a/src/entity/entity_set/entity_set_iterator.rs
+++ b/src/entity/entity_set/entity_set_iterator.rs
@@ -666,7 +666,7 @@ mod tests {
                 .unwrap();
         }
 
-        let results = context.query_result_iterator(Person).collect::<Vec<_>>();
+        // let results = context.query_result_iterator(Person).collect::<Vec<_>>();
         // for person in results {
             // let explicit_prop = context.get_property::<Person, ExplicitProp>(person);
             // let explicit_prop2 = context.get_property::<Person, ExplicitProp2>(person);

--- a/src/entity/index/full_index.rs
+++ b/src/entity/index/full_index.rs
@@ -92,7 +92,6 @@ mod tests {
         assert_eq!(results_b.len(), 1);
 
         assert_eq!(results_a, results_b);
-        // println!("Results: {:?}", results_a);
 
         context
             .add_entity(with!(Person, Weight(1u8), Height(2u8), Age(3u8)))
@@ -114,6 +113,5 @@ mod tests {
 
         assert_eq!(results_a, results_b);
 
-        // println!("Results: {:?}", results_a);
     }
 }

--- a/src/entity/index/full_index.rs
+++ b/src/entity/index/full_index.rs
@@ -92,7 +92,7 @@ mod tests {
         assert_eq!(results_b.len(), 1);
 
         assert_eq!(results_a, results_b);
-        println!("Results: {:?}", results_a);
+        // println!("Results: {:?}", results_a);
 
         context
             .add_entity(with!(Person, Weight(1u8), Height(2u8), Age(3u8)))
@@ -114,6 +114,6 @@ mod tests {
 
         assert_eq!(results_a, results_b);
 
-        println!("Results: {:?}", results_a);
+        // println!("Results: {:?}", results_a);
     }
 }

--- a/src/entity/index/full_index.rs
+++ b/src/entity/index/full_index.rs
@@ -112,6 +112,5 @@ mod tests {
         assert_eq!(results_b.len(), 1);
 
         assert_eq!(results_a, results_b);
-
     }
 }

--- a/src/global_properties.rs
+++ b/src/global_properties.rs
@@ -430,7 +430,6 @@ mod test {
         let path = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
             .join("tests/data/global_properties_malformed.json");
         let error = context.load_global_properties(&path);
-        // println!("Error {error:?}");
         match error {
             Err(IxaError::JsonError(_)) => {}
             _ => panic!("Unexpected error type"),

--- a/src/global_properties.rs
+++ b/src/global_properties.rs
@@ -430,7 +430,7 @@ mod test {
         let path = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
             .join("tests/data/global_properties_malformed.json");
         let error = context.load_global_properties(&path);
-        println!("Error {error:?}");
+        // println!("Error {error:?}");
         match error {
             Err(IxaError::JsonError(_)) => {}
             _ => panic!("Unexpected error type"),

--- a/src/profiling/data.rs
+++ b/src/profiling/data.rs
@@ -333,10 +333,10 @@ mod tests {
         assert_eq!(*count, 2);
         // Rate should be approximately 2/elapsed (2 events / ~0.1 second = ~20/sec)
         let expected_rate = 2.0 / elapsed;
-        println!(
-            "Rate: {}, Expected: {}, Elapsed: {}",
-            rate, expected_rate, elapsed
-        );
+        // println!(
+        //     "Rate: {}, Expected: {}, Elapsed: {}",
+        //     rate, expected_rate, elapsed
+        // );
         // Allow 10% margin for timing variations
         assert!(*rate > expected_rate * 0.9 && *rate < expected_rate * 1.1);
 

--- a/src/profiling/data.rs
+++ b/src/profiling/data.rs
@@ -333,10 +333,7 @@ mod tests {
         assert_eq!(*count, 2);
         // Rate should be approximately 2/elapsed (2 events / ~0.1 second = ~20/sec)
         let expected_rate = 2.0 / elapsed;
-        // println!(
-        //     "Rate: {}, Expected: {}, Elapsed: {}",
-        //     rate, expected_rate, elapsed
-        // );
+
         // Allow 10% margin for timing variations
         assert!(*rate > expected_rate * 0.9 && *rate < expected_rate * 1.1);
 

--- a/src/random/sampling_algorithms.rs
+++ b/src/random/sampling_algorithms.rs
@@ -710,13 +710,13 @@ mod tests {
         // from the inverse chi-square CDF.
         let critical = 148.23;
 
-        println!(
-            "χ² = {}, expected = {}, min = {}, max = {}",
-            chi_square,
-            expected,
-            selection_counts.iter().min().unwrap(),
-            selection_counts.iter().max().unwrap()
-        );
+        // println!(
+        //     "χ² = {}, expected = {}, min = {}, max = {}",
+        //     chi_square,
+        //     expected,
+        //     selection_counts.iter().min().unwrap(),
+        //     selection_counts.iter().max().unwrap()
+        // );
 
         assert!(
             chi_square < critical,

--- a/src/random/sampling_algorithms.rs
+++ b/src/random/sampling_algorithms.rs
@@ -710,14 +710,6 @@ mod tests {
         // from the inverse chi-square CDF.
         let critical = 148.23;
 
-        // println!(
-        //     "χ² = {}, expected = {}, min = {}, max = {}",
-        //     chi_square,
-        //     expected,
-        //     selection_counts.iter().min().unwrap(),
-        //     selection_counts.iter().max().unwrap()
-        // );
-
         assert!(
             chi_square < critical,
             "Element selection probabilities are not uniform: χ² = {}",


### PR DESCRIPTION
Objective:
There are some debug println!s in a few tests, like src/data_plugin.rs, src/global_properties.rs, src/entity/index/full_index.rs, src/data_structures/value_vec.rs that can be cleaned up

rm the lines with println! (not turn them into asserts or other func)
run the tests to assure nothing broke. I may need some pointers here, but I will attempt/research on my own first.

Process:
First commented the println, then ran tests. Tests passed, then I removed the commented lines.
All tests passed that were already passing.
