### PR TITLE
chore: Make plugin context traits dyn-compatible

### DIFF
--- a/examples/parameter-loading/parameters_loader.rs
+++ b/examples/parameter-loading/parameters_loader.rs
@@ -17,12 +17,18 @@ pub struct Parameters {
 define_global_property!(ParametersKey, Parameters);
 
 pub trait ParametersExt: PluginContext {
-    fn init_parameters(&mut self, file_path: &Path) -> Result<(), IxaError> {
+    fn init_parameters(&mut self, file_path: &Path) -> Result<(), IxaError>
+    where
+        Self: Sized,
+    {
         let parameters_json = self.load_parameters_from_json::<Parameters>(file_path)?;
         self.set_global_property_value(ParametersKey, parameters_json)?;
         Ok(())
     }
-    fn get_parameters(&self) -> &Parameters {
+    fn get_parameters(&self) -> &Parameters
+    where
+        Self: Sized,
+    {
         self.get_global_property_value(ParametersKey)
             .as_ref()
             .unwrap()

--- a/src/context.rs
+++ b/src/context.rs
@@ -471,28 +471,43 @@ impl Context {
     }
 }
 
-pub trait ContextBase: Sized {
-    fn subscribe_to_event<E: IxaEvent>(&mut self, handler: impl Fn(&mut Context, E) + 'static);
-    fn emit_event<E: IxaEvent>(&mut self, event: E);
-    fn add_plan(&mut self, time: f64, callback: impl FnOnce(&mut Context) + 'static) -> PlanId;
+pub trait ContextBase {
+    fn subscribe_to_event<E: IxaEvent>(&mut self, handler: impl Fn(&mut Context, E) + 'static)
+    where
+        Self: Sized;
+    fn emit_event<E: IxaEvent>(&mut self, event: E)
+    where
+        Self: Sized;
+    fn add_plan(&mut self, time: f64, callback: impl FnOnce(&mut Context) + 'static) -> PlanId
+    where
+        Self: Sized;
     fn add_plan_with_phase(
         &mut self,
         time: f64,
         callback: impl FnOnce(&mut Context) + 'static,
         phase: ExecutionPhase,
-    ) -> PlanId;
+    ) -> PlanId
+    where
+        Self: Sized;
     fn add_periodic_plan_with_phase(
         &mut self,
         period: f64,
         callback: impl Fn(&mut Context) + 'static,
         phase: ExecutionPhase,
-    );
+    ) where
+        Self: Sized;
     fn cancel_plan(&mut self, plan_id: &PlanId);
-    fn queue_callback(&mut self, callback: impl FnOnce(&mut Context) + 'static);
+    fn queue_callback(&mut self, callback: impl FnOnce(&mut Context) + 'static)
+    where
+        Self: Sized;
     #[must_use]
-    fn get_data_mut<T: DataPlugin>(&mut self, plugin: T) -> &mut T::DataContainer;
+    fn get_data_mut<T: DataPlugin>(&mut self, plugin: T) -> &mut T::DataContainer
+    where
+        Self: Sized;
     #[must_use]
-    fn get_data<T: DataPlugin>(&self, plugin: T) -> &T::DataContainer;
+    fn get_data<T: DataPlugin>(&self, plugin: T) -> &T::DataContainer
+    where
+        Self: Sized;
     #[must_use]
     fn get_current_time(&self) -> f64;
     #[must_use]

--- a/src/entity/context_extension.rs
+++ b/src/entity/context_extension.rs
@@ -98,7 +98,9 @@ pub trait ContextEntitiesExt {
     fn add_entity<E: Entity, PL: PropertyInitializationList<E>>(
         &mut self,
         property_list: PL,
-    ) -> Result<EntityId<E>, IxaError>;
+    ) -> Result<EntityId<E>, IxaError>
+    where
+        Self: Sized;
 
     /// Fetches the property value set for the given `entity_id`.
     ///
@@ -107,14 +109,17 @@ pub trait ContextEntitiesExt {
     /// let vaccine_status: VaccineStatus = context.get_property(entity_id);
     /// ```
     #[must_use]
-    fn get_property<E: Entity, P: Property<E>>(&self, entity_id: EntityId<E>) -> P;
+    fn get_property<E: Entity, P: Property<E>>(&self, entity_id: EntityId<E>) -> P
+    where
+        Self: Sized;
 
     /// Sets the value of the given property. This method unconditionally emits a `PropertyChangeEvent`.
     fn set_property<E: Entity, P: Property<E>>(
         &mut self,
         entity_id: EntityId<E>,
         property_value: P,
-    );
+    ) where
+        Self: Sized;
 
     /// Enables full indexing of property values for the property `P`.
     ///
@@ -122,13 +127,17 @@ pub trait ContextEntitiesExt {
     ///     `context.index_property::<Person, Age>()`
     ///
     /// This method both enables the index and catches it up to the current population.
-    fn index_property<E: Entity, P: IndexableProperty<E>>(&mut self);
+    fn index_property<E: Entity, P: IndexableProperty<E>>(&mut self)
+    where
+        Self: Sized;
 
     /// Enables value-count indexing of property values for the property `P`.
     ///
     /// If the property already has a full index, that index is left unchanged, as it
     /// already supports value-count queries.
-    fn index_property_counts<E: Entity, P: IndexableProperty<E>>(&mut self);
+    fn index_property_counts<E: Entity, P: IndexableProperty<E>>(&mut self)
+    where
+        Self: Sized;
 
     /// Tracks periodic value change counts for a newly created counter.
     ///
@@ -149,6 +158,7 @@ pub trait ContextEntitiesExt {
     /// ```
     fn track_periodic_value_change_counts<E, PL, P, F>(&mut self, period: f64, handler: F)
     where
+        Self: Sized,
         E: Entity,
         PL: PropertyList<E> + Eq + Hash,
         P: Property<E> + Eq + Hash,
@@ -163,7 +173,9 @@ pub trait ContextEntitiesExt {
     /// multi-properties.
     #[cfg(test)]
     #[must_use]
-    fn is_property_indexed<E: Entity, P: Property<E>>(&self) -> bool;
+    fn is_property_indexed<E: Entity, P: Property<E>>(&self) -> bool
+    where
+        Self: Sized;
 
     /// This method gives client code direct access to the query result as an `EntitySet`.
     /// This is especially efficient for indexed queries, as this method can reduce to wrapping
@@ -172,14 +184,17 @@ pub trait ContextEntitiesExt {
         &'a self,
         query: Q,
         callback: &mut dyn FnMut(EntitySet<'a, E>),
-    );
+    ) where
+        Self: Sized;
 
     /// Gives the count of distinct entity IDs satisfying the query. This is especially
     /// efficient for indexed queries.
     ///
     /// Supplying a naked entity, e.g. `Person`, is equivalent to calling `get_entity_count::<Person>()`.
     #[must_use]
-    fn query_entity_count<E: Entity, Q: Query<E>>(&self, query: Q) -> usize;
+    fn query_entity_count<E: Entity, Q: Query<E>>(&self, query: Q) -> usize
+    where
+        Self: Sized;
 
     /// Sample a single entity uniformly from the query results. Returns `None` if the
     /// query's result set is empty.
@@ -188,6 +203,7 @@ pub trait ContextEntitiesExt {
     #[must_use]
     fn sample_entity<E, Q, R>(&self, rng_id: R, query: Q) -> Option<EntityId<E>>
     where
+        Self: Sized,
         E: Entity,
         Q: Query<E>,
         R: RngId + 'static,
@@ -200,6 +216,7 @@ pub trait ContextEntitiesExt {
     #[must_use]
     fn count_and_sample_entity<E, Q, R>(&self, rng_id: R, query: Q) -> (usize, Option<EntityId<E>>)
     where
+        Self: Sized,
         E: Entity,
         Q: Query<E>,
         R: RngId + 'static,
@@ -213,6 +230,7 @@ pub trait ContextEntitiesExt {
     #[must_use]
     fn sample_entities<E, Q, R>(&self, rng_id: R, query: Q, n: usize) -> Vec<EntityId<E>>
     where
+        Self: Sized,
         E: Entity,
         Q: Query<E>,
         R: RngId + 'static,
@@ -220,26 +238,38 @@ pub trait ContextEntitiesExt {
 
     /// Returns a total count of all created entities of type `E`.
     #[must_use]
-    fn get_entity_count<E: Entity>(&self) -> usize;
+    fn get_entity_count<E: Entity>(&self) -> usize
+    where
+        Self: Sized;
 
     /// Returns an iterator over all created entities of type `E`.
     #[must_use]
-    fn get_entity_iterator<E: Entity>(&self) -> PopulationIterator<E>;
+    fn get_entity_iterator<E: Entity>(&self) -> PopulationIterator<E>
+    where
+        Self: Sized;
 
     /// Generates an `EntitySet` representing the query results.
     #[must_use]
-    fn query<E: Entity, Q: Query<E>>(&self, query: Q) -> EntitySet<E>;
+    fn query<E: Entity, Q: Query<E>>(&self, query: Q) -> EntitySet<E>
+    where
+        Self: Sized;
 
     /// Generates an iterator over the results of the query.
     #[must_use]
-    fn query_result_iterator<E: Entity, Q: Query<E>>(&self, query: Q) -> EntitySetIterator<E>;
+    fn query_result_iterator<E: Entity, Q: Query<E>>(&self, query: Q) -> EntitySetIterator<E>
+    where
+        Self: Sized;
 
     /// Determines if the given person matches this query.
     #[must_use]
-    fn match_entity<E: Entity, Q: Query<E>>(&self, entity_id: EntityId<E>, query: Q) -> bool;
+    fn match_entity<E: Entity, Q: Query<E>>(&self, entity_id: EntityId<E>, query: Q) -> bool
+    where
+        Self: Sized;
 
     /// Removes all `EntityId`s from the given vector that do not match the given query.
-    fn filter_entities<E: Entity, Q: Query<E>>(&self, entities: &mut Vec<EntityId<E>>, query: Q);
+    fn filter_entities<E: Entity, Q: Query<E>>(&self, entities: &mut Vec<EntityId<E>>, query: Q)
+    where
+        Self: Sized;
 }
 
 impl ContextEntitiesExt for Context {

--- a/src/global_properties.rs
+++ b/src/global_properties.rs
@@ -159,14 +159,18 @@ pub trait ContextGlobalPropertiesExt: ContextBase {
         &mut self,
         property: T,
         value: T::Value,
-    ) -> Result<(), IxaError>;
+    ) -> Result<(), IxaError>
+    where
+        Self: Sized;
 
     /// Return value of global property T
     #[must_use]
     fn get_global_property_value<T: GlobalProperty + 'static>(
         &self,
         _property: T,
-    ) -> Option<&T::Value>;
+    ) -> Option<&T::Value>
+    where
+        Self: Sized;
 
     /// Given a file path for a valid json file, deserialize parameter values
     /// for a given struct T
@@ -178,7 +182,10 @@ pub trait ContextGlobalPropertiesExt: ContextBase {
     fn load_parameters_from_json<T: 'static + Debug + DeserializeOwned>(
         &mut self,
         file_name: &Path,
-    ) -> Result<T, IxaError> {
+    ) -> Result<T, IxaError>
+    where
+        Self: Sized,
+    {
         trace!("Loading parameters from JSON: {file_name:?}");
         let config_file = fs::File::open(file_name)?;
         let reader = BufReader::new(config_file);

--- a/src/network/mod.rs
+++ b/src/network/mod.rs
@@ -199,7 +199,10 @@ pub trait ContextNetworkExt: ContextBase + ContextRandomExt {
         neighbor: EntityId<E>,
         weight: f32,
         inner: ET,
-    ) -> Result<(), IxaError> {
+    ) -> Result<(), IxaError>
+    where
+        Self: Sized,
+    {
         let data_container = self.get_data_mut(NetworkPlugin);
         data_container.add_edge::<E, ET>(entity_id, neighbor, weight, inner)
     }
@@ -221,7 +224,10 @@ pub trait ContextNetworkExt: ContextBase + ContextRandomExt {
         entity2: EntityId<E>,
         weight: f32,
         inner: ET,
-    ) -> Result<(), IxaError> {
+    ) -> Result<(), IxaError>
+    where
+        Self: Sized,
+    {
         let data_container = self.get_data_mut(NetworkPlugin);
         data_container.add_edge::<E, ET>(entity1, entity2, weight, inner.clone())?;
         data_container.add_edge::<E, ET>(entity2, entity1, weight, inner)
@@ -234,7 +240,10 @@ pub trait ContextNetworkExt: ContextBase + ContextRandomExt {
         &mut self,
         entity_id: EntityId<E>,
         neighbor: EntityId<E>,
-    ) -> Option<Edge<E, ET>> {
+    ) -> Option<Edge<E, ET>>
+    where
+        Self: Sized,
+    {
         let data_container = self.get_data_mut(NetworkPlugin);
         data_container.remove_edge::<E, ET>(entity_id, neighbor)
     }
@@ -245,17 +254,20 @@ pub trait ContextNetworkExt: ContextBase + ContextRandomExt {
         &self,
         entity_id: EntityId<E>,
         neighbor: EntityId<E>,
-    ) -> Option<&Edge<E, ET>> {
+    ) -> Option<&Edge<E, ET>>
+    where
+        Self: Sized,
+    {
         self.get_data(NetworkPlugin)
             .get_edge::<E, ET>(entity_id, neighbor)
     }
 
     /// Get all outgoing edges of type `ET` from `entity_id`.
     #[must_use]
-    fn get_edges<E: Entity, ET: EdgeType<E>>(
-        &self,
-        entity_id: EntityId<E>,
-    ) -> AdjacencyList<E, ET> {
+    fn get_edges<E: Entity, ET: EdgeType<E>>(&self, entity_id: EntityId<E>) -> AdjacencyList<E, ET>
+    where
+        Self: Sized,
+    {
         self.get_data(NetworkPlugin).get_edges::<E, ET>(entity_id)
     }
 
@@ -268,7 +280,10 @@ pub trait ContextNetworkExt: ContextBase + ContextRandomExt {
         &self,
         entity_id: EntityId<E>,
         filter: impl Fn(&Self, &Edge<E, ET>) -> bool,
-    ) -> AdjacencyList<E, ET> {
+    ) -> AdjacencyList<E, ET>
+    where
+        Self: Sized,
+    {
         let network_data = self.get_data(NetworkPlugin);
         let empty = vec![];
         let edges = network_data
@@ -283,10 +298,10 @@ pub trait ContextNetworkExt: ContextBase + ContextRandomExt {
 
     /// Find all entities who have an edge of type `ET` and degree `degree`.
     #[must_use]
-    fn find_entities_by_degree<E: Entity, ET: EdgeType<E>>(
-        &self,
-        degree: usize,
-    ) -> Vec<EntityId<E>> {
+    fn find_entities_by_degree<E: Entity, ET: EdgeType<E>>(&self, degree: usize) -> Vec<EntityId<E>>
+    where
+        Self: Sized,
+    {
         self.get_data(NetworkPlugin)
             .find_entities_by_degree::<E, ET>(degree)
     }
@@ -301,6 +316,7 @@ pub trait ContextNetworkExt: ContextBase + ContextRandomExt {
         entity_id: EntityId<E>,
     ) -> Result<Edge<E, ET>, IxaError>
     where
+        Self: Sized,
         R::RngType: Rng,
     {
         let edges = self.get_edges::<E, ET>(entity_id);

--- a/src/plugin_context.rs
+++ b/src/plugin_context.rs
@@ -7,6 +7,13 @@ use crate::{
 /// A supertrait that exposes useful methods from [`Context`]
 /// for plugins implementing [`Context`] extensions.
 ///
+/// `PluginContext` is dyn-compatible, so client code may accept
+/// `&dyn PluginContext` or `&mut dyn PluginContext` when it only needs
+/// object-safe behavior. Most typed helper methods, such as data plugin,
+/// entity, random, report, and network helpers, remain available on concrete
+/// [`Context`] values or generic `C: PluginContext` parameters because their
+/// signatures depend on type parameters.
+///
 /// Usage:
 // This example uses ctor-based registration, which is not supported
 // on every rustdoc target, so we ignore it.
@@ -56,7 +63,10 @@ mod test_plugin_context {
         fn all_methods(&mut self) {
             assert_eq!(self.get_current_time(), 0.0);
         }
-        fn all_methods_mut(&mut self) {
+        fn all_methods_mut(&mut self)
+        where
+            Self: Sized,
+        {
             self.setup();
             self.subscribe_to_event(|_: &mut Context, event: MyEvent| {
                 assert_eq!(event.data, 42);
@@ -90,19 +100,31 @@ mod test_plugin_context {
                 assert_eq!(*data, 42);
             });
         }
-        fn setup(&mut self) {
+        fn setup(&mut self)
+        where
+            Self: Sized,
+        {
             let data = self.get_data_mut(MyData);
             *data = 42;
             do_stuff_with_context(self);
         }
-        fn get_my_data(&self) -> i32 {
+        fn get_my_data(&self) -> i32
+        where
+            Self: Sized,
+        {
             *self.get_data(MyData)
         }
-        fn set_my_data(&mut self, value: i32) {
+        fn set_my_data(&mut self, value: i32)
+        where
+            Self: Sized,
+        {
             let data = self.get_data_mut(MyData);
             *data = value;
         }
-        fn test_external_function(&mut self) {
+        fn test_external_function(&mut self)
+        where
+            Self: Sized,
+        {
             self.setup();
             do_stuff_with_context(self);
         }
@@ -129,5 +151,25 @@ mod test_plugin_context {
         let mut context = Context::new();
         context.test_external_function();
         assert_eq!(context.get_my_data(), 42);
+    }
+
+    #[test]
+    fn test_plugin_context_is_dyn_compatible() {
+        fn accepts_dyn(context: &mut dyn PluginContext) {
+            assert_eq!(context.get_current_time(), 0.0);
+        }
+
+        let mut context = Context::new();
+        accepts_dyn(&mut context);
+    }
+
+    #[test]
+    fn test_plugin_extension_trait_is_dyn_compatible() {
+        fn accepts_dyn(context: &mut dyn MyDataExt) {
+            context.all_methods();
+        }
+
+        let mut context = Context::new();
+        accepts_dyn(&mut context);
     }
 }

--- a/src/profiling/reporting.rs
+++ b/src/profiling/reporting.rs
@@ -20,7 +20,10 @@ pub trait ProfilingContextExt: ContextReportExt {
 
     /// Writes the execution statistics for the context and all profiling data
     /// to a JSON file.
-    fn write_profiling_data(&mut self) {
+    fn write_profiling_data(&mut self)
+    where
+        Self: Sized,
+    {
         let (mut prefix, directory, overwrite) = {
             let report_options = self.report_options();
             (

--- a/src/random/context_ext.rs
+++ b/src/random/context_ext.rs
@@ -47,7 +47,10 @@ fn get_rng<R: RngId + 'static>(context: &impl ContextBase) -> RefMut<R::RngType>
 pub trait ContextRandomExt: ContextBase {
     /// Initializes the `RngPlugin` data container to store rngs as well as a base
     /// seed. Note that rngs are created lazily when `get_rng` is called.
-    fn init_random(&mut self, base_seed: u64) {
+    fn init_random(&mut self, base_seed: u64)
+    where
+        Self: Sized,
+    {
         trace!("initializing random module");
         let data_container = self.get_data_mut(RngPlugin);
         data_container.base_seed = base_seed;
@@ -66,7 +69,10 @@ pub trait ContextRandomExt: ContextBase {
         &self,
         _rng_type: R,
         sampler: impl FnOnce(&mut R::RngType) -> T,
-    ) -> T {
+    ) -> T
+    where
+        Self: Sized,
+    {
         let mut rng = get_rng::<R>(self);
         sampler(&mut rng)
     }
@@ -82,6 +88,7 @@ pub trait ContextRandomExt: ContextBase {
         distribution: impl Distribution<T>,
     ) -> T
     where
+        Self: Sized,
         R::RngType: Rng,
     {
         let mut rng = get_rng::<R>(self);
@@ -94,6 +101,7 @@ pub trait ContextRandomExt: ContextBase {
     #[must_use]
     fn sample_range<R: RngId + 'static, S, T>(&self, rng_id: R, range: S) -> T
     where
+        Self: Sized,
         R::RngType: Rng,
         S: SampleRange<T>,
         T: SampleUniform,
@@ -107,6 +115,7 @@ pub trait ContextRandomExt: ContextBase {
     #[must_use]
     fn sample_bool<R: RngId + 'static>(&self, rng_id: R, p: f64) -> bool
     where
+        Self: Sized,
         R::RngType: Rng,
     {
         self.sample(rng_id, |rng| rng.random_bool(p))
@@ -119,6 +128,7 @@ pub trait ContextRandomExt: ContextBase {
     #[must_use]
     fn sample_weighted<R: RngId + 'static, T>(&self, _rng_id: R, weights: &[T]) -> usize
     where
+        Self: Sized,
         R::RngType: Rng,
         T: Clone
             + Default

--- a/src/report.rs
+++ b/src/report.rs
@@ -111,7 +111,10 @@ pub trait ContextReportExt: ContextBase {
     // Builds the filename. Called by `add_report`, `short_name` refers to the
     // report type. The three main components are `prefix`, `directory`, and
     // `short_name`.
-    fn generate_filename(&mut self, short_name: &str) -> PathBuf {
+    fn generate_filename(&mut self, short_name: &str) -> PathBuf
+    where
+        Self: Sized,
+    {
         let data_container = self.get_data_mut(ReportPlugin);
         let prefix = &data_container.config.file_prefix;
         let directory = &data_container.config.output_dir;
@@ -126,7 +129,10 @@ pub trait ContextReportExt: ContextBase {
     /// # Errors
     /// If the file already exists and `overwrite` is set to false, raises an error and info message.
     /// If the file cannot be created, raises an error.
-    fn add_report_by_type_id(&mut self, type_id: TypeId, short_name: &str) -> Result<(), IxaError> {
+    fn add_report_by_type_id(&mut self, type_id: TypeId, short_name: &str) -> Result<(), IxaError>
+    where
+        Self: Sized,
+    {
         trace!("adding report {short_name} by type_id {type_id:?}");
         let path = self.generate_filename(short_name);
 
@@ -161,12 +167,18 @@ pub trait ContextReportExt: ContextBase {
     /// # Errors
     /// If the file already exists and `overwrite` is set to false, raises an error and info message.
     /// If the file cannot be created, raises an error.
-    fn add_report<T: Report + 'static>(&mut self, short_name: &str) -> Result<(), IxaError> {
+    fn add_report<T: Report + 'static>(&mut self, short_name: &str) -> Result<(), IxaError>
+    where
+        Self: Sized,
+    {
         trace!("Adding report {short_name}");
         self.add_report_by_type_id(TypeId::of::<T>(), short_name)
     }
 
-    fn get_writer(&self, type_id: TypeId) -> RefMut<Writer<File>> {
+    fn get_writer(&self, type_id: TypeId) -> RefMut<Writer<File>>
+    where
+        Self: Sized,
+    {
         // No data container will exist if no reports have been added
         let data_container = self.get_data(ReportPlugin);
         let writers = data_container.file_writers.try_borrow_mut().unwrap();
@@ -178,13 +190,19 @@ pub trait ContextReportExt: ContextBase {
     }
 
     /// Write a new row to the appropriate report file
-    fn send_report<T: Report>(&self, report: T) {
+    fn send_report<T: Report>(&self, report: T)
+    where
+        Self: Sized,
+    {
         let writer = &mut self.get_writer(report.type_id());
         report.serialize(writer);
     }
 
     /// Returns a `ConfigReportOptions` object which has setter methods for report configuration
-    fn report_options(&mut self) -> &mut ConfigReportOptions {
+    fn report_options(&mut self) -> &mut ConfigReportOptions
+    where
+        Self: Sized,
+    {
         let data_container = self.get_data_mut(ReportPlugin);
         &mut data_container.config
     }


### PR DESCRIPTION
## Summary

- Make `PluginContext` dyn-compatible by moving `Self: Sized` bounds onto non-object-safe typed helper methods.
- Add tests proving `dyn PluginContext` and dyn plugin extension traits compile for object-safe behavior.
- Update related extension traits and parameter-loading helpers to preserve concrete/generic typed APIs.
