### PR TITLE
fix: Fix ambiguous `IxaEvent` import in `triggers` doc tests

### DIFF
--- a/src/triggers/entity_count.rs
+++ b/src/triggers/entity_count.rs
@@ -40,7 +40,6 @@
 //! use ixa::{Context, ContextEntitiesExt, define_entity, IxaEvent};
 //! use ixa::entity::EntityId;
 //! use ixa::triggers::{ContextTriggersExt, EntityCountTrigger, TriggerCriterion};
-//! use ixa_derive::IxaEvent;
 //!
 //! define_entity!(Case);
 //!

--- a/src/triggers/mod.rs
+++ b/src/triggers/mod.rs
@@ -55,7 +55,6 @@
 //! use ixa::{Context, define_entity, define_property, IxaEvent};
 //! use ixa::entity::EntityId;
 //! use ixa::triggers::{ContextTriggersExt, PropertyChangeTrigger, TriggerCriterion};
-//! use ixa_derive::IxaEvent;
 //!
 //! define_entity!(Person);
 //! define_property!(struct Alive(bool), Person, default_const = Alive(true));

--- a/src/triggers/periodic_time.rs
+++ b/src/triggers/periodic_time.rs
@@ -54,7 +54,6 @@
 //! ```rust
 //! use ixa::{Context, ExecutionPhase, IxaEvent};
 //! use ixa::triggers::{ContextTriggersExt, PeriodicTimeTrigger, TriggerCriterion};
-//! use ixa_derive::IxaEvent;
 //!
 //! #[derive(IxaEvent)]
 //! struct ReportTimeReached {

--- a/src/triggers/property_change.rs
+++ b/src/triggers/property_change.rs
@@ -56,7 +56,6 @@
 //! use ixa::{Context, ContextEntitiesExt, define_entity, define_property, IxaEvent};
 //! use ixa::entity::EntityId;
 //! use ixa::triggers::{ContextTriggersExt, PropertyChangeTrigger, TriggerCriterion};
-//! use ixa_derive::IxaEvent;
 //!
 //! define_entity!(Person);
 //! define_property!(struct Alive(bool), Person, default_const = Alive(true));

--- a/src/triggers/property_value_count.rs
+++ b/src/triggers/property_value_count.rs
@@ -68,7 +68,6 @@
 //! use ixa::triggers::{
 //!     ContextTriggersExt, Direction, PropertyValueCountTrigger, TriggerCriterion, TriggerMode,
 //! };
-//! use ixa_derive::IxaEvent;
 //!
 //! define_entity!(Person);
 //! define_property!(

--- a/src/triggers/time.rs
+++ b/src/triggers/time.rs
@@ -42,7 +42,6 @@
 //! ```rust
 //! use ixa::{Context, ExecutionPhase, IxaEvent};
 //! use ixa::triggers::{ContextTriggersExt, TimeTrigger, TriggerCriterion};
-//! use ixa_derive::IxaEvent;
 //!
 //! #[derive(IxaEvent)]
 //! struct StopTimeReached {

--- a/src/triggers/toggling_trigger.rs
+++ b/src/triggers/toggling_trigger.rs
@@ -122,7 +122,6 @@
 //! use ixa::triggers::{
 //!     ContextTriggersExt, PropertyValueCountTrigger, TogglingTriggerCriteria,
 //! };
-//! use ixa_derive::IxaEvent;
 //!
 //! define_entity!(Person);
 //! define_property!(


### PR DESCRIPTION
Accidentally merged before fixing issue with `triggers` doc tests. This PR fixes the doc tests. 

The issue is a simple ambiguous import of `IxaEvent` caused by #967. Fix is equally simple.