### PR TITLE
feat: Passive plans

### DIFF
--- a/docs/book/src/topics/reports.md
+++ b/docs/book/src/topics/reports.md
@@ -409,6 +409,11 @@ pub fn init(context: &mut Context) {
 }
 ```
 
+Periodic plans are passive. They reschedule themselves after each report, but
+they do not keep the simulation running after active plans are exhausted. This
+means a periodic report can run at the final active simulation time, while later
+periodic report callbacks remain queued unless more active work is scheduled.
+
 The implementation of `write_aggregate_sir_report_item` is straightforward: We
 fetch the values from the data plugin, construct an instance of
 `AggregateSIRReportItem`, and "send" it to the report.

--- a/docs/book/src/topics/reports.md
+++ b/docs/book/src/topics/reports.md
@@ -410,9 +410,10 @@ pub fn init(context: &mut Context) {
 ```
 
 Periodic plans are passive. They reschedule themselves after each report, but
-they do not keep the simulation running after active plans are exhausted. This
-means a periodic report can run at the final active simulation time, while later
-periodic report callbacks remain queued unless more active work is scheduled.
+they do not keep the simulation running after non-passive plans are exhausted.
+This means a periodic report can run at the final simulation time,
+while later periodic report callbacks remain queued unless more work
+is scheduled.
 
 The implementation of `write_aggregate_sir_report_item` is straightforward: We
 fetch the values from the data plugin, construct an instance of

--- a/examples/births-deaths/README.md
+++ b/examples/births-deaths/README.md
@@ -33,7 +33,7 @@ scheduled for each individual. Once the person recovers, these plans are removed
 from the data structure. However, if the person dies before recovering, these
 plans are canceled at the time of death. The infection status of recovered
 individuals remains as recovered for the rest of the simulation, which will stop
-when no active plans remain and shutdown work is complete.
+when no plans remain and shutdown work is complete.
 
 ## Population manager
 

--- a/examples/births-deaths/README.md
+++ b/examples/births-deaths/README.md
@@ -33,7 +33,7 @@ scheduled for each individual. Once the person recovers, these plans are removed
 from the data structure. However, if the person dies before recovering, these
 plans are canceled at the time of death. The infection status of recovered
 individuals remains as recovered for the rest of the simulation, which will stop
-when the plan queue is empty.
+when no active plans remain and shutdown work is complete.
 
 ## Population manager
 

--- a/src/context.rs
+++ b/src/context.rs
@@ -304,7 +304,7 @@ impl Context {
         callback: impl FnOnce(&mut Context) + 'static,
         phase: ExecutionPhase,
     ) -> PlanId {
-        self.add_plan_with_phase_and_activity(time, callback, phase, true)
+        self.add_plan_with_phase_and_passivity(time, callback, phase, false)
     }
 
     /// Add a passive plan to the future event list at the specified time in the
@@ -343,15 +343,15 @@ impl Context {
         callback: impl FnOnce(&mut Context) + 'static,
         phase: ExecutionPhase,
     ) -> PlanId {
-        self.add_plan_with_phase_and_activity(time, callback, phase, false)
+        self.add_plan_with_phase_and_passivity(time, callback, phase, true)
     }
 
-    fn add_plan_with_phase_and_activity(
+    fn add_plan_with_phase_and_passivity(
         &mut self,
         time: f64,
         callback: impl FnOnce(&mut Context) + 'static,
         phase: ExecutionPhase,
-        is_active: bool,
+        is_passive: bool,
     ) -> PlanId {
         let current = self.get_current_time();
         assert!(!time.is_nan(), "Time {time} is invalid: cannot be NaN");
@@ -365,7 +365,7 @@ impl Context {
             current
         );
         self.plan_queue
-            .add_plan(time, Box::new(callback), phase, is_active)
+            .add_plan(time, Box::new(callback), phase, is_passive)
     }
 
     /// Add a plan to execute during shutdown-time in the normal phase.
@@ -419,10 +419,10 @@ impl Context {
     /// list.
     ///
     /// Periodic plans reschedule themselves after every run. They do not keep
-    /// the simulation timeline alive: when no active plans remain, normal
+    /// the simulation timeline alive: when no non-passive plans remain, normal
     /// shutdown begins, and only passive plans at the final current time can
     /// still run during that execution pass. Future passive periodic plans
-    /// remain queued and may run if later active work is scheduled.
+    /// remain queued and may run if later non-passive work is scheduled.
     ///
     /// Notes:
     /// * The first periodic plan is scheduled at time `0.0`. If `set_start_time` was
@@ -598,7 +598,7 @@ impl Context {
         self.start_time
     }
 
-    /// Execute the simulation until active plans are exhausted and shutdown
+    /// Execute the simulation until callbacks and plans are exhausted and shutdown
     /// work is complete.
     pub fn execute(&mut self) {
         trace!("entering event loop");
@@ -648,8 +648,8 @@ impl Context {
         match self.shutdown_status {
             ShutdownStatus::None => {
                 // Normal execution may advance simulation time to the next
-                // regular plan only while active regular work remains. Once no
-                // active regular plans remain, enter normal shutdown to drain
+                // regular plan only while non-passive regular work remains. Once no
+                // non-passive regular plans remain, enter normal shutdown to drain
                 // current-time regular work without advancing time.
                 if let Some(plan) = self.plan_queue.pop_next_if_active() {
                     trace!("calling plan at {:.6}", plan.time);
@@ -1430,7 +1430,7 @@ mod tests {
     }
 
     #[test]
-    fn passive_plans_at_final_active_time_run_across_phases() {
+    fn passive_plans_at_final_non_passive_time_run_across_phases() {
         let mut context = Context::new();
         add_passive_plan_with_phase(&mut context, 1.0, 1, ExecutionPhase::First);
         add_plan(&mut context, 1.0, 2);
@@ -1443,7 +1443,7 @@ mod tests {
     }
 
     #[test]
-    fn passive_future_plan_survives_until_later_active_work() {
+    fn passive_future_plan_survives_until_later_non_passive_work() {
         let mut context = Context::new();
         add_plan(&mut context, 1.0, 1);
         add_passive_plan(&mut context, 2.0, 2);
@@ -1576,7 +1576,7 @@ mod tests {
     #[test]
     fn periodic_plan_self_schedules() {
         // checks whether the periodic plan schedules itself passively without
-        // keeping execution alive after active plans are exhausted.
+        // keeping execution alive after non-passive plans are exhausted.
         let mut context = Context::new();
         context.add_periodic_plan_with_phase(
             1.0,

--- a/src/context.rs
+++ b/src/context.rs
@@ -304,6 +304,55 @@ impl Context {
         callback: impl FnOnce(&mut Context) + 'static,
         phase: ExecutionPhase,
     ) -> PlanId {
+        self.add_plan_with_phase_and_activity(time, callback, phase, true)
+    }
+
+    /// Add a passive plan to the future event list at the specified time in the
+    /// normal phase.
+    ///
+    /// Passive plans execute like regular plans but do not keep the simulation
+    /// timeline alive.
+    ///
+    /// Returns a [`PlanId`] for the newly-added plan that can be used to cancel it
+    /// if needed.
+    /// # Panics
+    ///
+    /// Panics if time is in the past, infinite, or NaN.
+    pub fn add_passive_plan(
+        &mut self,
+        time: f64,
+        callback: impl FnOnce(&mut Context) + 'static,
+    ) -> PlanId {
+        self.add_passive_plan_with_phase(time, callback, ExecutionPhase::Normal)
+    }
+
+    /// Add a passive plan to the future event list at the specified time and
+    /// with the specified phase.
+    ///
+    /// Passive plans execute like regular plans but do not keep the simulation
+    /// timeline alive.
+    ///
+    /// Returns a [`PlanId`] for the newly-added plan that can be used to cancel it
+    /// if needed.
+    /// # Panics
+    ///
+    /// Panics if time is in the past, infinite, or NaN.
+    pub fn add_passive_plan_with_phase(
+        &mut self,
+        time: f64,
+        callback: impl FnOnce(&mut Context) + 'static,
+        phase: ExecutionPhase,
+    ) -> PlanId {
+        self.add_plan_with_phase_and_activity(time, callback, phase, false)
+    }
+
+    fn add_plan_with_phase_and_activity(
+        &mut self,
+        time: f64,
+        callback: impl FnOnce(&mut Context) + 'static,
+        phase: ExecutionPhase,
+        is_active: bool,
+    ) -> PlanId {
         let current = self.get_current_time();
         assert!(!time.is_nan(), "Time {time} is invalid: cannot be NaN");
         assert!(
@@ -315,7 +364,8 @@ impl Context {
             "Time {time} is invalid: cannot be less than the current time ({}). Consider calling set_start_time() before scheduling plans.",
             current
         );
-        self.plan_queue.add_plan(time, Box::new(callback), phase)
+        self.plan_queue
+            .add_plan(time, Box::new(callback), phase, is_active)
     }
 
     /// Add a plan to execute during shutdown-time in the normal phase.
@@ -357,19 +407,22 @@ impl Context {
             period
         );
         callback(self);
-        if !self.plan_queue.is_empty() {
-            let next_time = self.get_current_time() + period;
-            self.add_plan_with_phase(
-                next_time,
-                move |context| context.evaluate_periodic_and_schedule_next(period, callback, phase),
-                phase,
-            );
-        }
+        let next_time = self.get_current_time() + period;
+        self.add_passive_plan_with_phase(
+            next_time,
+            move |context| context.evaluate_periodic_and_schedule_next(period, callback, phase),
+            phase,
+        );
     }
 
-    /// Add a plan with specified priority to the future event list, and
-    /// continuously repeat the plan at the specified period, stopping
-    /// only once there are no other plans scheduled.
+    /// Add a passive periodic plan with specified priority to the future event
+    /// list.
+    ///
+    /// Periodic plans reschedule themselves after every run. They do not keep
+    /// the simulation timeline alive: when no active plans remain, normal
+    /// shutdown begins, and only passive plans at the final current time can
+    /// still run during that execution pass. Future passive periodic plans
+    /// remain queued and may run if later active work is scheduled.
     ///
     /// Notes:
     /// * The first periodic plan is scheduled at time `0.0`. If `set_start_time` was
@@ -390,7 +443,7 @@ impl Context {
             "Period must be greater than 0"
         );
 
-        self.add_plan_with_phase(
+        self.add_passive_plan_with_phase(
             0.0,
             move |context| context.evaluate_periodic_and_schedule_next(period, callback, phase),
             phase,
@@ -409,12 +462,6 @@ impl Context {
         if result.is_none() {
             warn!("Tried to cancel nonexistent plan with ID = {plan_id:?}");
         }
-    }
-
-    #[doc(hidden)]
-    #[allow(dead_code)]
-    pub(crate) fn remaining_plan_count(&self) -> usize {
-        self.plan_queue.remaining_plan_count()
     }
 
     /// Add a `Callback` to the queue to be executed before the next plan
@@ -551,7 +598,8 @@ impl Context {
         self.start_time
     }
 
-    /// Execute the simulation until the plan and callback queues are empty
+    /// Execute the simulation until active plans are exhausted and shutdown
+    /// work is complete.
     pub fn execute(&mut self) {
         trace!("entering event loop");
 
@@ -600,14 +648,15 @@ impl Context {
         match self.shutdown_status {
             ShutdownStatus::None => {
                 // Normal execution may advance simulation time to the next
-                // regular plan. If no regular plans remain, natural completion
-                // transitions into shutdown-time plan execution.
-                if let Some(plan) = self.plan_queue.pop_next() {
+                // regular plan only while active regular work remains. Once no
+                // active regular plans remain, enter normal shutdown to drain
+                // current-time regular work without advancing time.
+                if let Some(plan) = self.plan_queue.pop_next_if_active() {
                     trace!("calling plan at {:.6}", plan.time);
                     self.current_time = Some(plan.time);
                     (plan.data)(self);
                 } else {
-                    self.shutdown_status = ShutdownStatus::ShutdownTimePlans;
+                    self.shutdown_status = ShutdownStatus::Normal;
                 }
             }
             ShutdownStatus::Normal => {
@@ -667,6 +716,17 @@ pub trait ContextBase: Sized {
         callback: impl FnOnce(&mut Context) + 'static,
         phase: ExecutionPhase,
     ) -> PlanId;
+    fn add_passive_plan(
+        &mut self,
+        time: f64,
+        callback: impl FnOnce(&mut Context) + 'static,
+    ) -> PlanId;
+    fn add_passive_plan_with_phase(
+        &mut self,
+        time: f64,
+        callback: impl FnOnce(&mut Context) + 'static,
+        phase: ExecutionPhase,
+    ) -> PlanId;
     fn add_shutdown_plan(&mut self, callback: impl FnOnce(&mut Context) + 'static) -> PlanId;
     fn add_shutdown_plan_with_phase(
         &mut self,
@@ -699,6 +759,8 @@ impl ContextBase for Context {
             fn emit_event<E: IxaEvent>(&mut self, event: E);
             fn add_plan(&mut self, time: f64, callback: impl FnOnce(&mut Context) + 'static) -> PlanId;
             fn add_plan_with_phase(&mut self, time: f64, callback: impl FnOnce(&mut Context) + 'static, phase: ExecutionPhase) -> PlanId;
+            fn add_passive_plan(&mut self, time: f64, callback: impl FnOnce(&mut Context) + 'static) -> PlanId;
+            fn add_passive_plan_with_phase(&mut self, time: f64, callback: impl FnOnce(&mut Context) + 'static, phase: ExecutionPhase) -> PlanId;
             fn add_shutdown_plan(&mut self, callback: impl FnOnce(&mut Context) + 'static) -> PlanId;
             fn add_shutdown_plan_with_phase(&mut self, callback: impl FnOnce(&mut Context) + 'static, phase: ExecutionPhase) -> PlanId;
             fn add_periodic_plan_with_phase(&mut self, period: f64, callback: impl Fn(&mut Context) + 'static, phase: ExecutionPhase);
@@ -780,6 +842,27 @@ mod tests {
         phase: ExecutionPhase,
     ) -> PlanId {
         context.add_plan_with_phase(
+            time,
+            move |context| {
+                context.get_data_mut(ComponentA).push(value);
+            },
+            phase,
+        )
+    }
+
+    fn add_passive_plan(context: &mut Context, time: f64, value: u32) -> PlanId {
+        context.add_passive_plan(time, move |context| {
+            context.get_data_mut(ComponentA).push(value);
+        })
+    }
+
+    fn add_passive_plan_with_phase(
+        context: &mut Context,
+        time: f64,
+        value: u32,
+        phase: ExecutionPhase,
+    ) -> PlanId {
+        context.add_passive_plan_with_phase(
             time,
             move |context| {
                 context.get_data_mut(ComponentA).push(value);
@@ -1335,6 +1418,49 @@ mod tests {
     }
 
     #[test]
+    fn passive_only_initial_time_runs_during_normal_shutdown() {
+        let mut context = Context::new();
+        add_passive_plan(&mut context, 0.0, 1);
+        add_passive_plan(&mut context, 1.0, 2);
+
+        context.execute();
+
+        assert_eq!(context.get_current_time(), 0.0);
+        assert_eq!(*context.get_data_mut(ComponentA), vec![1]);
+    }
+
+    #[test]
+    fn passive_plans_at_final_active_time_run_across_phases() {
+        let mut context = Context::new();
+        add_passive_plan_with_phase(&mut context, 1.0, 1, ExecutionPhase::First);
+        add_plan(&mut context, 1.0, 2);
+        add_passive_plan_with_phase(&mut context, 1.0, 3, ExecutionPhase::Last);
+
+        context.execute();
+
+        assert_eq!(context.get_current_time(), 1.0);
+        assert_eq!(*context.get_data_mut(ComponentA), vec![1, 2, 3]);
+    }
+
+    #[test]
+    fn passive_future_plan_survives_until_later_active_work() {
+        let mut context = Context::new();
+        add_plan(&mut context, 1.0, 1);
+        add_passive_plan(&mut context, 2.0, 2);
+
+        context.execute();
+
+        assert_eq!(context.get_current_time(), 1.0);
+        assert_eq!(*context.get_data_mut(ComponentA), vec![1]);
+
+        add_plan(&mut context, 2.0, 3);
+        context.execute();
+
+        assert_eq!(context.get_current_time(), 2.0);
+        assert_eq!(*context.get_data_mut(ComponentA), vec![1, 2, 3]);
+    }
+
+    #[test]
     fn cancel_plan_can_cancel_shutdown_plan() {
         let mut context = Context::new();
         let to_cancel = context.add_shutdown_plan(|context| {
@@ -1422,6 +1548,9 @@ mod tests {
         assert_eq!(*context.get_data_mut(ComponentA), Vec::<u32>::new());
 
         context.execute_single_step();
+        assert_eq!(*context.get_data_mut(ComponentA), Vec::<u32>::new());
+
+        context.execute_single_step();
         assert_eq!(*context.get_data_mut(ComponentA), vec![1]);
     }
 
@@ -1446,8 +1575,8 @@ mod tests {
 
     #[test]
     fn periodic_plan_self_schedules() {
-        // checks whether the person properties report schedules itself
-        // based on whether there are plans in the queue
+        // checks whether the periodic plan schedules itself passively without
+        // keeping execution alive after active plans are exhausted.
         let mut context = Context::new();
         context.add_periodic_plan_with_phase(
             1.0,
@@ -1460,9 +1589,9 @@ mod tests {
         context.add_plan(1.0, move |_context| {});
         context.add_plan(1.5, move |_context| {});
         context.execute();
-        assert_eq!(context.get_current_time(), 2.0);
+        assert_eq!(context.get_current_time(), 1.5);
 
-        assert_eq!(*context.get_data(ComponentA), vec![0, 1, 2]); // time 0.0, 1.0, and 2.0
+        assert_eq!(*context.get_data(ComponentA), vec![0, 1]); // time 0.0 and 1.0
     }
 
     // Tests for negative time handling

--- a/src/entity/context_extension.rs
+++ b/src/entity/context_extension.rs
@@ -76,12 +76,8 @@ fn handle_periodic_value_change_count_event<E, PL, P, F>(
         let _ = std::mem::replace(slot.get_mut(), counter);
     }
 
-    if context.remaining_plan_count() == 0 {
-        return;
-    }
-
     let next_time = context.get_current_time() + period;
-    context.add_plan_with_phase(
+    context.add_passive_plan_with_phase(
         next_time,
         move |context| {
             handle_periodic_value_change_count_event::<E, PL, P, F>(
@@ -135,9 +131,11 @@ pub trait ContextEntitiesExt {
     /// Also panics if `period` is not finite and strictly positive.
     ///
     /// Recording starts at `ExecutionPhase::First` at simulation start time. The
-    /// first report runs at simulation start time in `ExecutionPhase::Last`, then at
-    /// each subsequent `start_time + k * period`. After the handler returns, the
-    /// matched counter is cleared.
+    /// report callbacks are passive plans: they do not keep the simulation
+    /// timeline alive. Reports run at simulation start time in
+    /// `ExecutionPhase::Last`, then at each subsequent `start_time + k * period`
+    /// that is reached while active work remains or during final-time shutdown.
+    /// After the handler returns, the matched counter is cleared.
     ///
     /// ```rust,ignore
     /// context.track_periodic_value_change_counts::<Person, (InfectionStatus,), Age>(
@@ -409,7 +407,7 @@ impl ContextEntitiesExt for Context {
 
                 // We defer the first handler plan until now because it needs
                 // `counter_id`, and it must run in `ExecutionPhase::Last`.
-                context.add_plan_with_phase(
+                context.add_passive_plan_with_phase(
                     context.get_current_time(),
                     move |context| {
                         handle_periodic_value_change_count_event::<E, PL, P, F>(
@@ -1437,6 +1435,7 @@ mod tests {
             context.set_property(person, CounterValue(1));
             context.set_property(person, CounterValue(2));
         });
+        context.add_plan(1.0, |_| {});
 
         context.execute();
         assert_eq!(*observed.borrow(), vec![(0, 0), (1, 1)]);
@@ -1469,6 +1468,7 @@ mod tests {
         context.add_plan(1.5, move |context| {
             context.set_property(person, CounterValue(1));
         });
+        context.add_plan(2.0, |_| {});
 
         context.execute();
         assert_eq!(*observed.borrow(), vec![0, 1, 0]);

--- a/src/entity/context_extension.rs
+++ b/src/entity/context_extension.rs
@@ -134,7 +134,7 @@ pub trait ContextEntitiesExt {
     /// report callbacks are passive plans: they do not keep the simulation
     /// timeline alive. Reports run at simulation start time in
     /// `ExecutionPhase::Last`, then at each subsequent `start_time + k * period`
-    /// that is reached while active work remains or during final-time shutdown.
+    /// that is reached while (non-passive) work remains or during final-time shutdown.
     /// After the handler returns, the matched counter is cleared.
     ///
     /// ```rust,ignore

--- a/src/plan_queue.rs
+++ b/src/plan_queue.rs
@@ -13,6 +13,11 @@ use crate::{trace, HashMap, HashMapExt};
 type Callback = dyn FnOnce(&mut Context);
 type BoxedCallback = Box<Callback>;
 
+struct QueuedPlan {
+    callback: BoxedCallback,
+    is_active: bool,
+}
+
 /// A priority queue that stores scheduled plans.
 ///
 /// Regular plans are ordered by simulation time, execution phase, and plan ID.
@@ -21,7 +26,8 @@ type BoxedCallback = Box<Callback>;
 pub(crate) struct PlanQueue {
     queue: BinaryHeap<PlanSchedule>,
     shutdown_queue: BinaryHeap<PlanSchedule>,
-    data_map: HashMap<u64, BoxedCallback>,
+    data_map: HashMap<u64, QueuedPlan>,
+    active_plan_count: usize,
     /// The next plan ID that will be issued.
     next_plan_id: u64,
     /// Tracks the high water mark of plans in flight (scheduled but not yet executed).
@@ -40,6 +46,7 @@ impl PlanQueue {
             queue: BinaryHeap::new(),
             shutdown_queue: BinaryHeap::new(),
             data_map: HashMap::new(),
+            active_plan_count: 0,
             next_plan_id: 0,
             #[cfg(feature = "profiling")]
             max_plans_in_flight: 0,
@@ -57,6 +64,7 @@ impl PlanQueue {
         time: f64,
         callback: BoxedCallback,
         phase: ExecutionPhase,
+        is_active: bool,
     ) -> PlanId {
         trace!("adding plan at {time}");
         let plan_id = self.next_plan_id;
@@ -65,7 +73,16 @@ impl PlanQueue {
             time,
             phase,
         });
-        self.data_map.insert(plan_id, callback);
+        self.data_map.insert(
+            plan_id,
+            QueuedPlan {
+                callback,
+                is_active,
+            },
+        );
+        if is_active {
+            self.active_plan_count += 1;
+        }
         self.next_plan_id += 1;
         self.update_profiling_high_water_marks();
 
@@ -88,7 +105,13 @@ impl PlanQueue {
             time: 0.0,
             phase,
         });
-        self.data_map.insert(plan_id, callback);
+        self.data_map.insert(
+            plan_id,
+            QueuedPlan {
+                callback,
+                is_active: false,
+            },
+        );
         self.next_plan_id += 1;
         self.update_profiling_high_water_marks();
 
@@ -100,26 +123,26 @@ impl PlanQueue {
         trace!("cancel plan {plan_id:?}");
         // Delete the plan from the map, but leave in the heap. It will be skipped
         // when its heap entry reaches the root.
-        self.data_map.remove(&plan_id.0)
-    }
-
-    #[must_use]
-    pub(crate) fn is_empty(&mut self) -> bool {
-        self.next_time().is_none()
+        self.data_map.remove(&plan_id.0).map(|queued_plan| {
+            if queued_plan.is_active {
+                self.active_plan_count -= 1;
+            }
+            queued_plan.callback
+        })
     }
 
     /// Return the time the next plan is scheduled for, if there is one.
     #[must_use]
     pub(crate) fn next_time(&mut self) -> Option<f64> {
-        // First trim any cancelled plans. We want the time of the next legitimate plan.
-        while self
-            .queue
-            .peek()
-            .is_some_and(|entry| !self.data_map.contains_key(&entry.plan_id))
-        {
+        while let Some(entry) = self.queue.peek() {
+            // We only want to report the time if the plan has not been canceled.
+            if self.data_map.contains_key(&entry.plan_id) {
+                return Some(entry.time);
+            }
+            // Trim the canceled plan.
             self.queue.pop();
         }
-        self.queue.peek().map(|e| e.time)
+        None
     }
 
     /// Completely empties the queue, including the plans scheduled at shutdown time.
@@ -128,23 +151,40 @@ impl PlanQueue {
         self.data_map.clear();
         self.queue.clear();
         self.shutdown_queue.clear();
+        self.active_plan_count = 0;
         self.next_plan_id = 0;
     }
 
-    /// Retrieve the earliest regular plan in the queue.
+    /// Retrieve the earliest regular plan only if at least one active regular
+    /// plan is scheduled.
     ///
-    /// Returns the next plan if it exists or else `None` if the regular queue is
-    /// empty.
-    pub(crate) fn pop_next(&mut self) -> Option<Plan> {
+    /// The active-plan check controls whether normal execution may continue.
+    /// The returned plan is simply the next regular plan by time, phase, and
+    /// plan ID; it may be active or passive. If no live active regular plan is
+    /// scheduled, this returns `None` without removing passive plans from the
+    /// regular queue.
+    pub(crate) fn pop_next_if_active(&mut self) -> Option<Plan> {
+        if self.active_plan_count == 0 {
+            return None;
+        }
+
         trace!("getting next plan");
         loop {
-            // Return `None` if `pop` fails.
-            let entry = self.queue.pop()?;
+            // The `pop` should be infallible when the active plan count is positive unless the
+            // queue invariants have been violated.
+            let entry = self
+                .queue
+                .pop()
+                .expect("active plan count was positive but no regular plan was available");
+
             // Discard any cancelled plans we encounter.
-            if let Some(data) = self.data_map.remove(&entry.plan_id) {
+            if let Some(queued_plan) = self.data_map.remove(&entry.plan_id) {
+                if queued_plan.is_active {
+                    self.active_plan_count -= 1;
+                }
                 return Some(Plan {
                     time: entry.time,
-                    data,
+                    data: queued_plan.callback,
                 });
             }
         }
@@ -164,14 +204,18 @@ impl PlanQueue {
 
                 // Return only if the plan is scheduled for the given time
                 Some(entry) if entry.time == time => {
-                    let entry = self.queue.pop().expect("peeked entry must exist");
-                    let data = self
+                    // Pop is infallible here.
+                    let entry = self.queue.pop().unwrap();
+                    let queued_plan = self
                         .data_map
                         .remove(&entry.plan_id)
                         .expect("live plan must have callback");
+                    if queued_plan.is_active {
+                        self.active_plan_count -= 1;
+                    }
                     return Some(Plan {
-                        time: entry.time,
-                        data,
+                        time,
+                        data: queued_plan.callback,
                     });
                 }
 
@@ -187,23 +231,18 @@ impl PlanQueue {
     /// shutdown-time queue is empty.
     pub(crate) fn pop_next_shutdown(&mut self) -> Option<Plan> {
         trace!("getting next shutdown-time plan");
-        loop {
-            // Return `None` if `pop` fails.
-            let entry = self.shutdown_queue.pop()?;
-            // Discard any cancelled plans we encounter.
-            if let Some(data) = self.data_map.remove(&entry.plan_id) {
-                return Some(Plan {
-                    time: entry.time,
-                    data,
-                });
+        std::iter::from_fn(|| self.shutdown_queue.pop()).find_map(|entry| {
+            // If there's no `data_map` entry, the plan has been canceled, so discard
+            // and pop another plan.
+            let queued_plan = self.data_map.remove(&entry.plan_id)?;
+            if queued_plan.is_active {
+                self.active_plan_count -= 1;
             }
-        }
-    }
-
-    #[doc(hidden)]
-    /// Reports the count of remaining plans, excluding shutdown-time plans.
-    pub(crate) fn remaining_plan_count(&self) -> usize {
-        self.queue.len()
+            Some(Plan {
+                time: entry.time,
+                data: queued_plan.callback,
+            })
+        })
     }
 
     fn update_profiling_high_water_marks(&mut self) {
@@ -222,7 +261,7 @@ impl PlanQueue {
         let queue_bytes =
             (self.queue.capacity() + self.shutdown_queue.capacity()) * size_of::<PlanSchedule>();
 
-        let map_entry_bytes = self.data_map.capacity() * size_of::<(u64, BoxedCallback)>();
+        let map_entry_bytes = self.data_map.capacity() * size_of::<(u64, QueuedPlan)>();
 
         queue_bytes + map_entry_bytes
     }
@@ -301,7 +340,7 @@ mod tests {
     #[test]
     fn empty_queue() {
         let mut plan_queue = PlanQueue::new();
-        assert!(plan_queue.pop_next().is_none());
+        assert!(plan_queue.pop_next_if_active().is_none());
     }
 
     #[test]
@@ -313,34 +352,37 @@ mod tests {
             1.0,
             callback(1, Rc::clone(&observed)),
             ExecutionPhase::Normal,
+            true,
         );
         plan_queue.add_plan(
             3.0,
             callback(3, Rc::clone(&observed)),
             ExecutionPhase::Normal,
+            true,
         );
         plan_queue.add_plan(
             2.0,
             callback(2, Rc::clone(&observed)),
             ExecutionPhase::Normal,
+            true,
         );
-        assert!(!plan_queue.is_empty());
+        assert_eq!(plan_queue.next_time(), Some(1.0));
 
-        let next_plan = plan_queue.pop_next().unwrap();
+        let next_plan = plan_queue.pop_next_if_active().unwrap();
         assert_eq!(next_plan.time, 1.0);
         run_plan(next_plan, &mut context);
 
-        assert!(!plan_queue.is_empty());
-        let next_plan = plan_queue.pop_next().unwrap();
+        assert_eq!(plan_queue.next_time(), Some(2.0));
+        let next_plan = plan_queue.pop_next_if_active().unwrap();
         assert_eq!(next_plan.time, 2.0);
         run_plan(next_plan, &mut context);
 
-        assert!(!plan_queue.is_empty());
-        let next_plan = plan_queue.pop_next().unwrap();
+        assert_eq!(plan_queue.next_time(), Some(3.0));
+        let next_plan = plan_queue.pop_next_if_active().unwrap();
         assert_eq!(next_plan.time, 3.0);
         run_plan(next_plan, &mut context);
 
-        assert!(plan_queue.pop_next().is_none());
+        assert!(plan_queue.pop_next_if_active().is_none());
         assert_eq!(*observed.borrow(), vec![1, 2, 3]);
     }
 
@@ -353,21 +395,23 @@ mod tests {
             1.0,
             callback(1, Rc::clone(&observed)),
             ExecutionPhase::Normal,
+            true,
         );
         plan_queue.add_plan(
             1.0,
             callback(2, Rc::clone(&observed)),
             ExecutionPhase::Normal,
+            true,
         );
 
-        let next_plan = plan_queue.pop_next().unwrap();
+        let next_plan = plan_queue.pop_next_if_active().unwrap();
         assert_eq!(next_plan.time, 1.0);
         run_plan(next_plan, &mut context);
-        let next_plan = plan_queue.pop_next().unwrap();
+        let next_plan = plan_queue.pop_next_if_active().unwrap();
         assert_eq!(next_plan.time, 1.0);
         run_plan(next_plan, &mut context);
 
-        assert!(plan_queue.pop_next().is_none());
+        assert!(plan_queue.pop_next_if_active().is_none());
         assert_eq!(*observed.borrow(), vec![1, 2]);
     }
 
@@ -380,21 +424,23 @@ mod tests {
             1.0,
             callback(1, Rc::clone(&observed)),
             ExecutionPhase::Normal,
+            true,
         );
         plan_queue.add_plan(
             1.0,
             callback(2, Rc::clone(&observed)),
             ExecutionPhase::First,
+            true,
         );
 
-        let next_plan = plan_queue.pop_next().unwrap();
+        let next_plan = plan_queue.pop_next_if_active().unwrap();
         assert_eq!(next_plan.time, 1.0);
         run_plan(next_plan, &mut context);
-        let next_plan = plan_queue.pop_next().unwrap();
+        let next_plan = plan_queue.pop_next_if_active().unwrap();
         assert_eq!(next_plan.time, 1.0);
         run_plan(next_plan, &mut context);
 
-        assert!(plan_queue.pop_next().is_none());
+        assert!(plan_queue.pop_next_if_active().is_none());
         assert_eq!(*observed.borrow(), vec![2, 1]);
     }
 
@@ -407,29 +453,119 @@ mod tests {
             1.0,
             callback(1, Rc::clone(&observed)),
             ExecutionPhase::Normal,
+            true,
         );
         let plan_to_cancel = plan_queue.add_plan(
             2.0,
             callback(2, Rc::clone(&observed)),
             ExecutionPhase::Normal,
+            true,
         );
         plan_queue.add_plan(
             3.0,
             callback(3, Rc::clone(&observed)),
             ExecutionPhase::Normal,
+            true,
         );
         plan_queue.cancel_plan(&plan_to_cancel);
 
-        let next_plan = plan_queue.pop_next().unwrap();
+        let next_plan = plan_queue.pop_next_if_active().unwrap();
         assert_eq!(next_plan.time, 1.0);
         run_plan(next_plan, &mut context);
 
-        let next_plan = plan_queue.pop_next().unwrap();
+        let next_plan = plan_queue.pop_next_if_active().unwrap();
         assert_eq!(next_plan.time, 3.0);
         run_plan(next_plan, &mut context);
 
-        assert!(plan_queue.pop_next().is_none());
+        assert!(plan_queue.pop_next_if_active().is_none());
         assert_eq!(*observed.borrow(), vec![1, 3]);
+    }
+
+    #[test]
+    fn passive_only_plans_do_not_pop_during_active_execution() {
+        let observed = Rc::new(RefCell::new(Vec::new()));
+        let mut plan_queue = PlanQueue::new();
+        plan_queue.add_plan(
+            1.0,
+            callback(1, Rc::clone(&observed)),
+            ExecutionPhase::Normal,
+            false,
+        );
+
+        assert_eq!(plan_queue.active_plan_count, 0);
+        assert!(plan_queue.pop_next_if_active().is_none());
+        assert_eq!(plan_queue.next_time(), Some(1.0));
+        assert!(observed.borrow().is_empty());
+    }
+
+    #[test]
+    fn passive_plan_can_pop_before_later_active_plan() {
+        let observed = Rc::new(RefCell::new(Vec::new()));
+        let mut context = Context::new();
+        let mut plan_queue = PlanQueue::new();
+        plan_queue.add_plan(
+            1.0,
+            callback(1, Rc::clone(&observed)),
+            ExecutionPhase::Normal,
+            false,
+        );
+        plan_queue.add_plan(
+            2.0,
+            callback(2, Rc::clone(&observed)),
+            ExecutionPhase::Normal,
+            true,
+        );
+
+        assert_eq!(plan_queue.active_plan_count, 1);
+        let next_plan = plan_queue.pop_next_if_active().unwrap();
+        assert_eq!(next_plan.time, 1.0);
+        run_plan(next_plan, &mut context);
+        assert_eq!(plan_queue.active_plan_count, 1);
+
+        let next_plan = plan_queue.pop_next_if_active().unwrap();
+        assert_eq!(next_plan.time, 2.0);
+        run_plan(next_plan, &mut context);
+        assert_eq!(plan_queue.active_plan_count, 0);
+
+        assert_eq!(*observed.borrow(), vec![1, 2]);
+    }
+
+    #[test]
+    fn canceling_active_plan_decrements_active_count() {
+        let observed = Rc::new(RefCell::new(Vec::new()));
+        let mut plan_queue = PlanQueue::new();
+        let active = plan_queue.add_plan(
+            1.0,
+            callback(1, Rc::clone(&observed)),
+            ExecutionPhase::Normal,
+            true,
+        );
+        let passive = plan_queue.add_plan(
+            2.0,
+            callback(2, Rc::clone(&observed)),
+            ExecutionPhase::Normal,
+            false,
+        );
+
+        assert_eq!(plan_queue.active_plan_count, 1);
+        plan_queue.cancel_plan(&passive);
+        assert_eq!(plan_queue.active_plan_count, 1);
+        plan_queue.cancel_plan(&active);
+        assert_eq!(plan_queue.active_plan_count, 0);
+    }
+
+    #[test]
+    fn shutdown_plans_do_not_affect_active_count() {
+        let observed = Rc::new(RefCell::new(Vec::new()));
+        let mut context = Context::new();
+        let mut plan_queue = PlanQueue::new();
+        plan_queue.add_shutdown_plan(callback(1, Rc::clone(&observed)), ExecutionPhase::Normal);
+
+        assert_eq!(plan_queue.active_plan_count, 0);
+        let next_plan = plan_queue.pop_next_shutdown().unwrap();
+        run_plan(next_plan, &mut context);
+        assert_eq!(plan_queue.active_plan_count, 0);
+        assert_eq!(*observed.borrow(), vec![1]);
     }
 
     #[test]
@@ -440,11 +576,13 @@ mod tests {
             1.0,
             callback(1, Rc::clone(&observed)),
             ExecutionPhase::Normal,
+            true,
         );
         plan_queue.add_plan(
             2.0,
             callback(2, Rc::clone(&observed)),
             ExecutionPhase::Normal,
+            true,
         );
 
         plan_queue.cancel_plan(&plan_to_cancel);
@@ -461,11 +599,12 @@ mod tests {
             2.0,
             callback(2, Rc::clone(&observed)),
             ExecutionPhase::Normal,
+            true,
         );
 
         assert!(plan_queue.pop_next_at(1.0).is_none());
 
-        let next_plan = plan_queue.pop_next().unwrap();
+        let next_plan = plan_queue.pop_next_if_active().unwrap();
         assert_eq!(next_plan.time, 2.0);
         run_plan(next_plan, &mut context);
         assert_eq!(*observed.borrow(), vec![2]);
@@ -496,6 +635,7 @@ mod tests {
             1.0,
             callback(1, Rc::clone(&observed)),
             ExecutionPhase::Normal,
+            true,
         );
         let shutdown_id =
             plan_queue.add_shutdown_plan(callback(2, Rc::clone(&observed)), ExecutionPhase::Normal);

--- a/src/plan_queue.rs
+++ b/src/plan_queue.rs
@@ -15,7 +15,7 @@ type BoxedCallback = Box<Callback>;
 
 struct QueuedPlan {
     callback: BoxedCallback,
-    is_active: bool,
+    is_passive: bool,
 }
 
 /// A priority queue that stores scheduled plans.
@@ -27,7 +27,8 @@ pub(crate) struct PlanQueue {
     queue: BinaryHeap<PlanSchedule>,
     shutdown_queue: BinaryHeap<PlanSchedule>,
     data_map: HashMap<u64, QueuedPlan>,
-    active_plan_count: usize,
+    /// Count of scheduled plans excluding passive and shutdown-time plans.
+    regular_plan_count: usize,
     /// The next plan ID that will be issued.
     next_plan_id: u64,
     /// Tracks the high water mark of plans in flight (scheduled but not yet executed).
@@ -46,7 +47,7 @@ impl PlanQueue {
             queue: BinaryHeap::new(),
             shutdown_queue: BinaryHeap::new(),
             data_map: HashMap::new(),
-            active_plan_count: 0,
+            regular_plan_count: 0,
             next_plan_id: 0,
             #[cfg(feature = "profiling")]
             max_plans_in_flight: 0,
@@ -64,7 +65,7 @@ impl PlanQueue {
         time: f64,
         callback: BoxedCallback,
         phase: ExecutionPhase,
-        is_active: bool,
+        is_passive: bool,
     ) -> PlanId {
         trace!("adding plan at {time}");
         let plan_id = self.next_plan_id;
@@ -77,11 +78,11 @@ impl PlanQueue {
             plan_id,
             QueuedPlan {
                 callback,
-                is_active,
+                is_passive,
             },
         );
-        if is_active {
-            self.active_plan_count += 1;
+        if !is_passive {
+            self.regular_plan_count += 1;
         }
         self.next_plan_id += 1;
         self.update_profiling_high_water_marks();
@@ -109,7 +110,7 @@ impl PlanQueue {
             plan_id,
             QueuedPlan {
                 callback,
-                is_active: false,
+                is_passive: true,
             },
         );
         self.next_plan_id += 1;
@@ -124,8 +125,8 @@ impl PlanQueue {
         // Delete the plan from the map, but leave in the heap. It will be skipped
         // when its heap entry reaches the root.
         self.data_map.remove(&plan_id.0).map(|queued_plan| {
-            if queued_plan.is_active {
-                self.active_plan_count -= 1;
+            if !queued_plan.is_passive {
+                self.regular_plan_count -= 1;
             }
             queued_plan.callback
         })
@@ -151,36 +152,35 @@ impl PlanQueue {
         self.data_map.clear();
         self.queue.clear();
         self.shutdown_queue.clear();
-        self.active_plan_count = 0;
+        self.regular_plan_count = 0;
         self.next_plan_id = 0;
     }
 
-    /// Retrieve the earliest regular plan only if at least one active regular
-    /// plan is scheduled.
+    /// Retrieve the earliest regular plan only if the regular queue is active.
     ///
-    /// The active-plan check controls whether normal execution may continue.
-    /// The returned plan is simply the next regular plan by time, phase, and
-    /// plan ID; it may be active or passive. If no live active regular plan is
-    /// scheduled, this returns `None` without removing passive plans from the
-    /// regular queue.
+    /// The queue is active while at least one non-passive regular plan is
+    /// scheduled. The returned plan is simply the next regular plan by time,
+    /// phase, and plan ID; it may be passive. If no live non-passive regular
+    /// plan is scheduled, this returns `None` without removing passive plans
+    /// from the regular queue.
     pub(crate) fn pop_next_if_active(&mut self) -> Option<Plan> {
-        if self.active_plan_count == 0 {
+        if self.regular_plan_count == 0 {
             return None;
         }
 
         trace!("getting next plan");
         loop {
-            // The `pop` should be infallible when the active plan count is positive unless the
+            // The `pop` should be infallible when the plan count is positive unless the
             // queue invariants have been violated.
             let entry = self
                 .queue
                 .pop()
-                .expect("active plan count was positive but no regular plan was available");
+                .expect("plan count was positive but no plan was available");
 
             // Discard any cancelled plans we encounter.
             if let Some(queued_plan) = self.data_map.remove(&entry.plan_id) {
-                if queued_plan.is_active {
-                    self.active_plan_count -= 1;
+                if !queued_plan.is_passive {
+                    self.regular_plan_count -= 1;
                 }
                 return Some(Plan {
                     time: entry.time,
@@ -210,8 +210,8 @@ impl PlanQueue {
                         .data_map
                         .remove(&entry.plan_id)
                         .expect("live plan must have callback");
-                    if queued_plan.is_active {
-                        self.active_plan_count -= 1;
+                    if !queued_plan.is_passive {
+                        self.regular_plan_count -= 1;
                     }
                     return Some(Plan {
                         time,
@@ -235,8 +235,8 @@ impl PlanQueue {
             // If there's no `data_map` entry, the plan has been canceled, so discard
             // and pop another plan.
             let queued_plan = self.data_map.remove(&entry.plan_id)?;
-            if queued_plan.is_active {
-                self.active_plan_count -= 1;
+            if !queued_plan.is_passive {
+                self.regular_plan_count -= 1;
             }
             Some(Plan {
                 time: entry.time,
@@ -352,19 +352,19 @@ mod tests {
             1.0,
             callback(1, Rc::clone(&observed)),
             ExecutionPhase::Normal,
-            true,
+            false,
         );
         plan_queue.add_plan(
             3.0,
             callback(3, Rc::clone(&observed)),
             ExecutionPhase::Normal,
-            true,
+            false,
         );
         plan_queue.add_plan(
             2.0,
             callback(2, Rc::clone(&observed)),
             ExecutionPhase::Normal,
-            true,
+            false,
         );
         assert_eq!(plan_queue.next_time(), Some(1.0));
 
@@ -395,13 +395,13 @@ mod tests {
             1.0,
             callback(1, Rc::clone(&observed)),
             ExecutionPhase::Normal,
-            true,
+            false,
         );
         plan_queue.add_plan(
             1.0,
             callback(2, Rc::clone(&observed)),
             ExecutionPhase::Normal,
-            true,
+            false,
         );
 
         let next_plan = plan_queue.pop_next_if_active().unwrap();
@@ -424,13 +424,13 @@ mod tests {
             1.0,
             callback(1, Rc::clone(&observed)),
             ExecutionPhase::Normal,
-            true,
+            false,
         );
         plan_queue.add_plan(
             1.0,
             callback(2, Rc::clone(&observed)),
             ExecutionPhase::First,
-            true,
+            false,
         );
 
         let next_plan = plan_queue.pop_next_if_active().unwrap();
@@ -453,19 +453,19 @@ mod tests {
             1.0,
             callback(1, Rc::clone(&observed)),
             ExecutionPhase::Normal,
-            true,
+            false,
         );
         let plan_to_cancel = plan_queue.add_plan(
             2.0,
             callback(2, Rc::clone(&observed)),
             ExecutionPhase::Normal,
-            true,
+            false,
         );
         plan_queue.add_plan(
             3.0,
             callback(3, Rc::clone(&observed)),
             ExecutionPhase::Normal,
-            true,
+            false,
         );
         plan_queue.cancel_plan(&plan_to_cancel);
 
@@ -489,17 +489,17 @@ mod tests {
             1.0,
             callback(1, Rc::clone(&observed)),
             ExecutionPhase::Normal,
-            false,
+            true,
         );
 
-        assert_eq!(plan_queue.active_plan_count, 0);
+        assert_eq!(plan_queue.regular_plan_count, 0);
         assert!(plan_queue.pop_next_if_active().is_none());
         assert_eq!(plan_queue.next_time(), Some(1.0));
         assert!(observed.borrow().is_empty());
     }
 
     #[test]
-    fn passive_plan_can_pop_before_later_active_plan() {
+    fn passive_plan_can_pop_before_later_non_passive_plan() {
         let observed = Rc::new(RefCell::new(Vec::new()));
         let mut context = Context::new();
         let mut plan_queue = PlanQueue::new();
@@ -507,64 +507,64 @@ mod tests {
             1.0,
             callback(1, Rc::clone(&observed)),
             ExecutionPhase::Normal,
-            false,
+            true,
         );
         plan_queue.add_plan(
             2.0,
             callback(2, Rc::clone(&observed)),
             ExecutionPhase::Normal,
-            true,
+            false,
         );
 
-        assert_eq!(plan_queue.active_plan_count, 1);
+        assert_eq!(plan_queue.regular_plan_count, 1);
         let next_plan = plan_queue.pop_next_if_active().unwrap();
         assert_eq!(next_plan.time, 1.0);
         run_plan(next_plan, &mut context);
-        assert_eq!(plan_queue.active_plan_count, 1);
+        assert_eq!(plan_queue.regular_plan_count, 1);
 
         let next_plan = plan_queue.pop_next_if_active().unwrap();
         assert_eq!(next_plan.time, 2.0);
         run_plan(next_plan, &mut context);
-        assert_eq!(plan_queue.active_plan_count, 0);
+        assert_eq!(plan_queue.regular_plan_count, 0);
 
         assert_eq!(*observed.borrow(), vec![1, 2]);
     }
 
     #[test]
-    fn canceling_active_plan_decrements_active_count() {
+    fn canceling_non_passive_plan_decrements_regular_count() {
         let observed = Rc::new(RefCell::new(Vec::new()));
         let mut plan_queue = PlanQueue::new();
-        let active = plan_queue.add_plan(
+        let non_passive = plan_queue.add_plan(
             1.0,
             callback(1, Rc::clone(&observed)),
             ExecutionPhase::Normal,
-            true,
+            false,
         );
         let passive = plan_queue.add_plan(
             2.0,
             callback(2, Rc::clone(&observed)),
             ExecutionPhase::Normal,
-            false,
+            true,
         );
 
-        assert_eq!(plan_queue.active_plan_count, 1);
+        assert_eq!(plan_queue.regular_plan_count, 1);
         plan_queue.cancel_plan(&passive);
-        assert_eq!(plan_queue.active_plan_count, 1);
-        plan_queue.cancel_plan(&active);
-        assert_eq!(plan_queue.active_plan_count, 0);
+        assert_eq!(plan_queue.regular_plan_count, 1);
+        plan_queue.cancel_plan(&non_passive);
+        assert_eq!(plan_queue.regular_plan_count, 0);
     }
 
     #[test]
-    fn shutdown_plans_do_not_affect_active_count() {
+    fn shutdown_plans_do_not_affect_regular_count() {
         let observed = Rc::new(RefCell::new(Vec::new()));
         let mut context = Context::new();
         let mut plan_queue = PlanQueue::new();
         plan_queue.add_shutdown_plan(callback(1, Rc::clone(&observed)), ExecutionPhase::Normal);
 
-        assert_eq!(plan_queue.active_plan_count, 0);
+        assert_eq!(plan_queue.regular_plan_count, 0);
         let next_plan = plan_queue.pop_next_shutdown().unwrap();
         run_plan(next_plan, &mut context);
-        assert_eq!(plan_queue.active_plan_count, 0);
+        assert_eq!(plan_queue.regular_plan_count, 0);
         assert_eq!(*observed.borrow(), vec![1]);
     }
 
@@ -576,13 +576,13 @@ mod tests {
             1.0,
             callback(1, Rc::clone(&observed)),
             ExecutionPhase::Normal,
-            true,
+            false,
         );
         plan_queue.add_plan(
             2.0,
             callback(2, Rc::clone(&observed)),
             ExecutionPhase::Normal,
-            true,
+            false,
         );
 
         plan_queue.cancel_plan(&plan_to_cancel);
@@ -599,7 +599,7 @@ mod tests {
             2.0,
             callback(2, Rc::clone(&observed)),
             ExecutionPhase::Normal,
-            true,
+            false,
         );
 
         assert!(plan_queue.pop_next_at(1.0).is_none());
@@ -635,7 +635,7 @@ mod tests {
             1.0,
             callback(1, Rc::clone(&observed)),
             ExecutionPhase::Normal,
-            true,
+            false,
         );
         let shutdown_id =
             plan_queue.add_shutdown_plan(callback(2, Rc::clone(&observed)), ExecutionPhase::Normal);

--- a/src/plugin_context.rs
+++ b/src/plugin_context.rs
@@ -76,6 +76,16 @@ mod test_plugin_context {
             self.add_plan(1.0, |context| {
                 assert_eq!(context.get_my_data(), 42);
             });
+            self.add_passive_plan(1.0, |context| {
+                assert_eq!(context.get_my_data(), 42);
+            });
+            self.add_passive_plan_with_phase(
+                1.0,
+                |context| {
+                    assert_eq!(context.get_my_data(), 100);
+                },
+                crate::ExecutionPhase::Last,
+            );
             self.add_periodic_plan_with_phase(
                 1.0,
                 |context| {


### PR DESCRIPTION
The event loop includes a built-in stop condition in which "normal shutdown" is triggered if the regular plan queue is exhausted. This PR introduces a distinction between "active" and "passive" plans and modifies this stop condition so that normal shutdown is triggered if there are no more _active_ plans in the regular plan queue.

This is motivated by the fact that self-rescheduling periodic plans will always keep the event loop alive indefinitely, making the built-in "exhausted plan queue" stop condition unusable for all but the simplest toy models.

**Out of scope:**
- We should add an Ixa Book topic chapter on "Execution and Shutdown" in a separate PR.
- Shutdown semantics, in particular what happens when "normal shutdown" is triggered, belongs to #976 upon which this PR is stacked.
- We don't address primitives / convenience methods for constructing self-rescheduling plans directly in this PR except to modify the two existing mechanisms so they create passive plans. Whether we want better helpers or what they would be is out of scope for this PR.

## Public API

- Existing `add_plan` and `add_plan_with_phase` APIs remain _active_—they keep the simulation timeline alive. 
- New `add_passive_plan` and `add_passive_plan_with_phase` APIs schedule normal timed _passive_ plans that participate in the same time, phase, and FIFO ordering, but do not prevent shutdown once _active_ work is exhausted.
- `add_periodic_plan_with_phase` is now _passive plan only_, as it's plans are by definition perpetually self-rescheduling.
- Value-change count handlers registered with `track_periodic_value_change_counts` are implicitly self-rescheduling and are thus also now passive.

---

This PR is stacked on top of #976.