### PR TITLE
fix: publish mdBook output to Pages artifact

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -34,6 +34,11 @@ jobs:
       - name: Build docs
         run: mise run docs
 
+      - name: Validate docs output
+        run: |
+          test -f website/book/index.html
+          test -f website/doc/ixa/index.html
+
       - name: Setup Pages
         id: pages
         uses: actions/configure-pages@v6

--- a/mise.toml
+++ b/mise.toml
@@ -62,9 +62,9 @@ run = '''
   mise run rust:version
   cargo run --features write_cli_usage --example basic-infection -- --markdown-help
   cargo doc --all-features --no-deps
-  rm -rf website/doc
+  rm -rf website/{book,doc}
   cp -r target/doc website
-  mdbook build docs/book -d ../../website/book
+  mdbook build docs/book -d website/book
 '''
 
 [tasks.test-all]


### PR DESCRIPTION
## Summary

- Fix the docs task so mdBook writes to `website/book`, which is the directory uploaded to GitHub Pages.
- Clean both generated docs directories before rebuilding.
- Add a Pages workflow validation step to fail early if the book or Rust API docs are missing from the artifact.


## Bug

The Ixa Book GitHub Pages deployment broke on **May 27, 2026**, in commit:

`863daa6 chore: update mdbook (0.5.3) versions (#922)`

Before that commit, the docs workflow used `mdbook 0.4.52`, and the existing output path:

`../../website/book`

successfully produced `./website/book` in the Pages artifact.

After upgrading to `mdbook 0.5.3`, the same path resolved outside the repository checkout:

`/home/runner/work/ixa/ixa/../../website/book`

As a result, the Pages upload step still uploaded `./website`, but the generated book was no longer inside that directory.

## Evidence

Last known good deployment:

- Date: **May 27, 2026 14:21 UTC**
- Commit: `1da85ad`
- mdBook version: `0.4.52`
- Artifact included: `./book/index.html`
- Artifact size: `4,788,102` bytes

First broken deployment:

- Date: **May 27, 2026 19:55 UTC**
- Commit: `863daa6`
- mdBook version: `0.5.3`
- Artifact missing: `./book/...`
- Artifact size: `2,644,239` bytes

## Root Cause

The `mdbook 0.5.3` upgrade changed how the output path was resolved for this invocation. The existing relative path no longer landed under `./website/book`, so GitHub Pages deployed without the book.

