### PR TITLE
chore: Audit obsolete Clippy allow attributes

### DIFF
--- a/examples/basic-infection/src/transmission_manager.rs
+++ b/examples/basic-infection/src/transmission_manager.rs
@@ -26,7 +26,6 @@ fn attempt_infection(context: &mut Context) {
     // An alternative implementation calculates each person's time to infection
     // at the beginning of the simulation and schedules their infection at that time.
 
-    #[allow(clippy::cast_precision_loss)]
     let next_attempt_time = context.get_current_time()
         + context.sample_distr(TransmissionRng, Exp::new(FOI).unwrap()) / population_size as f64;
 

--- a/examples/births-deaths/src/transmission_manager.rs
+++ b/examples/births-deaths/src/transmission_manager.rs
@@ -27,7 +27,6 @@ fn attempt_infection(context: &mut Context, age_group: AgeGroupRisk) {
         if person_status == InfectionStatus::S {
             context.set_property(person_to_infect, InfectionStatus::I);
         }
-        #[allow(clippy::cast_precision_loss)]
         let next_attempt_time = context.get_current_time()
             + context.sample_distr(TransmissionRng1, Exp::new(foi).unwrap())
                 / population_size as f64;

--- a/examples/network-hhmodel/incidence_report.rs
+++ b/examples/network-hhmodel/incidence_report.rs
@@ -157,7 +157,6 @@ mod test {
 
             let to_infect: Vec<PersonId> = vec![context.sample_entity(MainRng, Person).unwrap()];
 
-            #[allow(clippy::vec_init_then_push)]
             seir::init(&mut context, &to_infect, 1.0);
 
             context.execute();

--- a/examples/network-hhmodel/main.rs
+++ b/examples/network-hhmodel/main.rs
@@ -49,6 +49,5 @@ fn initialize(context: &mut Context) {
     // Initialize infected person with InfectedBy value equal to their own PersonId
     let to_infect: Vec<PersonId> = vec![context.sample_entity(MainRng, Person).unwrap()];
 
-    #[allow(clippy::vec_init_then_push)]
     seir::init(context, &to_infect, 1.0);
 }

--- a/examples/network-hhmodel/parameters.rs
+++ b/examples/network-hhmodel/parameters.rs
@@ -3,7 +3,6 @@ use std::fmt::Debug;
 use ixa::prelude::*;
 use serde::{Deserialize, Serialize};
 
-#[allow(clippy::module_name_repetitions)]
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct ParametersValues {
     pub incubation_period: f64,

--- a/integration-tests/ixa-wasm-tests/src/transmission_manager.rs
+++ b/integration-tests/ixa-wasm-tests/src/transmission_manager.rs
@@ -26,7 +26,6 @@ fn attempt_infection(context: &mut Context) {
     // An alternative implementation calculates each person's time to infection
     // at the beginning of the simulation and schedules their infection at that time.
 
-    #[allow(clippy::cast_precision_loss)]
     let next_attempt_time = context.get_current_time()
         + context.sample_distr(TransmissionRng, Exp::new(FOI).unwrap()) / population_size as f64;
 

--- a/ixa-fips/src/lib.rs
+++ b/ixa-fips/src/lib.rs
@@ -12,10 +12,6 @@
 //! for ASPR synthetic population data files, including files that are within a zip archive.
 
 #![allow(dead_code)]
-// Positive instances of the following lints have been audited.
-#![allow(clippy::inline_always)]
-#![allow(clippy::cast_possible_truncation)]
-#![allow(clippy::cast_lossless)]
 
 mod errors;
 pub mod fips_code;

--- a/src/context.rs
+++ b/src/context.rs
@@ -140,7 +140,6 @@ impl Context {
     ///
     /// Handlers will be called upon event emission in order of subscription as
     /// queued `Callback`s with the appropriate event.
-    #[allow(clippy::missing_panics_doc)]
     pub fn subscribe_to_event<E: IxaEvent>(&mut self, handler: impl Fn(&mut Context, E) + 'static) {
         let handler_vec = self
             .event_handlers
@@ -159,7 +158,6 @@ impl Context {
     ///
     /// Receivers will handle events in the order that they have subscribed and
     /// are queued as callbacks
-    #[allow(clippy::missing_panics_doc)]
     pub fn emit_event<E: IxaEvent>(&mut self, event: E) {
         // Destructure to obtain event handlers and plan queue
         let Context {
@@ -304,7 +302,6 @@ impl Context {
     ///
     /// Returns a mutable reference to the data container
     #[must_use]
-    #[allow(clippy::needless_pass_by_value)]
     pub fn get_data_mut<T: DataPlugin>(&mut self, _data_plugin: T) -> &mut T::DataContainer {
         let index = T::index_within_context();
 
@@ -335,7 +332,6 @@ impl Context {
     ///
     /// Returns a reference to the data container if it exists or else `None`
     #[must_use]
-    #[allow(clippy::needless_pass_by_value)]
     pub fn get_data<T: DataPlugin>(&self, _data_plugin: T) -> &T::DataContainer {
         let index = T::index_within_context();
         self.data_plugins
@@ -921,8 +917,6 @@ mod tests {
     }
 
     #[test]
-    #[allow(clippy::cast_sign_loss)]
-    #[allow(clippy::cast_possible_truncation)]
     fn periodic_plan_self_schedules() {
         // checks whether the person properties report schedules itself
         // based on whether there are plans in the queue

--- a/src/entity/events.rs
+++ b/src/entity/events.rs
@@ -128,7 +128,6 @@ impl<E: Entity, P: Property<E>> PartialPropertyChangeEventCore<E, P> {
 /// Emitted when a new entity is created.
 /// These should not be emitted outside this module.
 #[derive(IxaEvent)]
-#[allow(clippy::manual_non_exhaustive)]
 pub struct EntityCreatedEvent<E: Entity> {
     /// The [`EntityId<E>`] of the new entity.
     pub entity_id: EntityId<E>,
@@ -144,7 +143,6 @@ impl<E: Entity> EntityCreatedEvent<E> {
 /// Emitted when a property is updated.
 /// These should not be emitted outside this module.
 #[derive(IxaEvent)]
-#[allow(clippy::manual_non_exhaustive)]
 pub struct PropertyChangeEvent<E: Entity, P: Property<E>> {
     /// The [`EntityId<E>`] that changed
     pub entity_id: EntityId<E>,

--- a/src/entity/property_store.rs
+++ b/src/entity/property_store.rs
@@ -86,7 +86,6 @@ static PROPERTY_METADATA_BUILDER: LazyLock<
 ///
 /// This is derived from `PROPERTY_METADATA_BUILDER` by moving the builder `HashMap` out. After this point,
 /// registration is no longer allowed.
-#[allow(clippy::type_complexity)]
 static PROPERTY_METADATA: OnceLock<HashMap<(usize, usize), Box<dyn Any + Send + Sync>>> =
     OnceLock::new();
 

--- a/src/entity/query/mod.rs
+++ b/src/entity/query/mod.rs
@@ -150,7 +150,6 @@ pub trait QueryInternal<E: Entity>: 'static {
     /// this query, if any.
     #[must_use]
     fn multi_property_id(&self) -> Option<usize> {
-        // Silence type complexity warning for this one-off data structure.
         #[allow(clippy::type_complexity)]
         static REGISTRY: OnceLock<Mutex<HashMap<(usize, TypeId), &'static Option<usize>>>> =
             OnceLock::new();

--- a/src/error.rs
+++ b/src/error.rs
@@ -5,7 +5,6 @@ use std::io;
 use thiserror::Error;
 
 #[derive(Error, Debug)]
-#[allow(clippy::module_name_repetitions)]
 /// Provides [`IxaError`] and maps to other errors to
 /// convert to an [`IxaError`]
 pub enum IxaError {

--- a/src/execution_stats.rs
+++ b/src/execution_stats.rs
@@ -1,6 +1,3 @@
-// Loss of precision is allowable in this module's use cases.
-#![allow(clippy::cast_precision_loss)]
-
 use std::time::Duration;
 #[cfg(not(target_arch = "wasm32"))]
 use std::time::Instant;

--- a/src/global_properties.rs
+++ b/src/global_properties.rs
@@ -34,7 +34,6 @@ use crate::{trace, ContextBase, HashMap, HashMapExt};
 type PropertySetterFn =
     dyn Fn(&mut Context, &str, serde_json::Value) -> Result<(), IxaError> + Send + Sync;
 
-#[allow(clippy::type_complexity)]
 // This is a global list of all the global properties that
 // are compiled in. Fundamentally it's a HashMap of property
 // names to the setter function, but it's wrapped in the
@@ -42,6 +41,7 @@ type PropertySetterFn =
 // shared and initialized at startup time while still being
 // safe.
 #[doc(hidden)]
+#[allow(clippy::type_complexity)]
 pub static GLOBAL_PROPERTIES: LazyLock<Mutex<RefCell<HashMap<String, Arc<PropertySetterFn>>>>> =
     LazyLock::new(|| Mutex::new(RefCell::new(HashMap::new())));
 
@@ -79,7 +79,6 @@ pub fn initialize_global_property_id(global_property_id: &AtomicUsize) -> usize 
     }
 }
 
-#[allow(clippy::missing_panics_doc)]
 pub fn add_global_property<T: GlobalProperty>(name: &str)
 where
     for<'de> <T as GlobalProperty>::Value: serde::Deserialize<'de>,

--- a/src/log/mod.rs
+++ b/src/log/mod.rs
@@ -217,7 +217,6 @@ pub fn remove_module_filter(module_path: &str) {
 
 /// Sets the level filters for a set of modules according to the provided map. Use this instead of
 /// `set_module_filter()` to set filters in bulk.
-#[allow(clippy::implicit_hasher)]
 pub fn set_module_filters<S: ToString>(module_filters: &[(&S, LevelFilter)]) {
     let mut log_configuration = get_log_configuration();
     log_configuration.set_module_filters(module_filters);

--- a/src/network/mod.rs
+++ b/src/network/mod.rs
@@ -317,7 +317,6 @@ pub trait ContextNetworkExt: ContextBase + ContextRandomExt {
 impl ContextNetworkExt for Context {}
 
 #[cfg(test)]
-#[allow(clippy::float_cmp)]
 // Tests for the inner core.
 mod test_inner {
     use super::NetworkData;
@@ -523,7 +522,6 @@ mod test_inner {
 }
 
 #[cfg(test)]
-#[allow(clippy::float_cmp)]
 // Tests for the API.
 mod test_api {
     use crate::context::Context;

--- a/src/numeric.rs
+++ b/src/numeric.rs
@@ -1,4 +1,3 @@
-#![allow(clippy::approx_constant)]
 //! Vendored from [statrs@0.18.0 (prec.rs)](http://github.com/statrs-dev/statrs/blob/v0.18.0/src/prec.rs), convenience
 //! wrappers around methods from the approx crate. Provides utility functions for working with floating point precision.
 
@@ -75,6 +74,7 @@ mod tests {
     }
 
     #[test]
+    #[allow(clippy::approx_constant)]
     fn assert_almost_eq_macro_passes() {
         // should not panic
         assert_almost_eq!(3.14159265, 3.14159264, 1e-7);

--- a/src/plan.rs
+++ b/src/plan.rs
@@ -196,7 +196,6 @@ pub struct PlanSchedule<P: Eq + PartialEq + Ord> {
     pub priority: P,
 }
 
-#[allow(clippy::expl_impl_clone_on_copy)] // Clippy false positive
 impl<P: Eq + PartialEq + Ord + Clone> Clone for PlanSchedule<P> {
     fn clone(&self) -> Self {
         PlanSchedule {
@@ -250,7 +249,6 @@ pub struct Plan<T> {
 }
 
 #[cfg(test)]
-#[allow(clippy::float_cmp)]
 mod tests {
     use super::Queue;
 

--- a/src/profiling/data.rs
+++ b/src/profiling/data.rs
@@ -115,7 +115,6 @@ impl ProfilingData {
 
         // Collect data rows
         for (key, count) in &self.counts {
-            #[allow(clippy::cast_precision_loss)]
             let rate = (*count as f64) / elapsed; // Just allow this to be `inf`/`nan` if `elapsed == 0.0`.
 
             rows.push(((*key).to_string(), *count, rate));

--- a/src/profiling/display.rs
+++ b/src/profiling/display.rs
@@ -223,7 +223,6 @@ pub fn format_with_commas_f64(value: f64) -> String {
 
 #[cfg(all(test, feature = "profiling"))]
 mod tests {
-    #![allow(clippy::unreadable_literal)]
     use std::time::Duration;
 
     use crate::profiling::display::{

--- a/src/report.rs
+++ b/src/report.rs
@@ -70,7 +70,6 @@ pub trait Report: 'static {
 
 /// # Errors
 /// function will return Error if it fails to `serialize_str`
-#[allow(clippy::trivially_copy_pass_by_ref)]
 #[allow(dead_code)]
 pub fn serialize_f64<S, const N: usize>(value: &f64, serializer: S) -> Result<S::Ok, S::Error>
 where
@@ -82,7 +81,6 @@ where
 
 /// # Errors
 /// function will return Error if it fails to `serialize_str`
-#[allow(clippy::trivially_copy_pass_by_ref)]
 #[allow(dead_code)]
 pub fn serialize_f32<S, const N: usize>(value: &f32, serializer: S) -> Result<S::Ok, S::Error>
 where

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -142,7 +142,6 @@ fn create_ixa_cli() -> Command {
 ///
 /// # Errors
 /// Returns an error if argument parsing or the setup function fails
-#[allow(clippy::missing_errors_doc)]
 pub fn run_with_custom_args<A, F>(setup_fn: F) -> Result<Context, Box<dyn std::error::Error>>
 where
     A: Args,
@@ -166,7 +165,6 @@ where
 ///
 /// # Errors
 /// Returns an error if argument parsing or the setup function fails
-#[allow(clippy::missing_errors_doc)]
 pub fn run_with_args<F>(setup_fn: F) -> Result<Context, Box<dyn std::error::Error>>
 where
     F: Fn(&mut Context, BaseArgs, Option<PlaceholderCustom>) -> Result<(), IxaError>,


### PR DESCRIPTION
## Summary

- Removed obsolete `#[allow(clippy::...)]` attributes that are no longer needed after disabling Clippy pedantic lints.
- Kept only the local Clippy allowances still required by the current workspace lint configuration.
- Narrowed one `approx_constant` allowance from module scope to the specific test that needs it.
