### PR TITLE
chore: add must use

### DIFF
--- a/integration-tests/ixa-runner-tests/tests/macros.rs
+++ b/integration-tests/ixa-runner-tests/tests/macros.rs
@@ -315,7 +315,7 @@ mod tests {
         let e = ctx.get_edge::<Person, TestEdge>(p1, p2).unwrap();
         assert_eq!(e.weight, 1.0);
         // Now remove the edge and ensure it's gone
-        ctx.remove_edge::<Person, TestEdge>(p1, p2);
+        assert!(ctx.remove_edge::<Person, TestEdge>(p1, p2).is_some());
         assert!(ctx.get_edge::<Person, TestEdge>(p1, p2).is_none());
 
         // Data plugin access

--- a/ixa-bench/src/generate_population.rs
+++ b/ixa-bench/src/generate_population.rs
@@ -39,6 +39,7 @@ pub struct PopulationIterator {
 }
 
 impl PopulationIterator {
+    #[must_use]
     pub fn new(
         n: usize,
         number_of_schools_as_percent_of_pop: f64,
@@ -117,6 +118,7 @@ impl ExactSizeIterator for PopulationIterator {
 
 impl FusedIterator for PopulationIterator {}
 
+#[must_use]
 pub fn generate_population(
     n: usize,
     number_of_schools_as_percent_of_pop: f64,
@@ -131,6 +133,7 @@ pub fn generate_population(
 }
 
 /// Generate a population using an optional seed for determinism
+#[must_use]
 pub fn generate_population_with_seed(
     n: usize,
     number_of_schools_as_percent_of_pop: f64,

--- a/ixa-bench/src/reference_sir/sir_baseline.rs
+++ b/ixa-bench/src/reference_sir/sir_baseline.rs
@@ -29,6 +29,7 @@ pub struct Model {
 }
 
 impl Model {
+    #[must_use]
     pub fn new(parameters: Parameters) -> Model {
         let stats = ModelStats::new(parameters.initial_infections, parameters.population, 0.2);
         Model {
@@ -128,6 +129,7 @@ impl Model {
         members[idx]
     }
 
+    #[must_use]
     pub fn get_stats(&self) -> &ModelStats {
         &self.stats
     }

--- a/ixa-bench/src/reference_sir/sir_ixa.rs
+++ b/ixa-bench/src/reference_sir/sir_ixa.rs
@@ -262,12 +262,14 @@ pub struct Model {
 }
 
 impl Model {
+    #[must_use]
     pub fn new(params: Parameters, options: ModelOptions) -> Self {
         let mut ctx = Context::new();
         ctx.set_global_property_value(Params, params).unwrap();
         ctx.set_global_property_value(Options, options).unwrap();
         Self { ctx }
     }
+    #[must_use]
     pub fn get_stats(&self) -> &ModelStats {
         self.ctx.get_stats()
     }

--- a/ixa-bench/src/reference_sir/stats.rs
+++ b/ixa-bench/src/reference_sir/stats.rs
@@ -15,6 +15,7 @@ pub struct Row {
 }
 
 impl ModelStats {
+    #[must_use]
     pub fn new(
         initial_infections: usize,
         population_size: usize,
@@ -44,12 +45,15 @@ impl ModelStats {
             .and_modify(|e| *e += 1)
             .or_insert(self.cum_incidence);
     }
+    #[must_use]
     pub fn get_cum_incidence(&self) -> usize {
         self.cum_incidence
     }
+    #[must_use]
     pub fn get_current_infected(&self) -> usize {
         self.current_infected
     }
+    #[must_use]
     pub fn get_timeseries(&self) -> Vec<Row> {
         self.cum_incidence_timeseries
             .iter()

--- a/src/context.rs
+++ b/src/context.rs
@@ -462,6 +462,7 @@ impl Context {
         }
     }
 
+    #[must_use]
     pub fn get_execution_statistics(&mut self) -> ExecutionStatistics {
         #[allow(unused_mut)]
         let mut stats = self.execution_profiler.compute_final_statistics();
@@ -492,9 +493,13 @@ pub trait ContextBase: Sized {
     );
     fn cancel_plan(&mut self, plan_id: &PlanId);
     fn queue_callback(&mut self, callback: impl FnOnce(&mut Context) + 'static);
+    #[must_use]
     fn get_data_mut<T: DataPlugin>(&mut self, plugin: T) -> &mut T::DataContainer;
+    #[must_use]
     fn get_data<T: DataPlugin>(&self, plugin: T) -> &T::DataContainer;
+    #[must_use]
     fn get_current_time(&self) -> f64;
+    #[must_use]
     fn get_execution_statistics(&mut self) -> ExecutionStatistics;
 }
 impl ContextBase for Context {

--- a/src/data_plugin.rs
+++ b/src/data_plugin.rs
@@ -17,6 +17,7 @@ pub fn add_data_plugin_to_registry<T: DataPlugin>() {
         .insert(TypeId::of::<T>());
 }
 
+#[must_use]
 pub fn get_data_plugin_ids() -> Vec<TypeId> {
     DATA_PLUGINS
         .lock()
@@ -27,6 +28,7 @@ pub fn get_data_plugin_ids() -> Vec<TypeId> {
         .collect()
 }
 
+#[must_use]
 pub fn get_data_plugin_count() -> usize {
     DATA_PLUGINS.lock().unwrap().borrow().len()
 }
@@ -42,6 +44,7 @@ static NEXT_DATA_PLUGIN_INDEX: Mutex<usize> = Mutex::new(0);
 
 /// Acquires a global lock on the next available plugin index, but only increments it if we
 /// successfully initialize the provided index. (Must be `pub`, as it's called from within a macro.)
+#[must_use]
 pub fn initialize_data_plugin_index(plugin_index: &AtomicUsize) -> usize {
     // Acquire a global lock.
     let mut guard = NEXT_DATA_PLUGIN_INDEX.lock().unwrap();
@@ -76,6 +79,7 @@ pub trait DataPlugin: Any {
 
     /// Returns the index into `Context::data_plugins`, the vector of data plugins, where
     /// the instance of this data plugin can be found.
+    #[must_use]
     fn index_within_context() -> usize;
 }
 

--- a/src/data_structures/entity_map.rs
+++ b/src/data_structures/entity_map.rs
@@ -75,6 +75,7 @@ pub struct EntityMap<E: Entity, V> {
 
 impl<E: Entity, V> EntityMap<E, V> {
     /// Creates an empty `EntityMap`.
+    #[must_use]
     pub fn new() -> Self {
         Self {
             data: Vec::new(),
@@ -84,6 +85,7 @@ impl<E: Entity, V> EntityMap<E, V> {
     }
 
     /// Creates an empty `EntityMap` with space for at least `capacity` values.
+    #[must_use]
     pub fn with_capacity(capacity: usize) -> Self {
         Self {
             data: Vec::with_capacity(capacity),
@@ -93,24 +95,28 @@ impl<E: Entity, V> EntityMap<E, V> {
     }
 
     /// Cheap conversion to an `EntityVec<E, Option<V>>`
+    #[must_use]
     pub fn into_entity_vec(self) -> EntityVec<E, Option<V>> {
         self.data.into()
     }
 
     /// Returns the number of stored key-value pairs.
     #[inline]
+    #[must_use]
     pub fn len(&self) -> usize {
         self.len
     }
 
     /// Returns the capacity of the backing storage.
     #[inline]
+    #[must_use]
     pub fn capacity(&self) -> usize {
         self.data.capacity()
     }
 
     /// Returns `true` if the map contains no values.
     #[inline]
+    #[must_use]
     pub fn is_empty(&self) -> bool {
         self.len == 0
     }
@@ -129,16 +135,19 @@ impl<E: Entity, V> EntityMap<E, V> {
     }
 
     /// Returns `true` if `entity_id` is present in the map.
+    #[must_use]
     pub fn contains_key(&self, entity_id: EntityId<E>) -> bool {
         self.get(entity_id).is_some()
     }
 
     /// Returns the value for `entity_id`, or `None` if not present.
+    #[must_use]
     pub fn get(&self, entity_id: EntityId<E>) -> Option<&V> {
         self.data.get(entity_id.0).and_then(Option::as_ref)
     }
 
     /// Returns the value for `entity_id` mutably, or `None` if not present.
+    #[must_use]
     pub fn get_mut(&mut self, entity_id: EntityId<E>) -> Option<&mut V> {
         self.data.get_mut(entity_id.0).and_then(Option::as_mut)
     }
@@ -181,6 +190,7 @@ impl<E: Entity, V> EntityMap<E, V> {
     }
 
     /// Removes and returns the value for `entity_id`, if present.
+    #[must_use]
     pub fn remove(&mut self, entity_id: EntityId<E>) -> Option<V> {
         let removed = self.data.get_mut(entity_id.0).and_then(Option::take);
         if removed.is_some() {
@@ -196,6 +206,7 @@ impl<E: Entity, V> EntityMap<E, V> {
     }
 
     /// Returns an iterator over `(EntityId<E>, &V)` pairs.
+    #[must_use]
     pub fn iter(&self) -> Iter<'_, E, V> {
         Iter {
             inner: self.data.iter().enumerate(),

--- a/src/data_structures/entity_vec.rs
+++ b/src/data_structures/entity_vec.rs
@@ -62,6 +62,7 @@ pub struct EntityVec<E: Entity, V> {
 
 impl<E: Entity, V> EntityVec<E, V> {
     /// Creates an empty `EntityVec`.
+    #[must_use]
     pub fn new() -> Self {
         Self {
             data: Vec::new(),
@@ -70,6 +71,7 @@ impl<E: Entity, V> EntityVec<E, V> {
     }
 
     /// Creates an empty `EntityVec` with space for at least `capacity` items.
+    #[must_use]
     pub fn with_capacity(capacity: usize) -> Self {
         Self {
             data: Vec::with_capacity(capacity),
@@ -79,18 +81,21 @@ impl<E: Entity, V> EntityVec<E, V> {
 
     /// Returns the number of values stored.
     #[inline]
+    #[must_use]
     pub fn len(&self) -> usize {
         self.data.len()
     }
 
     /// Returns the capacity of the backing vector.
     #[inline]
+    #[must_use]
     pub fn capacity(&self) -> usize {
         self.data.capacity()
     }
 
     /// Returns `true` if no values are stored.
     #[inline]
+    #[must_use]
     pub fn is_empty(&self) -> bool {
         self.data.is_empty()
     }
@@ -111,36 +116,43 @@ impl<E: Entity, V> EntityVec<E, V> {
     }
 
     /// Removes and returns the last value, or `None` if empty.
+    #[must_use]
     pub fn pop(&mut self) -> Option<V> {
         self.data.pop()
     }
 
     /// Returns the value for `entity_id`, or `None` if this vector is not long enough.
+    #[must_use]
     pub fn get(&self, entity_id: EntityId<E>) -> Option<&V> {
         self.data.get(entity_id.0)
     }
 
     /// Returns the mutable value for `entity_id`, or `None` if this vector is not long enough.
+    #[must_use]
     pub fn get_mut(&mut self, entity_id: EntityId<E>) -> Option<&mut V> {
         self.data.get_mut(entity_id.0)
     }
 
     /// Returns the last value, or `None` if empty.
+    #[must_use]
     pub fn last(&self) -> Option<&V> {
         self.data.last()
     }
 
     /// Returns the last value mutably, or `None` if empty.
+    #[must_use]
     pub fn last_mut(&mut self) -> Option<&mut V> {
         self.data.last_mut()
     }
 
     /// Returns the backing slice.
+    #[must_use]
     pub fn as_slice(&self) -> &[V] {
         &self.data
     }
 
     /// Returns the backing slice mutably.
+    #[must_use]
     pub fn as_mut_slice(&mut self) -> &mut [V] {
         &mut self.data
     }
@@ -190,6 +202,7 @@ impl<E: Entity, V> EntityVec<E, V> {
     }
 
     /// Returns `true` if the vector contains `value`.
+    #[must_use]
     pub fn contains(&self, value: &V) -> bool
     where
         V: PartialEq,
@@ -198,6 +211,7 @@ impl<E: Entity, V> EntityVec<E, V> {
     }
 
     /// Consumes the `EntityVec` and returns the backing `Vec`.
+    #[must_use]
     pub fn into_vec(self) -> Vec<V> {
         self.data
     }

--- a/src/data_structures/value_vec.rs
+++ b/src/data_structures/value_vec.rs
@@ -40,6 +40,7 @@ pub struct ValueVec<V: Copy> {
 
 impl<V: Copy> ValueVec<V> {
     /// Creates an empty `ValueVec`.
+    #[must_use]
     pub fn new() -> Self {
         Self {
             data: UnsafeCell::new(Vec::new()),
@@ -47,6 +48,7 @@ impl<V: Copy> ValueVec<V> {
     }
 
     /// Creates with capacity.
+    #[must_use]
     pub fn with_capacity(cap: usize) -> Self {
         Self {
             data: UnsafeCell::new(Vec::with_capacity(cap)),
@@ -55,6 +57,7 @@ impl<V: Copy> ValueVec<V> {
 
     /// Current number of elements.
     #[inline]
+    #[must_use]
     pub fn len(&self) -> usize {
         // Safety: This is already an immutable operation
         unsafe { (&*self.data.get()).len() }
@@ -62,6 +65,7 @@ impl<V: Copy> ValueVec<V> {
 
     /// Current capacity of the backing Vec.
     #[inline]
+    #[must_use]
     pub fn capacity(&self) -> usize {
         // Safety: This is already an immutable operation
         unsafe { (&*self.data.get()).capacity() }
@@ -69,6 +73,7 @@ impl<V: Copy> ValueVec<V> {
 
     /// Returns true if the vector has no elements.
     #[inline]
+    #[must_use]
     pub fn is_empty(&self) -> bool {
         self.len() == 0
     }
@@ -89,12 +94,14 @@ impl<V: Copy> ValueVec<V> {
     }
 
     /// Pops and **returns** the last element (by move), or `None` if empty.
+    #[must_use]
     pub fn pop(&self) -> Option<V> {
         self.with_vec(|v| v.pop())
     }
 
     /// Returns the value of the element at `index`, if `index` is in range. Returns `None` if `index` is out of bounds.
     /// This is a bounds-checked variant of [`ValueVec::at`].
+    #[must_use]
     pub fn get(&self, index: usize) -> Option<V> {
         unsafe { (&*self.data.get()).get(index).copied() }
     }
@@ -102,11 +109,13 @@ impl<V: Copy> ValueVec<V> {
     /// Returns the value at `index`. Panics if `index` is out of bounds.
     ///
     /// Use [`ValueVec::get`] for a bounds-checked version of this method.
+    #[must_use]
     pub fn at(&self, index: usize) -> V {
         unsafe { (&*self.data.get())[index] }
     }
 
     /// Moves a value into the slot at `index`, returning the old value (via move). Panics if `index` is out of bounds.
+    #[must_use]
     pub fn replace(&self, index: usize, value: V) -> V {
         self.with_vec(|v| core::mem::replace(&mut v[index], value))
     }
@@ -133,6 +142,7 @@ impl<V: Copy> ValueVec<V> {
     }
 
     /// Removes and returns the element at `index`, shifting elements left. Panics if `index` is out of bounds.
+    #[must_use]
     pub fn remove(&self, index: usize) -> V {
         self.with_vec(|v| v.remove(index))
     }
@@ -140,11 +150,13 @@ impl<V: Copy> ValueVec<V> {
     /// Removes and returns the element at `index` by swapping in the last element.
     ///
     /// O(1) removal when order does not matter.
+    #[must_use]
     pub fn swap_remove(&self, index: usize) -> V {
         self.with_vec(|v| v.swap_remove(index))
     }
 
     /// Returns `true` if the `ValueVec` contains an element with the given value.
+    #[must_use]
     pub fn contains(&self, value: &V) -> bool
     where
         V: PartialEq,
@@ -179,6 +191,7 @@ impl<V: Copy> ValueVec<V> {
     /// Returns a **snapshot** `Vec<V>` by cloning all elements.
     ///
     /// Use `From<ValueVec<V>> for Vec<V>` for a zero-cost conversion if you don't want to clone.
+    #[must_use]
     pub fn to_vec(&self) -> Vec<V>
     where
         V: Clone,

--- a/src/entity/context_extension.rs
+++ b/src/entity/context_extension.rs
@@ -106,6 +106,7 @@ pub trait ContextEntitiesExt {
     /// ```rust, ignore
     /// let vaccine_status: VaccineStatus = context.get_property(entity_id);
     /// ```
+    #[must_use]
     fn get_property<E: Entity, P: Property<E>>(&self, entity_id: EntityId<E>) -> P;
 
     /// Sets the value of the given property. This method unconditionally emits a `PropertyChangeEvent`.
@@ -161,6 +162,7 @@ pub trait ContextEntitiesExt {
     /// This method only checks the concrete property storage for `P`, not any equivalent
     /// multi-properties.
     #[cfg(test)]
+    #[must_use]
     fn is_property_indexed<E: Entity, P: Property<E>>(&self) -> bool;
 
     /// This method gives client code direct access to the query result as an `EntitySet`.
@@ -176,12 +178,14 @@ pub trait ContextEntitiesExt {
     /// efficient for indexed queries.
     ///
     /// Supplying a naked entity, e.g. `Person`, is equivalent to calling `get_entity_count::<Person>()`.
+    #[must_use]
     fn query_entity_count<E: Entity, Q: Query<E>>(&self, query: Q) -> usize;
 
     /// Sample a single entity uniformly from the query results. Returns `None` if the
     /// query's result set is empty.
     ///
     /// To sample from the entire population, pass the entity type directly, for example `Person`.
+    #[must_use]
     fn sample_entity<E, Q, R>(&self, rng_id: R, query: Q) -> Option<EntityId<E>>
     where
         E: Entity,
@@ -193,6 +197,7 @@ pub trait ContextEntitiesExt {
     ///
     /// Returns `(count, sample)`, where `sample` is `None` iff `count == 0`.
     /// To sample from the entire population, pass the entity type directly, for example `Person`.
+    #[must_use]
     fn count_and_sample_entity<E, Q, R>(&self, rng_id: R, query: Q) -> (usize, Option<EntityId<E>>)
     where
         E: Entity,
@@ -205,6 +210,7 @@ pub trait ContextEntitiesExt {
     /// set is returned.
     ///
     /// To sample from the entire population, pass the entity type directly, for example `Person`.
+    #[must_use]
     fn sample_entities<E, Q, R>(&self, rng_id: R, query: Q, n: usize) -> Vec<EntityId<E>>
     where
         E: Entity,
@@ -213,18 +219,23 @@ pub trait ContextEntitiesExt {
         R::RngType: Rng;
 
     /// Returns a total count of all created entities of type `E`.
+    #[must_use]
     fn get_entity_count<E: Entity>(&self) -> usize;
 
     /// Returns an iterator over all created entities of type `E`.
+    #[must_use]
     fn get_entity_iterator<E: Entity>(&self) -> PopulationIterator<E>;
 
     /// Generates an `EntitySet` representing the query results.
+    #[must_use]
     fn query<E: Entity, Q: Query<E>>(&self, query: Q) -> EntitySet<E>;
 
     /// Generates an iterator over the results of the query.
+    #[must_use]
     fn query_result_iterator<E: Entity, Q: Query<E>>(&self, query: Q) -> EntitySetIterator<E>;
 
     /// Determines if the given person matches this query.
+    #[must_use]
     fn match_entity<E: Entity, Q: Query<E>>(&self, entity_id: EntityId<E>, query: Q) -> bool;
 
     /// Removes all `EntityId`s from the given vector that do not match the given query.

--- a/src/entity/entity.rs
+++ b/src/entity/entity.rs
@@ -84,22 +84,26 @@ impl<E: Entity> EntityId<E> {
 
 /// All entities must implement this trait using the `define_entity!` macro.
 pub trait Entity: Any + Default {
+    #[must_use]
     fn name() -> &'static str {
         let full = std::any::type_name::<Self>();
         full.rsplit("::").next().unwrap()
     }
 
+    #[must_use]
     fn type_id() -> TypeId {
         TypeId::of::<Self>()
     }
 
     /// Get a list of all properties this `Entity` has. This list is static, computed in with `ctor` magic.
+    #[must_use]
     fn property_ids() -> &'static [TypeId] {
         let (property_ids, _) = get_entity_metadata_static(<Self as Entity>::type_id());
         property_ids
     }
 
     /// Get a list of all properties of this `Entity` that _must_ be supplied when a new entity is created.
+    #[must_use]
     fn required_property_ids() -> &'static [TypeId] {
         let (_, required_property_ids) = get_entity_metadata_static(<Self as Entity>::type_id());
         required_property_ids
@@ -108,9 +112,11 @@ pub trait Entity: Any + Default {
     /// The index of this item in the owner, which is initialized globally per type
     /// upon first access. We explicitly initialize this in a `ctor` in order to know
     /// how many [`Entity`] types exist globally when we construct any `EntityStore`.
+    #[must_use]
     fn id() -> usize;
 
     /// Creates a new boxed instance of the item.
+    #[must_use]
     fn new_boxed() -> Box<Self> {
         Box::default()
     }

--- a/src/entity/entity_set/entity_set.rs
+++ b/src/entity/entity_set/entity_set.rs
@@ -74,6 +74,7 @@ impl<'a, E: Entity> EntitySet<'a, E> {
     }
 
     /// Create an empty entity set.
+    #[must_use]
     pub fn empty() -> Self {
         EntitySet(EntitySetInner::Source(SourceSet::empty()))
     }
@@ -99,6 +100,7 @@ impl<'a, E: Entity> EntitySet<'a, E> {
         EntitySet(EntitySetInner::Intersection(sets))
     }
 
+    #[must_use]
     pub fn union(self, other: Self) -> Self {
         // Idempotence: A ∪ A = A  (same structure over same sources)
         if self.structurally_eq(&other) {
@@ -130,6 +132,7 @@ impl<'a, E: Entity> EntitySet<'a, E> {
         EntitySet(EntitySetInner::Union(Box::new(left), Box::new(right)))
     }
 
+    #[must_use]
     pub fn intersection(self, other: Self) -> Self {
         // Idempotence: A ∩ A = A
         if self.structurally_eq(&other) {
@@ -165,6 +168,7 @@ impl<'a, E: Entity> EntitySet<'a, E> {
         EntitySet(EntitySetInner::Intersection(sets))
     }
 
+    #[must_use]
     pub fn difference(self, other: Self) -> Self {
         // Self-subtraction: A \ A = ∅
         if self.structurally_eq(&other) {
@@ -201,6 +205,7 @@ impl<'a, E: Entity> EntitySet<'a, E> {
     }
 
     /// Test whether `entity_id` is a member of this set.
+    #[must_use]
     pub fn contains(&self, entity_id: EntityId<E>) -> bool {
         match self {
             EntitySet(EntitySetInner::Source(source)) => source.contains(entity_id),
@@ -217,6 +222,7 @@ impl<'a, E: Entity> EntitySet<'a, E> {
     }
 
     /// Collect this set's contents into an owned vector of `EntityId<E>`.
+    #[must_use]
     pub fn to_owned_vec(self) -> Vec<EntityId<E>> {
         self.into_iter().collect()
     }
@@ -229,6 +235,7 @@ impl<'a, E: Entity> EntitySet<'a, E> {
     /// `IndexSet`), runs in O(1) with at most two index lookups and no
     /// iterator construction. Falls back to O(n) reservoir sampling for
     /// composite sets and `PropertySet` sources.
+    #[must_use]
     pub fn sample_entity_excluding<R, X>(&self, rng: &mut R, excluded: X) -> Option<EntityId<E>>
     where
         R: Rng,
@@ -259,6 +266,7 @@ impl<'a, E: Entity> EntitySet<'a, E> {
 
     /// Sample a single entity uniformly from this set. Returns `None` if the
     /// set is empty.
+    #[must_use]
     pub fn sample_entity<R>(&self, rng: &mut R) -> Option<EntityId<E>>
     where
         R: Rng,
@@ -278,6 +286,7 @@ impl<'a, E: Entity> EntitySet<'a, E> {
     /// Count the entities in this set and sample one uniformly from them.
     ///
     /// Returns `(count, sample)` where `sample` is `None` iff `count == 0`.
+    #[must_use]
     pub fn count_and_sample_entity<R>(&self, rng: &mut R) -> (usize, Option<EntityId<E>>)
     where
         R: Rng,
@@ -294,6 +303,7 @@ impl<'a, E: Entity> EntitySet<'a, E> {
 
     /// Sample up to `requested` entities uniformly from this set. If the set
     /// has fewer than `requested` entities, the entire set is returned.
+    #[must_use]
     pub fn sample_entities<R>(&self, rng: &mut R, requested: usize) -> Vec<EntityId<E>>
     where
         R: Rng,
@@ -312,6 +322,7 @@ impl<'a, E: Entity> EntitySet<'a, E> {
     ///
     /// This is true only for direct `SourceSet` leaves except `PropertySet`.
     /// Composite expressions return `None`.
+    #[must_use]
     pub fn try_len(&self) -> Option<usize> {
         match self {
             EntitySet(EntitySetInner::Source(source)) => source.try_len(),

--- a/src/entity/entity_store.rs
+++ b/src/entity/entity_store.rs
@@ -188,6 +188,7 @@ impl EntityStore {
     /// This is one of the pitfalls of this pattern: there is no guarantee that types
     /// implementing `Entity` followed the rules. We can have at least some confidence,
     /// though, in their correctness by supplying a correct implementation via a macro.
+    #[must_use]
     pub fn new() -> Self {
         let num_items = get_registered_entity_count();
         Self {
@@ -260,11 +261,13 @@ impl EntityStore {
     }
 
     /// Returns an iterator over all valid `EntityId<E>`s
+    #[must_use]
     pub fn get_entity_iterator<E: Entity>(&self) -> PopulationIterator<E> {
         let count = self.get_entity_count::<E>();
         PopulationIterator::new(count)
     }
 
+    #[must_use]
     pub fn get_property_store<E: Entity>(&self) -> &PropertyStore<E> {
         let index = E::id();
         let record = self.items

--- a/src/entity/events.rs
+++ b/src/entity/events.rs
@@ -136,6 +136,7 @@ pub struct EntityCreatedEvent<E: Entity> {
 }
 
 impl<E: Entity> EntityCreatedEvent<E> {
+    #[must_use]
     pub fn new(entity_id: EntityId<E>) -> Self {
         Self { entity_id }
     }

--- a/src/entity/index/full_index.rs
+++ b/src/entity/index/full_index.rs
@@ -45,6 +45,7 @@ impl<E: Entity, P: IndexableProperty<E>> FullIndex<E, P> {
         }
     }
 
+    #[must_use]
     pub fn get(&self, key: &P) -> Option<&IndexSet<EntityId<E>>> {
         self.data.get(key)
     }

--- a/src/entity/index/mod.rs
+++ b/src/entity/index/mod.rs
@@ -36,16 +36,20 @@ pub enum PropertyIndexType {
 }
 
 pub trait PropertyIndex<E: Entity, P: Property<E>> {
+    #[must_use]
     fn index_type(&self) -> PropertyIndexType;
 
+    #[must_use]
     fn get_index_set_result(&self, value: &P) -> IndexSetResult<'_, E>;
 
+    #[must_use]
     fn get_index_count_result(&self, value: &P) -> IndexCountResult;
 
     fn remove_entity(&mut self, value: &P, entity_id: EntityId<E>);
 
     fn add_entity(&mut self, value: &P, entity_id: EntityId<E>);
 
+    #[must_use]
     fn max_indexed(&self) -> usize;
 
     fn set_max_indexed(&mut self, max_indexed: usize);

--- a/src/entity/index/value_count_index.rs
+++ b/src/entity/index/value_count_index.rs
@@ -49,6 +49,7 @@ impl<E: Entity, P: IndexableProperty<E>> ValueCountIndex<E, P> {
         }
     }
 
+    #[must_use]
     pub fn get(&self, key: &P) -> Option<usize> {
         self.data.get(key).copied()
     }

--- a/src/entity/multi_property.rs
+++ b/src/entity/multi_property.rs
@@ -69,6 +69,7 @@ static PRE_MAIN_DIAGNOSTICS: LazyLock<Mutex<Vec<PreMainDiagnostic>>> =
     LazyLock::new(|| Mutex::new(Vec::new()));
 
 /// Looks up the representative multi-property ID for a sorted list of component `TypeId`s.
+#[must_use]
 pub fn type_ids_to_multi_property_id(entity_id: usize, type_ids: &[TypeId]) -> Option<usize> {
     let hash = one_shot_128(&type_ids);
     MULTI_PROPERTY_ID_MAP
@@ -163,6 +164,7 @@ const fn make_indices<const N: usize>() -> [usize; N] {
 ///
 /// "Static" in the name refers to the fact that it takes and returns an array of statically
 /// known size, avoiding `Vec` allocations.
+#[must_use]
 pub fn static_sorted_indices<T: Ord, const N: usize>(keys: &[T; N]) -> [usize; N] {
     let mut indices = make_indices::<N>();
     indices.sort_unstable_by_key(|&i| &keys[i]);
@@ -186,6 +188,7 @@ pub fn static_apply_reordering<T: Copy, const N: usize>(values: &mut [T; N], ind
 ///
 /// If `indices[sorted_position] == original_position`, the returned array maps
 /// `original_position` back to `sorted_position`.
+#[must_use]
 pub fn static_inverse_indices<const N: usize>(indices: &[usize; N]) -> [usize; N] {
     let mut inverse = [0; N];
     for (sorted_position, &original_position) in indices.iter().enumerate() {

--- a/src/entity/property.rs
+++ b/src/entity/property.rs
@@ -65,6 +65,7 @@ pub trait Property<E: Entity>: Copy + Debug + PartialEq + 'static {
     /// Source-level name, set by the macros to `stringify!($property)`.
     const NAME: &'static str;
 
+    #[must_use]
     fn name() -> &'static str {
         Self::NAME
     }
@@ -125,6 +126,7 @@ pub trait Property<E: Entity>: Copy + Debug + PartialEq + 'static {
     }
 
     /// For implementing the registry pattern
+    #[must_use]
     fn id() -> usize;
 
     /// Returns a vector of transitive non-derived dependencies. If the property is not derived, the
@@ -133,6 +135,7 @@ pub trait Property<E: Entity>: Copy + Debug + PartialEq + 'static {
     /// This function is only used to construct the static dependency graph
     /// within property `ctor`s, after which time the dependents of a property
     /// are accessible through `Property<E>::dependents()` as a `&'static [usize]`.
+    #[must_use]
     fn non_derived_dependencies() -> Vec<usize> {
         let mut result = HashSet::default();
         Self::collect_non_derived_dependencies(&mut result);
@@ -144,6 +147,7 @@ pub trait Property<E: Entity>: Copy + Debug + PartialEq + 'static {
 
     /// Get a list of derived properties that depend on this property. The properties are
     /// represented by their `Property::id()`. The list is pre-computed in `ctor`s.
+    #[must_use]
     fn dependents() -> &'static [usize] {
         get_property_dependents_static::<E>(Self::id())
     }

--- a/src/entity/property_list.rs
+++ b/src/entity/property_list.rs
@@ -34,9 +34,11 @@ pub trait PropertyList<E: Entity>: Copy + 'static {
     fn validate() -> Result<(), IxaError>;
 
     /// Checks that this property list includes all properties in the given list.
+    #[must_use]
     fn contains_properties(property_type_ids: &[TypeId]) -> bool;
 
     /// Checks that this property list contains all required properties of the entity.
+    #[must_use]
     fn contains_required_properties() -> bool {
         Self::contains_properties(E::required_property_ids())
     }
@@ -50,6 +52,7 @@ pub trait PropertyList<E: Entity>: Copy + 'static {
     );
 
     /// Gets the tuple of property values for the given entity.
+    #[must_use]
     fn get_values_for_entity(context: &Context, entity_id: EntityId<E>) -> Self;
 }
 

--- a/src/entity/property_store.rs
+++ b/src/entity/property_store.rs
@@ -220,6 +220,7 @@ impl<E: Entity> Default for PropertyStore<E> {
 
 impl<E: Entity> PropertyStore<E> {
     /// Creates a new [`PropertyStore`].
+    #[must_use]
     pub fn new() -> Self {
         let num_items = get_registered_property_count::<E>();
         // The constructors for each `PropertyValueStoreCore<E, P>` are stored in the `PROPERTY_METADATA` global.
@@ -310,6 +311,7 @@ impl<E: Entity> PropertyStore<E> {
 
     /// Creates a `PartialPropertyChangeEvent` instance for the `entity_id` and `property_index`. This method is only
     /// called for derived dependents of some property that has changed (one of `P`'s non-derived dependencies).
+    #[must_use]
     pub(crate) fn create_partial_property_change(
         &self,
         property_index: usize,
@@ -324,6 +326,7 @@ impl<E: Entity> PropertyStore<E> {
     }
 
     /// Returns whether the property with `property_index` needs partial change-event processing.
+    #[must_use]
     pub(crate) fn should_create_partial_property_change(
         &self,
         property_index: usize,
@@ -339,6 +342,7 @@ impl<E: Entity> PropertyStore<E> {
     /// Returns whether or not the property `P` is indexed.
     ///
     #[cfg(test)]
+    #[must_use]
     pub fn is_property_indexed<P: Property<E>>(&self) -> bool {
         self.items
             .get(P::id())
@@ -398,6 +402,7 @@ impl<E: Entity> PropertyStore<E> {
     /// Creates a stratified value change counter for tracked property `P` with strata `PL`.
     ///
     /// Returns the counter ID.
+    #[must_use]
     pub fn create_value_change_counter<PL, P>(&mut self) -> usize
     where
         PL: PropertyList<E> + Eq + std::hash::Hash,
@@ -428,6 +433,7 @@ impl<E: Entity> PropertyStore<E> {
         }
     }
 
+    #[must_use]
     pub fn get_index_set_for_query_parts(
         &self,
         property_id: usize,
@@ -436,6 +442,7 @@ impl<E: Entity> PropertyStore<E> {
         self.items[property_id].get_index_set_for_query_parts(query_parts)
     }
 
+    #[must_use]
     pub fn get_index_count_for_query_parts(
         &self,
         property_id: usize,

--- a/src/entity/property_value_store_core.rs
+++ b/src/entity/property_value_store_core.rs
@@ -47,6 +47,7 @@ impl<E: Entity, P: Property<E>> PropertyValueStoreCore<E, P> {
         Box::new(Self::new())
     }
 
+    #[must_use]
     pub fn with_capacity(capacity: usize) -> Self {
         Self {
             data: RawPropertyValueVec::with_capacity(capacity),
@@ -55,6 +56,7 @@ impl<E: Entity, P: Property<E>> PropertyValueStoreCore<E, P> {
         }
     }
 
+    #[must_use]
     pub(crate) fn index_type(&self) -> PropertyIndexType {
         self.index
             .as_deref()
@@ -62,6 +64,7 @@ impl<E: Entity, P: Property<E>> PropertyValueStoreCore<E, P> {
     }
 
     /// Adds a value change counter and returns its ID.
+    #[must_use]
     pub(crate) fn add_value_change_counter(
         &mut self,
         counter: Box<dyn ValueChangeCounter<E, P>>,
@@ -77,6 +80,7 @@ impl<E: Entity, P: Property<E>> PropertyValueStoreCore<E, P> {
     }
 
     /// Returns the property value for the given entity.
+    #[must_use]
     pub fn get(&self, entity_id: EntityId<E>) -> P {
         debug_assert!(
             !P::is_derived(),
@@ -134,6 +138,7 @@ impl<E: Entity, P: Property<E>> PropertyValueStoreCore<E, P> {
     }
 
     /// Sets the value for `entity_id` to `value`, returning the previous value.
+    #[must_use]
     pub fn replace(&mut self, entity_id: EntityId<E>, value: P) -> P {
         debug_assert!(
             !P::is_derived(),
@@ -241,6 +246,6 @@ mod tests {
     fn replace_required_property_skipping_entity_id_panics() {
         let mut store = PropertyValueStoreCore::<StoreCorePerson, RequiredScore>::new();
 
-        store.replace(EntityId::new(1), RequiredScore(10));
+        let _ = store.replace(EntityId::new(1), RequiredScore(10));
     }
 }

--- a/src/entity/query/mod.rs
+++ b/src/entity/query/mod.rs
@@ -143,10 +143,12 @@ pub trait QueryInternal<E: Entity>: 'static {
         Self: 'a;
 
     /// Returns an unordered list of type IDs of the properties in this query.
+    #[must_use]
     fn get_type_ids(&self) -> Vec<TypeId>;
 
     /// Returns the property ID of the representative multi-property having the properties of
     /// this query, if any.
+    #[must_use]
     fn multi_property_id(&self) -> Option<usize> {
         // Silence type complexity warning for this one-off data structure.
         #[allow(clippy::type_complexity)]
@@ -169,22 +171,27 @@ pub trait QueryInternal<E: Entity>: 'static {
     }
 
     /// Indicates whether this query matches the entire population for `E`.
+    #[must_use]
     fn is_empty_query(&self) -> bool {
         false
     }
 
     /// Exposes the query parts without allocating.
+    #[must_use]
     fn query_parts(&self) -> Self::QueryParts<'_>;
 
     /// Creates a new query result as an `EntitySet`.
+    #[must_use]
     fn new_query_result<'c>(&self, context: &'c Context) -> EntitySet<'c, E>;
 
     /// Creates a new `EntitySetIterator`.
+    #[must_use]
     fn new_query_result_iterator<'c>(&self, context: &'c Context) -> EntitySetIterator<'c, E> {
         self.new_query_result(context).into_iter()
     }
 
     /// Determines if the given person matches this query.
+    #[must_use]
     fn match_entity(&self, entity_id: EntityId<E>, context: &Context) -> bool;
 
     /// Removes all `EntityId`s from the given vector that do not match this query.

--- a/src/entity/value_change_counter.rs
+++ b/src/entity/value_change_counter.rs
@@ -18,6 +18,7 @@ pub struct StratifiedValueChangeCounter<E: Entity, PL: PropertyList<E>, P: Prope
 }
 
 impl<E: Entity, PL: PropertyList<E>, P: Property<E>> StratifiedValueChangeCounter<E, PL, P> {
+    #[must_use]
     pub fn new() -> Self {
         Self {
             counts: HashMap::default(),
@@ -25,6 +26,7 @@ impl<E: Entity, PL: PropertyList<E>, P: Property<E>> StratifiedValueChangeCounte
         }
     }
 
+    #[must_use]
     pub fn get_count(&self, stratum: PL, value: P) -> usize
     where
         PL: Eq + Hash,

--- a/src/execution_stats.rs
+++ b/src/execution_stats.rs
@@ -17,6 +17,7 @@ use wasm_bindgen::prelude::*;
 
 #[cfg(target_arch = "wasm32")]
 #[wasm_bindgen]
+#[must_use]
 /// The `wasm` target does not support `std::time::Instant::now()`.
 /// Works in both Window and Web Worker contexts.
 pub fn get_high_res_time() -> f64 {
@@ -75,6 +76,7 @@ pub(crate) struct ExecutionProfilingCollector {
 
 #[cfg(feature = "profiling")]
 impl ExecutionProfilingCollector {
+    #[must_use]
     pub fn new() -> ExecutionProfilingCollector {
         let process_id = sysinfo::get_current_pid().ok();
         #[cfg(target_arch = "wasm32")]
@@ -131,6 +133,7 @@ impl ExecutionProfilingCollector {
 
     /// Gives accumulated CPU time of the process in CPU-milliseconds since simulation start.
     #[allow(unused)]
+    #[must_use]
     pub fn cpu_time(&mut self) -> u64 {
         if let Some(process_id) = self.process_id {
             // Only refresh cpu statistics
@@ -160,6 +163,7 @@ impl ExecutionProfilingCollector {
     }
 
     /// Computes the final summary statistics
+    #[must_use]
     pub fn compute_final_statistics(&mut self) -> ExecutionStatistics {
         let mut cpu_time_millis = 0;
 
@@ -202,6 +206,7 @@ pub(crate) struct ExecutionProfilingCollector {
 
 #[cfg(not(feature = "profiling"))]
 impl ExecutionProfilingCollector {
+    #[must_use]
     pub fn new() -> ExecutionProfilingCollector {
         #[cfg(target_arch = "wasm32")]
         let now = get_high_res_time();
@@ -214,6 +219,7 @@ impl ExecutionProfilingCollector {
     #[inline]
     pub fn refresh(&mut self) {}
 
+    #[must_use]
     pub fn compute_final_statistics(&mut self) -> ExecutionStatistics {
         #[cfg(target_arch = "wasm32")]
         let wall_time = get_high_res_time() - self.start_time;

--- a/src/global_properties.rs
+++ b/src/global_properties.rs
@@ -50,6 +50,7 @@ pub static GLOBAL_PROPERTIES: LazyLock<Mutex<RefCell<HashMap<String, Arc<Propert
 static NEXT_GLOBAL_PROPERTY_ID: Mutex<usize> = Mutex::new(0);
 
 /// A convenience getter for `NEXT_GLOBAL_PROPERTY_ID`.
+#[must_use]
 pub fn get_global_property_count() -> usize {
     *NEXT_GLOBAL_PROPERTY_ID.lock().unwrap()
 }
@@ -59,6 +60,7 @@ pub fn get_global_property_count() -> usize {
 /// Acquires a global lock on the next available global property ID, but only
 /// increments it if we successfully initialize the provided ID. The ID of a
 /// global property is assigned at runtime but only once per type.
+#[must_use]
 pub fn initialize_global_property_id(global_property_id: &AtomicUsize) -> usize {
     let mut guard = NEXT_GLOBAL_PROPERTY_ID.lock().unwrap();
     let candidate = *guard;
@@ -132,10 +134,12 @@ pub trait GlobalProperty: Any {
     /// The actual type of the data stored in the global property
     type Value: Any;
 
+    #[must_use]
     fn id() -> usize;
 
     fn new() -> Self;
 
+    #[must_use]
     fn name() -> &'static str {
         let full = std::any::type_name::<Self>();
         full.rsplit("::").next().unwrap()
@@ -159,6 +163,7 @@ pub trait ContextGlobalPropertiesExt: ContextBase {
     ) -> Result<(), IxaError>;
 
     /// Return value of global property T
+    #[must_use]
     fn get_global_property_value<T: GlobalProperty + 'static>(
         &self,
         _property: T,

--- a/src/hashing.rs
+++ b/src/hashing.rs
@@ -106,6 +106,7 @@ impl<const N: usize, E: rkyv::rancor::Source> rkyv::ser::Writer<E> for EqualityB
 
 /// Provides API parity with `std::collections::HashMap`.
 pub trait HashMapExt {
+    #[must_use]
     fn new() -> Self;
 }
 
@@ -121,9 +122,11 @@ impl<K, V> HashMapExt for HashMap<K, V> {
 pub trait HashSetExt {
     type Item;
 
+    #[must_use]
     fn new() -> Self;
 
     /// Equivalent to `self.iter().cloned().collect::<Vec<_>>()`.
+    #[must_use]
     fn to_owned_vec(&self) -> Vec<Self::Item>;
 }
 
@@ -152,6 +155,7 @@ impl<T: Clone> HashSetExt for IndexSet<T> {
 }
 
 /// A convenience method to compute the hash of a `&str`.
+#[must_use]
 pub fn hash_str(data: &str) -> u64 {
     let mut hasher = rustc_hash::FxHasher::default();
     hasher.write(data.as_bytes());
@@ -166,6 +170,7 @@ pub(crate) fn finish_deterministic_hash_128(hasher: DeterministicHasher) -> Hash
 }
 
 /// Helper for any `T: Hash` using the crate's deterministic hasher.
+#[must_use]
 pub fn one_shot_128<T: Hash>(value: &T) -> u128 {
     let mut hasher = DeterministicHasher::default();
     value.hash(&mut hasher);

--- a/src/macros/define_global_property.rs
+++ b/src/macros/define_global_property.rs
@@ -58,7 +58,7 @@ macro_rules! define_global_property {
                     let mut name = module.split("::").next().unwrap().to_string();
                     name += ".";
                     name += stringify!($global_property);
-                    <$global_property as $crate::global_properties::GlobalProperty>::id();
+                    let _ = <$global_property as $crate::global_properties::GlobalProperty>::id();
                     $crate::global_properties::add_global_property::<$global_property>(&name);
                 }
             }

--- a/src/network/edge.rs
+++ b/src/network/edge.rs
@@ -29,6 +29,7 @@ impl<E: Entity, ET: EdgeType<E>> Clone for Edge<E, ET> {
 }
 
 pub trait EdgeType<E: Entity>: Clone + 'static {
+    #[must_use]
     fn name() -> &'static str {
         let full = std::any::type_name::<Self>();
         full.rsplit("::").next().unwrap()
@@ -37,6 +38,7 @@ pub trait EdgeType<E: Entity>: Clone + 'static {
     /// The index of this item in the owner, which is initialized globally per type
     /// upon first access. We explicitly initialize this in a `ctor` in order to know
     /// how many [`EdgeType<E>`] types exist globally when we construct any `NetworkStore<E>`.
+    #[must_use]
     fn id() -> usize;
 }
 
@@ -47,6 +49,7 @@ static NEXT_EDGE_TYPE_ID_BY_ENTITY: LazyLock<Mutex<HashMap<usize, usize>>> =
     LazyLock::new(|| Mutex::new(HashMap::default()));
 
 /// Returns the number of registered edge types for the entity type `E`.
+#[must_use]
 pub fn get_registered_edge_type_count<E: Entity>() -> usize {
     let map = NEXT_EDGE_TYPE_ID_BY_ENTITY.lock().unwrap();
     *map.get(&E::id()).unwrap_or(&0)
@@ -72,6 +75,7 @@ pub fn add_to_edge_type_to_registry<E: Entity, ET: EdgeType<E>>() {
 /// In fact, for our use case we know we are calling this function
 /// once for each type in each `EdgeType<E>`'s `ctor` function, which
 /// should be the only time this method is ever called for the type.
+#[must_use]
 pub fn initialize_edge_type_id<E: Entity>(edge_type_id: &AtomicUsize) -> usize {
     // Acquire a global lock.
     let mut guard = NEXT_EDGE_TYPE_ID_BY_ENTITY.lock().unwrap();

--- a/src/network/mod.rs
+++ b/src/network/mod.rs
@@ -75,6 +75,7 @@ impl NetworkData {
 
     /// Remove the edge from the given entity to the given neighbor and return it, or
     /// `None` if the edge does not exist.
+    #[must_use]
     pub fn remove_edge<E: Entity, ET: EdgeType<E>>(
         &mut self,
         entity_id: EntityId<E>,
@@ -228,6 +229,7 @@ pub trait ContextNetworkExt: ContextBase + ContextRandomExt {
 
     /// Remove the edge of type `ET` from `entity_id` to `neighbor` and return it, or `None` if
     /// the edge does not exist.
+    #[must_use]
     fn remove_edge<E: Entity, ET: EdgeType<E>>(
         &mut self,
         entity_id: EntityId<E>,

--- a/src/network/network.rs
+++ b/src/network/network.rs
@@ -38,14 +38,17 @@ impl<E: Entity, ET: EdgeType<E>> Default for Network<E, ET> {
 
 #[allow(unused)]
 impl<E: Entity, ET: EdgeType<E> + 'static> Network<E, ET> {
+    #[must_use]
     pub(crate) fn new() -> Self {
         Self::default()
     }
 
+    #[must_use]
     pub(crate) fn new_boxed() -> Box<dyn Any> {
         Box::new(Self::new())
     }
 
+    #[must_use]
     pub fn with_capacity(capacity: usize) -> Self {
         Self {
             adjacency_lists: AdjacencyListVec::with_capacity(capacity),
@@ -59,6 +62,7 @@ impl<E: Entity, ET: EdgeType<E> + 'static> Network<E, ET> {
 
     /// Returns a clone of the adjacency list for the given entity. Returns an empty list
     /// if the list is empty.
+    #[must_use]
     pub fn get_list_cloned(&self, entity_id: EntityId<E>) -> AdjacencyList<E, ET> {
         self.adjacency_lists
             .get(entity_id.0)
@@ -68,12 +72,14 @@ impl<E: Entity, ET: EdgeType<E> + 'static> Network<E, ET> {
 
     /// Returns an immutable reference to the adjacency list for the given entity,
     /// or `None` if the list is empty.
+    #[must_use]
     pub fn get_list(&self, entity_id: EntityId<E>) -> Option<&AdjacencyList<E, ET>> {
         self.adjacency_lists.get(entity_id.0)
     }
 
     /// Returns a mutable reference to the adjacency list for the given entity,
     /// or `None` if the list is empty.
+    #[must_use]
     pub fn get_list_mut(&mut self, entity_id: EntityId<E>) -> Option<&mut AdjacencyList<E, ET>> {
         self.adjacency_lists.get_mut(entity_id.0)
     }
@@ -102,6 +108,7 @@ impl<E: Entity, ET: EdgeType<E> + 'static> Network<E, ET> {
 
     /// Remove the edge from the given entity to the given neighbor and return it, or
     /// `None` if the edge does not exist.
+    #[must_use]
     pub fn remove_edge(
         &mut self,
         entity_id: EntityId<E>,
@@ -117,6 +124,7 @@ impl<E: Entity, ET: EdgeType<E> + 'static> Network<E, ET> {
 
     /// Returns an immutable reference to the edge from the given entity
     /// to the given neighbor, or `None` if the edge does not exist.
+    #[must_use]
     pub fn get_edge(&self, entity_id: EntityId<E>, neighbor: EntityId<E>) -> Option<&Edge<E, ET>> {
         let index = entity_id.0;
         self.adjacency_lists
@@ -126,6 +134,7 @@ impl<E: Entity, ET: EdgeType<E> + 'static> Network<E, ET> {
 
     /// Returns a mutable reference to the edge from the given entity
     /// to the given neighbor, or `None` if the edge does not exist.
+    #[must_use]
     pub fn get_edge_mut(
         &mut self,
         entity_id: EntityId<E>,
@@ -138,6 +147,7 @@ impl<E: Entity, ET: EdgeType<E> + 'static> Network<E, ET> {
     }
 
     /// Returns a list of `EntityId<E>`s having exactly the given number of neighbors.
+    #[must_use]
     pub fn find_entities_by_degree(&self, degree: usize) -> Vec<EntityId<E>> {
         self.adjacency_lists
             .iter()

--- a/src/profiling/data.rs
+++ b/src/profiling/data.rs
@@ -185,12 +185,14 @@ pub fn increment_named_count(key: &'static str) {
 pub fn increment_named_count(_key: &'static str) {}
 
 #[cfg(feature = "profiling")]
+#[must_use]
 pub fn open_span(label: &'static str) -> Span {
     let mut container = profiling_data();
     container.open_span(label)
 }
 
 #[cfg(not(feature = "profiling"))]
+#[must_use]
 pub fn open_span(label: &'static str) -> Span {
     Span::new(label)
 }

--- a/src/profiling/display.rs
+++ b/src/profiling/display.rs
@@ -165,6 +165,7 @@ pub fn print_formatted_table(rows: &[Vec<String>]) {
 
 /// Formats an integer with thousands separator.
 #[cfg(feature = "profiling")]
+#[must_use]
 pub fn format_with_commas(value: usize) -> String {
     let s = value.to_string();
     let mut result = String::new();
@@ -184,6 +185,7 @@ pub fn format_with_commas(value: usize) -> String {
 
 /// Formats a float with thousands separator.
 #[cfg(feature = "profiling")]
+#[must_use]
 pub fn format_with_commas_f64(value: f64) -> String {
     // Format to two decimal places
     let formatted = format!("{:.2}", value.abs()); // format positive part only

--- a/src/random/context_ext.rs
+++ b/src/random/context_ext.rs
@@ -61,6 +61,7 @@ pub trait ContextRandomExt: ContextBase {
     /// [`RngId`] by applying the specified sampler function. If the Rng has not been used
     /// before, one will be created with the base seed you defined in `set_base_random_seed`.
     /// Note that this will panic if `set_base_random_seed` was not called yet.
+    #[must_use]
     fn sample<R: RngId + 'static, T>(
         &self,
         _rng_type: R,
@@ -74,6 +75,7 @@ pub trait ContextRandomExt: ContextBase {
     /// associated with the given [`RngId`]. If the Rng has not been used before, one will be
     /// created with the base seed you defined in `set_base_random_seed`.
     /// Note that this will panic if `set_base_random_seed` was not called yet.
+    #[must_use]
     fn sample_distr<R: RngId + 'static, T>(
         &self,
         _rng_type: R,
@@ -89,6 +91,7 @@ pub trait ContextRandomExt: ContextBase {
     /// Gets a random sample within the range provided by `range`
     /// using the generator associated with the given [`RngId`].
     /// Note that this will panic if `set_base_random_seed` was not called yet.
+    #[must_use]
     fn sample_range<R: RngId + 'static, S, T>(&self, rng_id: R, range: S) -> T
     where
         R::RngType: Rng,
@@ -101,6 +104,7 @@ pub trait ContextRandomExt: ContextBase {
     /// Gets a random boolean value which is true with probability `p`
     /// using the generator associated with the given [`RngId`].
     /// Note that this will panic if `set_base_random_seed` was not called yet.
+    #[must_use]
     fn sample_bool<R: RngId + 'static>(&self, rng_id: R, p: f64) -> bool
     where
         R::RngType: Rng,
@@ -112,6 +116,7 @@ pub trait ContextRandomExt: ContextBase {
     /// with the given weights using the generator associated with the
     /// given [`RngId`].  Note that this will panic if
     /// `set_base_random_seed` was not called yet.
+    #[must_use]
     fn sample_weighted<R: RngId + 'static, T>(&self, _rng_id: R, weights: &[T]) -> usize
     where
         R::RngType: Rng,

--- a/src/random/sampling_algorithms.rs
+++ b/src/random/sampling_algorithms.rs
@@ -18,6 +18,7 @@ use crate::rand::Rng;
 ///
 /// The iterator need only support iteration; random indexing is not required.
 /// This function is intended for use when the result set is indexed and its length is known.
+#[must_use]
 pub fn sample_single_from_known_length<I, R, T>(rng: &mut R, mut iter: I) -> Option<T>
 where
     R: Rng,
@@ -46,6 +47,7 @@ where
 /// of 10^4). The reservoir algorithm from [`rand`](crate::rand) reduces to the "known length"
 /// algorithm when `iterator.size_hint()` returns `(k, Some(k))` for some `k`. Otherwise,
 /// this algorithm is much faster than the [`rand`](crate::rand)  implementation (factor of 100).
+#[must_use]
 pub fn sample_single_l_reservoir<I, R, T>(rng: &mut R, iterable: I) -> Option<T>
 where
     R: Rng,
@@ -82,6 +84,7 @@ where
 /// and `sample` is `None` iff `count == 0`.
 ///
 /// This uses single-item reservoir sampling while tracking total count.
+#[must_use]
 pub fn count_and_sample_single_l_reservoir<I, R, T>(rng: &mut R, iterable: I) -> (usize, Option<T>)
 where
     R: Rng,
@@ -113,6 +116,7 @@ where
 ///
 /// This strategy is particularly effective for small `requested` (≤ 5), since it
 /// avoids iterating over the entire set and is typically faster than reservoir sampling.
+#[must_use]
 pub fn sample_multiple_from_known_length<I, R, T>(rng: &mut R, iter: I, requested: usize) -> Vec<T>
 where
     R: Rng,
@@ -154,6 +158,7 @@ where
 ///
 /// This algorithm is significantly faster than the reservoir algorithm in `rand` and is
 /// on par with the "known length" algorithm for large `requested` values.
+#[must_use]
 pub fn sample_multiple_l_reservoir<I, R, T>(rng: &mut R, iter: I, requested: usize) -> Vec<T>
 where
     R: Rng,
@@ -206,6 +211,7 @@ where
 /// `Borrow<T>` bound. Dispatches to `sample_single_excluding_iteration` for slices of
 /// length `< 4` and `sample_single_excluding_rejection` otherwise. Tuned via
 /// `ixa-bench/criterion/sample_single_excluding.rs`.
+#[must_use]
 pub fn sample_single_excluding<'a, R, T, E>(
     rng: &mut R,
     slice: &'a [T],
@@ -229,6 +235,7 @@ where
 /// entries, then picks the k-th. Wins for very small slices (`n <= 3`) where
 /// the per-trial overhead of rejection sampling exceeds the cost of a tiny
 /// filter. Exposed so benchmarks can compare strategies directly.
+#[must_use]
 pub fn sample_single_excluding_iteration<'a, R, T, E>(
     rng: &mut R,
     slice: &'a [T],
@@ -255,6 +262,7 @@ where
 /// matches (or `n`, whichever is smaller), which also returns `None` when
 /// every element matches. Exposed so benchmarks can compare strategies
 /// directly.
+#[must_use]
 pub fn sample_single_excluding_rejection<'a, R, T, E>(
     rng: &mut R,
     slice: &'a [T],
@@ -295,6 +303,7 @@ where
 /// in O(n) time and is correct even when the iterator does not report an
 /// exact length. Prefer [`sample_single_excluding`] for slices, which can
 /// dispatch to a faster rejection-sampling strategy backed by random access.
+#[must_use]
 pub fn sample_single_excluding_l_reservoir<I, R, T, E>(
     rng: &mut R,
     iterable: I,


### PR DESCRIPTION
## Summary

Adds `#[must_use]` annotations across value-returning APIs where ignoring the result is likely a bug or wasted work.

This covers the main entity/query/property/random sampling surfaces, collection helpers, registry/store/index accessors, profiling/execution helpers, network getters, and relevant `ixa-bench` support code.

## Details

- Added `#[must_use]` to user-facing APIs such as:
  - `ContextEntitiesExt::get_property`
  - `query_entity_count`
  - `sample_entity`
  - `count_and_sample_entity`
  - `sample_entities`
  - `get_entity_count`
  - `query` / `query_result_iterator`
- Added `#[must_use]` to random sampling helpers, including:
  - `ContextRandomExt::sample`
  - `sample_distr`
  - `sample_range`
  - `sample_bool`
  - `sample_weighted`
  - lower-level sampling algorithms
- Added annotations to pure/value-returning helpers in entity stores, property stores, indexes, collections, hashing, profiling, execution stats, and network internals.

