### PR TITLE
chore: re-export IxaEvent derive from ixa

### DIFF
--- a/examples/basic-infection/Cargo.toml
+++ b/examples/basic-infection/Cargo.toml
@@ -11,7 +11,6 @@ publish = false
 
 [dependencies]
 ixa = { path = "../../" }
-ixa-derive = { path = "../../ixa-derive" }
 
 serde.workspace = true
 rand_distr.workspace = true

--- a/examples/births-deaths/Cargo.toml
+++ b/examples/births-deaths/Cargo.toml
@@ -11,7 +11,6 @@ publish = false
 
 [dependencies]
 ixa = { path = "../../" }
-ixa-derive = { path = "../../ixa-derive" }
 
 serde.workspace = true
 rand_distr.workspace = true

--- a/src/context.rs
+++ b/src/context.rs
@@ -533,10 +533,10 @@ mod tests {
     use std::cell::RefCell;
     use std::marker::PhantomData;
 
-    use ixa_derive::IxaEvent;
-
     use super::*;
-    use crate::{define_data_plugin, define_entity, define_property, with, ContextEntitiesExt};
+    use crate::{
+        define_data_plugin, define_entity, define_property, with, ContextEntitiesExt, IxaEvent,
+    };
 
     define_data_plugin!(ComponentA, Vec<u32>, vec![]);
 

--- a/src/entity/events.rs
+++ b/src/entity/events.rs
@@ -26,7 +26,6 @@ because a non-derived p
 
 */
 
-use ixa_derive::IxaEvent;
 use smallbox::space::S4;
 use smallbox::SmallBox;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -31,11 +31,26 @@
 //!
 //! - **`logging`**: enables structured logging for native and wasm targets.
 //! - **`profiling`**: enables collection and reporting of execution profiling statistics. Disabled by default.
+//!
+//! ## Events
+//!
+//! Event types can derive [`IxaEvent`] with the same import used for the trait:
+//!
+//! ```
+//! use ixa::IxaEvent;
+//!
+//! #[derive(IxaEvent)]
+//! struct MyEvent;
+//!
+//! fn assert_event<E: IxaEvent>() {}
+//! assert_event::<MyEvent>();
+//! ```
 
 #![doc = include_str!(concat!(env!("CARGO_MANIFEST_DIR"), "/docs/book/src/cli-usage.md"))]
 
 pub mod context;
 pub use context::{Context, ContextBase, ExecutionPhase, IxaEvent};
+pub use ixa_derive::IxaEvent;
 
 mod plugin_context;
 pub use plugin_context::PluginContext;
@@ -87,12 +102,9 @@ pub use crate::hashing::{HashMap, HashMapExt, HashSet, HashSetExt};
 pub mod prelude;
 
 pub mod prelude_for_plugins {
-    pub use ixa_derive::IxaEvent;
-
-    pub use crate::context::{ContextBase, IxaEvent};
-    pub use crate::define_data_plugin;
     pub use crate::error::IxaError;
     pub use crate::prelude::*;
+    pub use crate::{define_data_plugin, ContextBase, IxaEvent};
 }
 
 pub mod entity;


### PR DESCRIPTION
## Summary

- Re-export `ixa_derive::IxaEvent` from the `ixa` crate root
- Document the new ergonomic usage: `use ixa::IxaEvent; #[derive(IxaEvent)]`
- Update internal derives to exercise the crate-root re-export
- Remove direct `ixa-derive` dependencies from example crates that no longer need them
