### PR TITLE
fix: resolve "moved" borrow in `schedule_relative!`

### DIFF
--- a/src/macros/schedule_relative.rs
+++ b/src/macros/schedule_relative.rs
@@ -22,11 +22,12 @@
 /// ```
 #[macro_export]
 macro_rules! schedule_relative {
-    ($context:expr, $delay:expr, $action:expr $(, $arg:expr)* $(,)?) => {{
-        let context = ($context);
-        let time = context.get_current_time() + $delay;
-        context.add_plan(time, move |context| {
-            ($action)(context $(, $arg)*)
-        })
-    }};
+    ($context:expr, $delay:expr, $action:expr $(, $arg:expr)* $(,)?) => {
+        {
+            let time = ($context).get_current_time() + $delay;
+            ($context).add_plan(time, move |context| {
+                ($action)(context $(, $arg)*)
+            })
+        }
+    };
 }


### PR DESCRIPTION
This PR reverts a change intended to prevent the `$context` expression from being evaluated twice in the expansion of the `schedule_relative!` macro. The original idea is, we could just assign the value of `$context` to a locally scoped variable. 

```rust
{
	// This block is a local scope for the `context` variable.
	let context = ($context);
    // The rest of the macro code...
}
```

The problem is, if the macro is invoked with a variable `context: &mut Context`, the reference is _moved_ out of `context`, invalidating any downstream usages of the `context` variable. We could do a reborrow instead:

```rust
{
	// This block is a local scope for the `context` variable.
	let context = &mut *($context);
    // The rest of the macro code...
}
```

This works when a `&mut Context` is passed to the macro but fails for a `mut Context`, which isn't acceptable. 

The simplest fix is to just let the `$context` evaluate twice. This is probably fine, because:

- we expect the macro to be invoked with just an identifier in most cases anyway;
- if being evaluated twice is actually a problem, it's trivial to fix in client code by just introducing a local variable.