### PR TITLE
fix: Moved private module docs for triggers to the public trigger types

### DIFF
--- a/src/triggers/entity_count.rs
+++ b/src/triggers/entity_count.rs
@@ -1,71 +1,3 @@
-//! Trigger criterion for the count of entities of a given type.
-//!
-//! [`EntityCountTrigger`] observes
-//! [`EntityCreatedEvent`](crate::entity::events::EntityCreatedEvent) for a single entity type and
-//! emits when the total number of entities of that type increases to the configured threshold.
-//!
-//! ## Construction
-//!
-//! ```rust,ignore
-//! EntityCountTrigger::<E>::increases_to(threshold)
-//! ```
-//!
-//! ## Observation
-//!
-//! The observation data passed to
-//! [`TriggerCriterion::emit_with`](super::TriggerCriterion::emit_with) is
-//! [`EntityCountTriggerEvent`]:
-//!
-//! ```rust,ignore
-//! pub struct EntityCountTriggerEvent<E: Entity> {
-//!     pub entity_id: EntityId<E>,
-//!     pub count: usize,
-//! }
-//! ```
-//!
-//! ## Semantics
-//!
-//! As entities can only be created, not destroyed, the count of entities is monotonic. Thus, this
-//! criterion does not use [`Direction`](super::Direction) or [`TriggerMode`](super::TriggerMode).
-//!
-//! - It fires when a creation makes the count equal to the threshold.
-//! - The observed count always equals the threshold the trigger was created with.
-//! - If the entity population already equals or exceeds the threshold _before_ the trigger is
-//!   registered, it will never emit.
-//! - A threshold of `0` will not be reached by an entity creation and is therefore not allowed.
-//!
-//! ## Example
-//!
-//! ```rust
-//! use ixa::{Context, ContextEntitiesExt, define_entity, IxaEvent};
-//! use ixa::entity::EntityId;
-//! use ixa::triggers::{ContextTriggersExt, EntityCountTrigger, TriggerCriterion};
-//!
-//! define_entity!(Case);
-//!
-//! // The event records which case caused us to reach the threshold and
-//! // the value of the threshold itself (as `count`).
-//! #[derive(IxaEvent)]
-//! struct SecondCase {
-//!     case_id: EntityId<Case>,
-//!     count: usize,
-//! }
-//!
-//! let mut context = Context::new();
-//!
-//! context.register_trigger(
-//!     EntityCountTrigger::increases_to(2)
-//!         .emit_with(|observation| SecondCase {
-//!             case_id: observation.entity_id,
-//!             count: observation.count,
-//!         }),
-//! );
-//!
-//! context.subscribe_to_event(|_context, _event: SecondCase| {
-//!     // respond when the second Case entity is created
-//! });
-//! ```
-//!
 use std::marker::PhantomData;
 
 use super::TriggerCriterion;
@@ -73,6 +5,74 @@ use crate::entity::events::EntityCreatedEvent;
 use crate::entity::{Entity, EntityId};
 use crate::Context;
 
+/// Trigger criterion for the count of entities of a given type.
+///
+/// [`EntityCountTrigger`] observes
+/// [`EntityCreatedEvent`](crate::entity::events::EntityCreatedEvent) for a single entity type and
+/// emits when the total number of entities of that type increases to the configured threshold.
+///
+/// ## Construction
+///
+/// ```rust,ignore
+/// EntityCountTrigger::<E>::increases_to(threshold)
+/// ```
+///
+/// ## Observation
+///
+/// The observation data passed to
+/// [`TriggerCriterion::emit_with`](super::TriggerCriterion::emit_with) is
+/// [`EntityCountTriggerEvent`]:
+///
+/// ```rust,ignore
+/// pub struct EntityCountTriggerEvent<E: Entity> {
+///     pub entity_id: EntityId<E>,
+///     pub count: usize,
+/// }
+/// ```
+///
+/// ## Semantics
+///
+/// As entities can only be created, not destroyed, the count of entities is monotonic. Thus, this
+/// criterion does not use [`Direction`](super::Direction) or [`TriggerMode`](super::TriggerMode).
+///
+/// - It fires when a creation makes the count equal to the threshold.
+/// - The observed count always equals the threshold the trigger was created with.
+/// - If the entity population already equals or exceeds the threshold _before_ the trigger is
+///   registered, it will never emit.
+/// - A threshold of `0` will not be reached by an entity creation and is therefore not allowed.
+///
+/// ## Example
+///
+/// ```rust
+/// use ixa::{Context, ContextEntitiesExt, define_entity, IxaEvent};
+/// use ixa::entity::EntityId;
+/// use ixa::triggers::{ContextTriggersExt, EntityCountTrigger, TriggerCriterion};
+///
+/// define_entity!(Case);
+///
+/// // The event records which case caused us to reach the threshold and
+/// // the value of the threshold itself (as `count`).
+/// #[derive(IxaEvent)]
+/// struct SecondCase {
+///     case_id: EntityId<Case>,
+///     count: usize,
+/// }
+///
+/// let mut context = Context::new();
+///
+/// context.register_trigger(
+///     EntityCountTrigger::increases_to(2)
+///         .emit_with(|observation| SecondCase {
+///             case_id: observation.entity_id,
+///             count: observation.count,
+///         }),
+/// );
+///
+/// context.subscribe_to_event(|_context, _event: SecondCase| {
+///     // respond when the second Case entity is created
+/// });
+/// ```
+///
 pub struct EntityCountTrigger<E: Entity> {
     threshold: usize,
     _entity: PhantomData<fn() -> E>,

--- a/src/triggers/mod.rs
+++ b/src/triggers/mod.rs
@@ -1,7 +1,7 @@
 //! Trigger criteria that emit user-defined events.
 //!
 //! A trigger is a way to say: when some simulation criterion is met, emit a
-//! concrete user-defined [`IxaEvent`](crate::IxaEvent). Trigger-emitted events
+//! concrete user-defined [`IxaEvent`]. Trigger-emitted events
 //! are ordinary Ixa events, so any number of subscribers can listen for them
 //! with [`Context::subscribe_to_event`](crate::Context::subscribe_to_event).
 //!
@@ -48,7 +48,7 @@
 //! Use [`TriggerCriterion::emit_with`] when the emitted event should contain data from the trigger
 //! observation. When the criterion is met, this observation value is passed to the event
 //! constructor (typically a closure or static constructor method) supplied to `emit_with`, and that
-//! constructor returns the concrete user-defined [`IxaEvent`](crate::IxaEvent) that subscribers
+//! constructor returns the concrete user-defined [`IxaEvent`] that subscribers
 //! will receive.
 //!
 //! ```rust

--- a/src/triggers/periodic_time.rs
+++ b/src/triggers/periodic_time.rs
@@ -1,89 +1,89 @@
-//! Trigger criterion for regular simulation time intervals.
-//!
-//! [`PeriodicTimeTrigger`] observes the simulation clock and emits repeatedly at a configured
-//! period and execution phase.
-//!
-//! ## Construction
-//!
-//! ```rust,ignore
-//! PeriodicTimeTrigger::every(period)
-//! PeriodicTimeTrigger::every_with_phase(period, phase)
-//! PeriodicTimeTrigger::every(period).with_phase(phase) // Equivalent to `every_with_phase`
-//! PeriodicTimeTrigger::every(period).start_with_delay(delay)
-//! PeriodicTimeTrigger::every(period).start_at(start_time)
-//! ```
-//!
-//! ## Observation
-//!
-//! The observation data passed to
-//! [`TriggerCriterion::emit_with`](super::TriggerCriterion::emit_with) is
-//! [`PeriodicTimeTriggerEvent`]. It contains the simulation time observed when the scheduled
-//! periodic plan runs, the configured period, and the phase used to schedule it:
-//!
-//! ```rust,ignore
-//! pub struct PeriodicTimeTriggerEvent {
-//!     pub time: f64,
-//!     pub period: f64,
-//!     pub phase: ExecutionPhase,
-//! }
-//! ```
-//!
-//! ## Semantics
-//!
-//! This trigger uses the same rescheduling behavior as periodic plans: when the scheduled callback
-//! runs, the next occurrence is scheduled at `current_time + period` if there are still plans in the
-//! queue. Unlike [`Context::add_periodic_plan_with_phase`](crate::Context::add_periodic_plan_with_phase),
-//! the first occurrence is seeded explicitly so it can start at the current time, after a delay, or
-//! at an absolute simulation time.
-//!
-//! By default, the first occurrence is scheduled at `context.get_current_time()` when the trigger is
-//! installed, and the execution phase is
-//! [`ExecutionPhase::Normal`](crate::ExecutionPhase::Normal).
-//!
-//! The period must be positive, finite, and not NaN. A delay must be non-negative, finite, and not
-//! NaN. An absolute start time must be finite and not NaN; the context validates at trigger
-//! installation that it is not in the past.
-//! Builder inputs are converted to `f64` before these checks are applied.
-//!
-//! Since time is monotonic, this criterion does not use [`Direction`](super::Direction) or
-//! [`TriggerMode`](super::TriggerMode). It emits whenever its periodic schedule executes. If several
-//! plans are scheduled for the same time, the selected [`ExecutionPhase`](crate::ExecutionPhase)
-//! controls phase ordering.
-//!
-//! ## Example
-//!
-//! ```rust
-//! use ixa::{Context, ExecutionPhase, IxaEvent};
-//! use ixa::triggers::{ContextTriggersExt, PeriodicTimeTrigger, TriggerCriterion};
-//!
-//! #[derive(IxaEvent)]
-//! struct ReportTimeReached {
-//!     time: f64,
-//!     period: f64,
-//!     phase: ExecutionPhase,
-//! }
-//!
-//! let mut context = Context::new();
-//!
-//! context.register_trigger(
-//!     PeriodicTimeTrigger::every(7.0)
-//!         .with_phase(ExecutionPhase::Last)
-//!         .start_with_delay(7.0)
-//!         .emit_with(|observation| ReportTimeReached {
-//!             time: observation.time,
-//!             period: observation.period,
-//!             phase: observation.phase,
-//!         }),
-//! );
-//!
-//! context.subscribe_to_event(|_context, _event: ReportTimeReached| {
-//!     // collect periodic reports
-//! });
-//! ```
-//!
 use super::TriggerCriterion;
 use crate::{Context, ExecutionPhase};
 
+/// Trigger criterion for regular simulation time intervals.
+///
+/// [`PeriodicTimeTrigger`] observes the simulation clock and emits repeatedly at a configured
+/// period and execution phase.
+///
+/// ## Construction
+///
+/// ```rust,ignore
+/// PeriodicTimeTrigger::every(period)
+/// PeriodicTimeTrigger::every_with_phase(period, phase)
+/// PeriodicTimeTrigger::every(period).with_phase(phase) // Equivalent to `every_with_phase`
+/// PeriodicTimeTrigger::every(period).start_with_delay(delay)
+/// PeriodicTimeTrigger::every(period).start_at(start_time)
+/// ```
+///
+/// ## Observation
+///
+/// The observation data passed to
+/// [`TriggerCriterion::emit_with`](super::TriggerCriterion::emit_with) is
+/// [`PeriodicTimeTriggerEvent`]. It contains the simulation time observed when the scheduled
+/// periodic plan runs, the configured period, and the phase used to schedule it:
+///
+/// ```rust,ignore
+/// pub struct PeriodicTimeTriggerEvent {
+///     pub time: f64,
+///     pub period: f64,
+///     pub phase: ExecutionPhase,
+/// }
+/// ```
+///
+/// ## Semantics
+///
+/// This trigger uses the same rescheduling behavior as periodic plans: when the scheduled callback
+/// runs, the next occurrence is scheduled at `current_time + period` if there are still plans in the
+/// queue. Unlike [`Context::add_periodic_plan_with_phase`](crate::Context::add_periodic_plan_with_phase),
+/// the first occurrence is seeded explicitly so it can start at the current time, after a delay, or
+/// at an absolute simulation time.
+///
+/// By default, the first occurrence is scheduled at `context.get_current_time()` when the trigger is
+/// installed, and the execution phase is
+/// [`ExecutionPhase::Normal`](crate::ExecutionPhase::Normal).
+///
+/// The period must be positive, finite, and not NaN. A delay must be non-negative, finite, and not
+/// NaN. An absolute start time must be finite and not NaN; the context validates at trigger
+/// installation that it is not in the past.
+/// Builder inputs are converted to `f64` before these checks are applied.
+///
+/// Since time is monotonic, this criterion does not use [`Direction`](super::Direction) or
+/// [`TriggerMode`](super::TriggerMode). It emits whenever its periodic schedule executes. If several
+/// plans are scheduled for the same time, the selected [`ExecutionPhase`](crate::ExecutionPhase)
+/// controls phase ordering.
+///
+/// ## Example
+///
+/// ```rust
+/// use ixa::{Context, ExecutionPhase, IxaEvent};
+/// use ixa::triggers::{ContextTriggersExt, PeriodicTimeTrigger, TriggerCriterion};
+///
+/// #[derive(IxaEvent)]
+/// struct ReportTimeReached {
+///     time: f64,
+///     period: f64,
+///     phase: ExecutionPhase,
+/// }
+///
+/// let mut context = Context::new();
+///
+/// context.register_trigger(
+///     PeriodicTimeTrigger::every(7.0)
+///         .with_phase(ExecutionPhase::Last)
+///         .start_with_delay(7.0)
+///         .emit_with(|observation| ReportTimeReached {
+///             time: observation.time,
+///             period: observation.period,
+///             phase: observation.phase,
+///         }),
+/// );
+///
+/// context.subscribe_to_event(|_context, _event: ReportTimeReached| {
+///     // collect periodic reports
+/// });
+/// ```
+///
 pub struct PeriodicTimeTrigger {
     period: f64,
     start: PeriodicTimeTriggerStart,

--- a/src/triggers/property_change.rs
+++ b/src/triggers/property_change.rs
@@ -1,85 +1,3 @@
-//! Trigger criterion for writes to an entity property with particular previous and/or current
-//! values.
-//!
-//! [`PropertyChangeTrigger`] observes
-//! [`PropertyChangeEvent`](crate::entity::events::PropertyChangeEvent) for a specific
-//! entity/property pair and emits when a property write matches its configured previous value,
-//! current value, or both.
-//!
-//! ## Construction
-//!
-//! ```rust,ignore
-//! PropertyChangeTrigger::<E, P>::from(from)
-//! PropertyChangeTrigger::<E, P>::to(to)
-//! PropertyChangeTrigger::<E, P>::from_to(from, to)
-//! PropertyChangeTrigger::<E, P>::from(from).once()
-//! PropertyChangeTrigger::<E, P>::from(from).repeating()
-//! ```
-//!
-//! ## Observation
-//!
-//! The observation data passed to
-//! [`TriggerCriterion::emit_with`](super::TriggerCriterion::emit_with) is
-//! [`PropertyChangeTriggerEvent`]. It contains the entity ID, the previous property value, the
-//! current property value, and the selected [`TriggerMode`](super::TriggerMode) with which the
-//! trigger was created:
-//!
-//! ```rust,ignore
-//! pub struct PropertyChangeTriggerEvent<E, P>
-//! where
-//!     E: Entity,
-//!     P: Property<E>,
-//! {
-//!     pub entity_id: EntityId<E>,
-//!     pub previous: P,
-//!     pub current: P,
-//!     pub mode: TriggerMode,
-//! }
-//! ```
-//!
-//! ## Semantics
-//!
-//! By default, the criterion uses [`TriggerMode::Repeating`](super::TriggerMode::Repeating) and
-//! emits for every matching property write. Call [`PropertyChangeTrigger::once`] to emit only for
-//! the first matching write, or [`PropertyChangeTrigger::repeating`] to return to the default
-//! repeating behavior.
-//!
-//! A `from` constraint matches `event.previous`; a `to` constraint matches `event.current`;
-//! `from_to` requires both. Property writes are eventful even when the old and new values are
-//! equal. For example, `PropertyChangeTrigger::to(Alive(false))` can match a write that sets
-//! `Alive(false)` when the entity was already `Alive(false)`, and
-//! `PropertyChangeTrigger::from_to(Alive(false), Alive(false))` matches that no-op write exactly.
-//!
-//! ## Example
-//!
-//! ```rust
-//! use ixa::{Context, ContextEntitiesExt, define_entity, define_property, IxaEvent};
-//! use ixa::entity::EntityId;
-//! use ixa::triggers::{ContextTriggersExt, PropertyChangeTrigger, TriggerCriterion};
-//!
-//! define_entity!(Person);
-//! define_property!(struct Alive(bool), Person, default_const = Alive(true));
-//!
-//! #[derive(IxaEvent)]
-//! struct FirstDeath {
-//!     person: EntityId<Person>
-//! }
-//!
-//! let mut context = Context::new();
-//!
-//! context.register_trigger(
-//!     PropertyChangeTrigger::from_to(Alive(true), Alive(false))
-//!         .once()
-//!         .emit_with(|observation| FirstDeath {
-//!             person: observation.entity_id
-//!         }),
-//! );
-//!
-//! context.subscribe_to_event(|_context, _event: FirstDeath| {
-//!     // respond when a person changes from alive to dead
-//! });
-//! ```
-//!
 use std::cell::Cell;
 use std::marker::PhantomData;
 use std::rc::Rc;
@@ -90,6 +8,87 @@ use crate::entity::property::Property;
 use crate::entity::{Entity, EntityId};
 use crate::Context;
 
+/// Trigger criterion for writes to an entity property with particular previous and/or current
+/// values.
+///
+/// [`PropertyChangeTrigger`] observes
+/// [`PropertyChangeEvent`](crate::entity::events::PropertyChangeEvent) for a specific
+/// entity/property pair and emits when a property write matches its configured previous value,
+/// current value, or both.
+///
+/// ## Construction
+///
+/// ```rust,ignore
+/// PropertyChangeTrigger::<E, P>::from(from)
+/// PropertyChangeTrigger::<E, P>::to(to)
+/// PropertyChangeTrigger::<E, P>::from_to(from, to)
+/// PropertyChangeTrigger::<E, P>::from(from).once()
+/// PropertyChangeTrigger::<E, P>::from(from).repeating()
+/// ```
+///
+/// ## Observation
+///
+/// The observation data passed to
+/// [`TriggerCriterion::emit_with`](super::TriggerCriterion::emit_with) is
+/// [`PropertyChangeTriggerEvent`]. It contains the entity ID, the previous property value, the
+/// current property value, and the selected [`TriggerMode`](super::TriggerMode) with which the
+/// trigger was created:
+///
+/// ```rust,ignore
+/// pub struct PropertyChangeTriggerEvent<E, P>
+/// where
+///     E: Entity,
+///     P: Property<E>,
+/// {
+///     pub entity_id: EntityId<E>,
+///     pub previous: P,
+///     pub current: P,
+///     pub mode: TriggerMode,
+/// }
+/// ```
+///
+/// ## Semantics
+///
+/// By default, the criterion uses [`TriggerMode::Repeating`](super::TriggerMode::Repeating) and
+/// emits for every matching property write. Call [`PropertyChangeTrigger::once`] to emit only for
+/// the first matching write, or [`PropertyChangeTrigger::repeating`] to return to the default
+/// repeating behavior.
+///
+/// A `from` constraint matches `event.previous`; a `to` constraint matches `event.current`;
+/// `from_to` requires both. Property writes are eventful even when the old and new values are
+/// equal. For example, `PropertyChangeTrigger::to(Alive(false))` can match a write that sets
+/// `Alive(false)` when the entity was already `Alive(false)`, and
+/// `PropertyChangeTrigger::from_to(Alive(false), Alive(false))` matches that no-op write exactly.
+///
+/// ## Example
+///
+/// ```rust
+/// use ixa::{Context, ContextEntitiesExt, define_entity, define_property, IxaEvent};
+/// use ixa::entity::EntityId;
+/// use ixa::triggers::{ContextTriggersExt, PropertyChangeTrigger, TriggerCriterion};
+///
+/// define_entity!(Person);
+/// define_property!(struct Alive(bool), Person, default_const = Alive(true));
+///
+/// #[derive(IxaEvent)]
+/// struct FirstDeath {
+///     person: EntityId<Person>
+/// }
+///
+/// let mut context = Context::new();
+///
+/// context.register_trigger(
+///     PropertyChangeTrigger::from_to(Alive(true), Alive(false))
+///         .once()
+///         .emit_with(|observation| FirstDeath {
+///             person: observation.entity_id
+///         }),
+/// );
+///
+/// context.subscribe_to_event(|_context, _event: FirstDeath| {
+///     // respond when a person changes from alive to dead
+/// });
+/// ```
 pub struct PropertyChangeTrigger<E, P>
 where
     E: Entity,

--- a/src/triggers/property_value_count.rs
+++ b/src/triggers/property_value_count.rs
@@ -1,109 +1,3 @@
-//! Trigger criterion for the count of entities with a particular property value.
-//!
-//! [`PropertyValueCountTrigger`] observes
-//! [`EntityCreatedEvent`](crate::entity::events::EntityCreatedEvent) and
-//! [`PropertyChangeEvent`](crate::entity::events::PropertyChangeEvent) for a specific
-//! entity/property pair and emits when the count of entities with a configured property value
-//! crosses a configured threshold.
-//!
-//! ## Construction
-//!
-//! ```rust,ignore
-//! PropertyValueCountTrigger::<E, P>::increases_to(value, threshold)
-//! PropertyValueCountTrigger::<E, P>::decreases_to(value, threshold)
-//! PropertyValueCountTrigger::<E, P>::changes_to(value, threshold)
-//! PropertyValueCountTrigger::<E, P>::changes_to(value, threshold).once()
-//! PropertyValueCountTrigger::<E, P>::changes_to(value, threshold).repeating()
-//! ```
-//!
-//! ## Observation
-//!
-//! The observation data passed to
-//! [`TriggerCriterion::emit_with`](super::TriggerCriterion::emit_with) is
-//! [`PropertyValueCountTriggerEvent`]. It contains the entity ID whose creation or property write
-//! caused the crossing, the tracked property value, the new count, the observed
-//! [`Direction`](super::Direction), the configured direction filter as `Option<Direction>`, and the
-//! selected [`TriggerMode`](super::TriggerMode):
-//!
-//! ```rust,ignore
-//! pub struct PropertyValueCountTriggerEvent<E, P>
-//! where
-//!     E: Entity,
-//!     P: Property<E>,
-//! {
-//!     pub entity_id: EntityId<E>,
-//!     pub value: P,
-//!     pub count: usize,
-//!     pub direction_filter: Option<Direction>,
-//!     pub direction: Direction,
-//!     pub mode: TriggerMode,
-//! }
-//! ```
-//!
-//! ## Semantics
-//!
-//! The initial count is measured when the trigger is registered. The criterion emits only on a
-//! later threshold crossing. Since counts change one entity at a time, a crossing occurs when the
-//! new count equals the threshold and differs from the previous count. [`Direction::Increasing`]
-//! means the count increased to the threshold, while [`Direction::Decreasing`] means the count
-//! decreased to the threshold. `changes_to` leaves the direction filter unset and emits for either
-//! observed direction. `increases_to` and `decreases_to` set the direction filter to the
-//! corresponding observed direction.
-//!
-//! By default, the criterion uses [`TriggerMode::Repeating`](super::TriggerMode::Repeating) and
-//! emits every time the count crosses the threshold and passes the configured direction filter. Call
-//! [`PropertyValueCountTrigger::once`] to emit only for the first crossing, or
-//! [`PropertyValueCountTrigger::repeating`] to return to the default repeating behavior.
-//!
-//! Entity creation can cause a crossing if the new entity has the tracked value. Property writes
-//! can cause a crossing when they move an entity into or out of the tracked value. A no-op write
-//! where `previous == current` still emits a property-change event at the entity layer, but it does
-//! not change this trigger's tracked count and therefore cannot by itself cross the threshold.
-//!
-//! ## Example
-//!
-//! ```rust
-//! use ixa::{Context, ContextEntitiesExt, define_entity, define_property, IxaEvent};
-//! use ixa::entity::EntityId;
-//! use ixa::triggers::{
-//!     ContextTriggersExt, Direction, PropertyValueCountTrigger, TriggerCriterion, TriggerMode,
-//! };
-//!
-//! define_entity!(Person);
-//! define_property!(
-//!     enum InfectionStatus {
-//!         Susceptible,
-//!         Infectious,
-//!     },
-//!     Person,
-//!     default_const = InfectionStatus::Susceptible
-//! );
-//!
-//! // The event records which person caused us to reach the threshold and
-//! // the value of the threshold itself (as `count`).
-//! #[derive(IxaEvent)]
-//! struct InfectiousThresholdReached {
-//!     person: EntityId<Person>,
-//!     count: usize
-//! }
-//!
-//! let mut context = Context::new();
-//!
-//! context.register_trigger(
-//!     PropertyValueCountTrigger::increases_to(
-//!         InfectionStatus::Infectious,
-//!         2,
-//!     ).emit_with(|observation| InfectiousThresholdReached {
-//!         person: observation.entity_id,
-//!         count: observation.count
-//!     }),
-//! );
-//!
-//! context.subscribe_to_event(|_context, _event: InfectiousThresholdReached| {
-//!     // respond when the infectious count crosses from below 2 to at least 2
-//! });
-//! ```
-
 use std::cell::Cell;
 use std::marker::PhantomData;
 use std::rc::Rc;
@@ -114,6 +8,111 @@ use crate::entity::property::Property;
 use crate::entity::{ContextEntitiesExt, Entity, EntityId};
 use crate::{Context, EntityPropertyTuple};
 
+/// Trigger criterion for the count of entities with a particular property value.
+///
+/// [`PropertyValueCountTrigger`] observes
+/// [`EntityCreatedEvent`](crate::entity::events::EntityCreatedEvent) and
+/// [`PropertyChangeEvent`](crate::entity::events::PropertyChangeEvent) for a specific
+/// entity/property pair and emits when the count of entities with a configured property value
+/// crosses a configured threshold.
+///
+/// ## Construction
+///
+/// ```rust,ignore
+/// PropertyValueCountTrigger::<E, P>::increases_to(value, threshold)
+/// PropertyValueCountTrigger::<E, P>::decreases_to(value, threshold)
+/// PropertyValueCountTrigger::<E, P>::changes_to(value, threshold)
+/// PropertyValueCountTrigger::<E, P>::changes_to(value, threshold).once()
+/// PropertyValueCountTrigger::<E, P>::changes_to(value, threshold).repeating()
+/// ```
+///
+/// ## Observation
+///
+/// The observation data passed to
+/// [`TriggerCriterion::emit_with`](super::TriggerCriterion::emit_with) is
+/// [`PropertyValueCountTriggerEvent`]. It contains the entity ID whose creation or property write
+/// caused the crossing, the tracked property value, the new count, the observed
+/// [`Direction`](super::Direction), the configured direction filter as `Option<Direction>`, and the
+/// selected [`TriggerMode`](super::TriggerMode):
+///
+/// ```rust,ignore
+/// pub struct PropertyValueCountTriggerEvent<E, P>
+/// where
+///     E: Entity,
+///     P: Property<E>,
+/// {
+///     pub entity_id: EntityId<E>,
+///     pub value: P,
+///     pub count: usize,
+///     pub direction_filter: Option<Direction>,
+///     pub direction: Direction,
+///     pub mode: TriggerMode,
+/// }
+/// ```
+///
+/// ## Semantics
+///
+/// The initial count is measured when the trigger is registered. The criterion emits only on a
+/// later threshold crossing. Since counts change one entity at a time, a crossing occurs when the
+/// new count equals the threshold and differs from the previous count. [`Direction::Increasing`]
+/// means the count increased to the threshold, while [`Direction::Decreasing`] means the count
+/// decreased to the threshold. `changes_to` leaves the direction filter unset and emits for either
+/// observed direction. `increases_to` and `decreases_to` set the direction filter to the
+/// corresponding observed direction.
+///
+/// By default, the criterion uses [`TriggerMode::Repeating`](super::TriggerMode::Repeating) and
+/// emits every time the count crosses the threshold and passes the configured direction filter. Call
+/// [`PropertyValueCountTrigger::once`] to emit only for the first crossing, or
+/// [`PropertyValueCountTrigger::repeating`] to return to the default repeating behavior.
+///
+/// Entity creation can cause a crossing if the new entity has the tracked value. Property writes
+/// can cause a crossing when they move an entity into or out of the tracked value. A no-op write
+/// where `previous == current` still emits a property-change event at the entity layer, but it does
+/// not change this trigger's tracked count and therefore cannot by itself cross the threshold.
+///
+/// ## Example
+///
+/// ```rust
+/// use ixa::{Context, ContextEntitiesExt, define_entity, define_property, IxaEvent};
+/// use ixa::entity::EntityId;
+/// use ixa::triggers::{
+///     ContextTriggersExt, Direction, PropertyValueCountTrigger, TriggerCriterion, TriggerMode,
+/// };
+///
+/// define_entity!(Person);
+/// define_property!(
+///     enum InfectionStatus {
+///         Susceptible,
+///         Infectious,
+///     },
+///     Person,
+///     default_const = InfectionStatus::Susceptible
+/// );
+///
+/// // The event records which person caused us to reach the threshold and
+/// // the value of the threshold itself (as `count`).
+/// #[derive(IxaEvent)]
+/// struct InfectiousThresholdReached {
+///     person: EntityId<Person>,
+///     count: usize
+/// }
+///
+/// let mut context = Context::new();
+///
+/// context.register_trigger(
+///     PropertyValueCountTrigger::increases_to(
+///         InfectionStatus::Infectious,
+///         2,
+///     ).emit_with(|observation| InfectiousThresholdReached {
+///         person: observation.entity_id,
+///         count: observation.count
+///     }),
+/// );
+///
+/// context.subscribe_to_event(|_context, _event: InfectiousThresholdReached| {
+///     // respond when the infectious count crosses from below 2 to at least 2
+/// });
+/// ```
 pub struct PropertyValueCountTrigger<E, P>
 where
     E: Entity,

--- a/src/triggers/time.rs
+++ b/src/triggers/time.rs
@@ -1,73 +1,72 @@
-//! Trigger criterion for a specific simulation time.
-//!
-//! [`TimeTrigger`] observes the simulation clock and emits when the simulation reaches a configured
-//! time and execution phase.
-//!
-//! ## Construction
-//!
-//! ```rust,ignore
-//! TimeTrigger::at(at)
-//! TimeTrigger::at_phase(at, phase)
-//! TimeTrigger::at(at).with_phase(phase)
-//! ```
-//!
-//! ## Observation
-//!
-//! The observation data passed to
-//! [`TriggerCriterion::emit_with`](super::TriggerCriterion::emit_with) is [`TimeTriggerEvent`]. It
-//! contains the simulation time observed when the scheduled plan runs and the phase used to schedule
-//! it:
-//!
-//! ```rust,ignore
-//! pub struct TimeTriggerEvent {
-//!     pub time: f64,
-//!     pub phase: ExecutionPhase,
-//! }
-//! ```
-//!
-//! ## Semantics
-//!
-//! This trigger is equivalent to scheduling a plan that emits an event with
-//! [`context.add_plan`](crate::Context::add_plan) /
-//! [`context.add_plan_with_phase`](crate::Context::add_plan_with_phase).
-//!
-//! [`TimeTrigger::at`] uses [`ExecutionPhase::Normal`](crate::ExecutionPhase::Normal).
-//! Constructor time inputs are converted to `f64` and validated when the trigger is installed.
-//! Since time is monotonic, this criterion does not use [`Direction`](super::Direction) or
-//! [`TriggerMode`](super::TriggerMode). It emits once, when its scheduled plan executes. If several
-//! plans are scheduled for the same time, the selected [`ExecutionPhase`](crate::ExecutionPhase)
-//! controls phase ordering.
-//!
-//! ## Example
-//!
-//! ```rust
-//! use ixa::{Context, ExecutionPhase, IxaEvent};
-//! use ixa::triggers::{ContextTriggersExt, TimeTrigger, TriggerCriterion};
-//!
-//! #[derive(IxaEvent)]
-//! struct StopTimeReached {
-//!     time: f64,
-//!     phase: ExecutionPhase,
-//! }
-//!
-//! let mut context = Context::new();
-//!
-//! context.register_trigger(
-//!     TimeTrigger::at_phase(50.0, ExecutionPhase::Last)
-//!         .emit_with(|observation| StopTimeReached {
-//!             time: observation.time,
-//!             phase: observation.phase,
-//!         }),
-//! );
-//!
-//! context.subscribe_to_event(|context, _event: StopTimeReached| {
-//!     context.shutdown();
-//! });
-//! ```
-//!
 use super::TriggerCriterion;
 use crate::{Context, ExecutionPhase};
 
+/// Trigger criterion for a specific simulation time.
+///
+/// [`TimeTrigger`] observes the simulation clock and emits when the simulation reaches a configured
+/// time and execution phase.
+///
+/// ## Construction
+///
+/// ```rust,ignore
+/// TimeTrigger::at(at)
+/// TimeTrigger::at_phase(at, phase)
+/// TimeTrigger::at(at).with_phase(phase)
+/// ```
+///
+/// ## Observation
+///
+/// The observation data passed to
+/// [`TriggerCriterion::emit_with`](super::TriggerCriterion::emit_with) is [`TimeTriggerEvent`]. It
+/// contains the simulation time observed when the scheduled plan runs and the phase used to schedule
+/// it:
+///
+/// ```rust,ignore
+/// pub struct TimeTriggerEvent {
+///     pub time: f64,
+///     pub phase: ExecutionPhase,
+/// }
+/// ```
+///
+/// ## Semantics
+///
+/// This trigger is equivalent to scheduling a plan that emits an event with
+/// [`context.add_plan`](crate::Context::add_plan) /
+/// [`context.add_plan_with_phase`](crate::Context::add_plan_with_phase).
+///
+/// [`TimeTrigger::at`] uses [`ExecutionPhase::Normal`](crate::ExecutionPhase::Normal).
+/// Constructor time inputs are converted to `f64` and validated when the trigger is installed.
+/// Since time is monotonic, this criterion does not use [`Direction`](super::Direction) or
+/// [`TriggerMode`](super::TriggerMode). It emits once, when its scheduled plan executes. If several
+/// plans are scheduled for the same time, the selected [`ExecutionPhase`](crate::ExecutionPhase)
+/// controls phase ordering.
+///
+/// ## Example
+///
+/// ```rust
+/// use ixa::{Context, ExecutionPhase, IxaEvent};
+/// use ixa::triggers::{ContextTriggersExt, TimeTrigger, TriggerCriterion};
+///
+/// #[derive(IxaEvent)]
+/// struct StopTimeReached {
+///     time: f64,
+///     phase: ExecutionPhase,
+/// }
+///
+/// let mut context = Context::new();
+///
+/// context.register_trigger(
+///     TimeTrigger::at_phase(50.0, ExecutionPhase::Last)
+///         .emit_with(|observation| StopTimeReached {
+///             time: observation.time,
+///             phase: observation.phase,
+///         }),
+/// );
+///
+/// context.subscribe_to_event(|context, _event: StopTimeReached| {
+///     context.shutdown();
+/// });
+/// ```
 pub struct TimeTrigger {
     at: f64,
     phase: ExecutionPhase,

--- a/src/triggers/toggling_trigger.rs
+++ b/src/triggers/toggling_trigger.rs
@@ -1,173 +1,3 @@
-//! Composite trigger that toggles between inactive and active states.
-//!
-//! [`TogglingTriggerCriteria`] composes two trigger criteria: one activation criterion and one
-//! deactivation criterion. The trigger starts inactive by default. When the activation criterion
-//! matches while inactive, the trigger becomes active and emits the activation event. Later
-//! activation matches are ignored while the trigger remains active. When the deactivation criterion
-//! matches while active, the trigger becomes inactive and emits the deactivation event. Later
-//! deactivation matches are ignored while the trigger remains inactive.
-//!
-//! This is useful for thermostat-style hysteresis. For example, a model can activate an
-//! intervention when a property-value count reaches a lower threshold and deactivate it when the
-//! same count reaches an upper threshold. The thresholds themselves are ordinary criteria; the
-//! toggling trigger only gates those criteria by its current active/inactive state.
-//!
-//! ## Construction
-//!
-//! ```rust,ignore
-//! TogglingTriggerCriteria::new(activation_criterion, deactivation_criterion)
-//! TogglingTriggerCriteria::new(activation_criterion, deactivation_criterion).initially_active()
-//! TogglingTriggerCriteria::new(activation_criterion, deactivation_criterion).initially_inactive()
-//! TogglingTriggerCriteria::new(activation_criterion, deactivation_criterion).once()
-//! TogglingTriggerCriteria::new(activation_criterion, deactivation_criterion).repeating()
-//! TogglingTriggerCriteria::new(activation_criterion, deactivation_criterion)
-//!     .emit_with(make_active_event, make_inactive_event)
-//! TogglingTriggerCriteria::new(activation_criterion, deactivation_criterion)
-//!     .emit_values(active_event, inactive_event)
-//! TogglingTriggerCriteria::new(activation_criterion, deactivation_criterion)
-//!     .emit_defaults::<ActiveEv, InactiveEv>()
-//! ```
-//!
-//! ```rust,ignore
-//! TogglingTrigger::new(
-//!     activation_criterion,
-//!     make_active_event,
-//!     deactivation_criterion,
-//!     make_inactive_event,
-//! )
-//! TogglingTrigger::new(
-//!     activation_criterion,
-//!     make_active_event,
-//!     deactivation_criterion,
-//!     make_inactive_event,
-//! ).initially_active()
-//! TogglingTrigger::new(
-//!     activation_criterion,
-//!     make_active_event,
-//!     deactivation_criterion,
-//!     make_inactive_event,
-//! ).initially_inactive()
-//! TogglingTrigger::new(
-//!     activation_criterion,
-//!     make_active_event,
-//!     deactivation_criterion,
-//!     make_inactive_event,
-//! ).once()
-//! TogglingTrigger::new(
-//!     activation_criterion,
-//!     make_active_event,
-//!     deactivation_criterion,
-//!     make_inactive_event,
-//! ).repeating()
-//! ```
-//!
-//! ## Observation
-//!
-//! `TogglingTrigger` does not define its own observation struct. The activation event constructor
-//! receives the activation criterion's observation, and the deactivation event constructor receives
-//! the deactivation criterion's observation:
-//!
-//! ```rust,ignore
-//! make_active_event: impl Fn(AC::Observation) -> ActiveEv
-//! make_inactive_event: impl Fn(DC::Observation) -> InactiveEv
-//! ```
-//!
-//! ## Semantics
-//!
-//! - If the trigger is inactive and the activation criterion matches, a single activation event is
-//!   emitted and the trigger's internal state is changed to active.
-//! - If the trigger is inactive and the deactivation criterion matches, there is no effect.
-//! - If the trigger is active and the activation criterion matches, there is no effect.
-//! - If the trigger is active and the deactivation criterion matches, a single deactivation event
-//!   is emitted and the trigger's internal state is changed to inactive.
-//!
-//! ### Repeating or once
-//!
-//! The "mode" of the completed [`TogglingTrigger`] controls how long the active/inactive state
-//! machine remains enabled. A toggling trigger defaults to
-//! [`TriggerMode::Repeating`](super::TriggerMode::Repeating), whether it is constructed through
-//! [`TogglingTriggerCriteria::emit_with`] or directly with [`TogglingTrigger::new`]. In repeating
-//! mode, it can activate, deactivate, and activate again for as long as its component criteria
-//! continue to match.
-//!
-//! Calling [`TogglingTriggerCriteria::once`] or [`TogglingTrigger::once`] sets the completed
-//! toggling trigger to [`TriggerMode::Once`]. For a toggling trigger, "once" means one active
-//! period, _not_ one raw criterion match. If the trigger starts inactive, it can emit one activation
-//! event and then one deactivation event. After that deactivation event, the toggling trigger is
-//! permanently disabled and ignores all later criterion matches. If the trigger starts active with
-//! [`TogglingTriggerCriteria::initially_active`] or [`TogglingTrigger::initially_active`], the one
-//! active period is already in progress; the first accepted deactivation emits the deactivation
-//! event and then disables the trigger. (Matches of the underlying criterion that are ignored
-//! because they occur in the wrong active/inactive state do not by themselves disable a `once`
-//! toggling trigger.)
-//!
-//! The mode of the completed `TogglingTrigger` should not be confused with the mode of each component
-//! criterion, which controls how often that individual criterion reports matches to the toggling
-//! trigger. In fact, component criteria should almost always be repeating even when the
-//! `TogglingTrigger` itself is configured with [`TogglingTriggerCriteria::once`] or
-//! [`TogglingTrigger::once`]. If an underlying criterion uses
-//! [`TriggerMode::Once`](super::TriggerMode::Once), that criterion can be consumed by a match that
-//! the toggling trigger ignores because it occurred in the wrong state. For example, a once-only
-//! activation criterion can match while the toggling trigger is already active; the toggling trigger
-//! will correctly ignore that activation match, but the activation criterion may never report
-//! another match.
-//!
-//! [`TogglingTrigger::new`] is also available for all-at-once construction of a complete
-//! `TogglingTrigger`.
-//!
-//! ## Example
-//!
-//! ```rust
-//! use ixa::{Context, ContextEntitiesExt, define_entity, define_property, IxaEvent};
-//! use ixa::triggers::{
-//!     ContextTriggersExt, PropertyValueCountTrigger, TogglingTriggerCriteria,
-//! };
-//!
-//! define_entity!(Person);
-//! define_property!(
-//!     enum InfectionStatus {
-//!         Susceptible,
-//!         Infectious,
-//!     },
-//!     Person,
-//!     default_const = InfectionStatus::Susceptible
-//! );
-//!
-//! #[derive(IxaEvent)]
-//! struct InterventionActivated {
-//!     count: usize,
-//! }
-//!
-//! #[derive(IxaEvent)]
-//! struct InterventionDeactivated {
-//!     count: usize,
-//! }
-//!
-//! let mut context = Context::new();
-//!
-//! context.register_trigger(TogglingTriggerCriteria::new(
-//!     PropertyValueCountTrigger::changes_to(
-//!         InfectionStatus::Infectious,
-//!         10,
-//!     ),
-//!     PropertyValueCountTrigger::changes_to(
-//!         InfectionStatus::Infectious,
-//!         25,
-//!     ),
-//! ).emit_with(
-//!     |event| InterventionActivated { count: event.count },
-//!     |event| InterventionDeactivated { count: event.count },
-//! ));
-//!
-//! context.subscribe_to_event(|_context, _event: InterventionActivated| {
-//!     // respond when the intervention becomes active
-//! });
-//!
-//! context.subscribe_to_event(|_context, _event: InterventionDeactivated| {
-//!     // respond when the intervention becomes inactive
-//! });
-//! ```
-
 use std::cell::Cell;
 use std::marker::PhantomData;
 use std::rc::Rc;
@@ -176,6 +6,174 @@ use super::{TriggerCriterion, TriggerMode, TriggerSpec};
 use crate::{Context, IxaEvent};
 
 /// A pair of activation and deactivation criteria that can be bound to emitted events.
+///
+/// [`TogglingTriggerCriteria`] composes two trigger criteria: one activation criterion and one
+/// deactivation criterion. The trigger starts inactive by default. When the activation criterion
+/// matches while inactive, the trigger becomes active and emits the activation event. Later
+/// activation matches are ignored while the trigger remains active. When the deactivation criterion
+/// matches while active, the trigger becomes inactive and emits the deactivation event. Later
+/// deactivation matches are ignored while the trigger remains inactive.
+///
+/// This is useful for thermostat-style hysteresis. For example, a model can activate an
+/// intervention when a property-value count reaches a lower threshold and deactivate it when the
+/// same count reaches an upper threshold. The thresholds themselves are ordinary criteria; the
+/// toggling trigger only gates those criteria by its current active/inactive state.
+///
+/// ## Construction
+///
+/// ```rust,ignore
+/// TogglingTriggerCriteria::new(activation_criterion, deactivation_criterion)
+/// TogglingTriggerCriteria::new(activation_criterion, deactivation_criterion).initially_active()
+/// TogglingTriggerCriteria::new(activation_criterion, deactivation_criterion).initially_inactive()
+/// TogglingTriggerCriteria::new(activation_criterion, deactivation_criterion).once()
+/// TogglingTriggerCriteria::new(activation_criterion, deactivation_criterion).repeating()
+/// TogglingTriggerCriteria::new(activation_criterion, deactivation_criterion)
+///     .emit_with(make_active_event, make_inactive_event)
+/// TogglingTriggerCriteria::new(activation_criterion, deactivation_criterion)
+///     .emit_values(active_event, inactive_event)
+/// TogglingTriggerCriteria::new(activation_criterion, deactivation_criterion)
+///     .emit_defaults::<ActiveEv, InactiveEv>()
+/// ```
+///
+/// ```rust,ignore
+/// TogglingTrigger::new(
+///     activation_criterion,
+///     make_active_event,
+///     deactivation_criterion,
+///     make_inactive_event,
+/// )
+/// TogglingTrigger::new(
+///     activation_criterion,
+///     make_active_event,
+///     deactivation_criterion,
+///     make_inactive_event,
+/// ).initially_active()
+/// TogglingTrigger::new(
+///     activation_criterion,
+///     make_active_event,
+///     deactivation_criterion,
+///     make_inactive_event,
+/// ).initially_inactive()
+/// TogglingTrigger::new(
+///     activation_criterion,
+///     make_active_event,
+///     deactivation_criterion,
+///     make_inactive_event,
+/// ).once()
+/// TogglingTrigger::new(
+///     activation_criterion,
+///     make_active_event,
+///     deactivation_criterion,
+///     make_inactive_event,
+/// ).repeating()
+/// ```
+///
+/// ## Observation
+///
+/// `TogglingTrigger` does not define its own observation struct. The activation event constructor
+/// receives the activation criterion's observation, and the deactivation event constructor receives
+/// the deactivation criterion's observation:
+///
+/// ```rust,ignore
+/// make_active_event: impl Fn(AC::Observation) -> ActiveEv
+/// make_inactive_event: impl Fn(DC::Observation) -> InactiveEv
+/// ```
+///
+/// ## Semantics
+///
+/// - If the trigger is inactive and the activation criterion matches, a single activation event is
+///   emitted and the trigger's internal state is changed to active.
+/// - If the trigger is inactive and the deactivation criterion matches, there is no effect.
+/// - If the trigger is active and the activation criterion matches, there is no effect.
+/// - If the trigger is active and the deactivation criterion matches, a single deactivation event
+///   is emitted and the trigger's internal state is changed to inactive.
+///
+/// ### Repeating or once
+///
+/// The "mode" of the completed [`TogglingTrigger`] controls how long the active/inactive state
+/// machine remains enabled. A toggling trigger defaults to
+/// [`TriggerMode::Repeating`](super::TriggerMode::Repeating), whether it is constructed through
+/// [`TogglingTriggerCriteria::emit_with`] or directly with [`TogglingTrigger::new`]. In repeating
+/// mode, it can activate, deactivate, and activate again for as long as its component criteria
+/// continue to match.
+///
+/// Calling [`TogglingTriggerCriteria::once`] or [`TogglingTrigger::once`] sets the completed
+/// toggling trigger to [`TriggerMode::Once`]. For a toggling trigger, "once" means one active
+/// period, _not_ one raw criterion match. If the trigger starts inactive, it can emit one activation
+/// event and then one deactivation event. After that deactivation event, the toggling trigger is
+/// permanently disabled and ignores all later criterion matches. If the trigger starts active with
+/// [`TogglingTriggerCriteria::initially_active`] or [`TogglingTrigger::initially_active`], the one
+/// active period is already in progress; the first accepted deactivation emits the deactivation
+/// event and then disables the trigger. (Matches of the underlying criterion that are ignored
+/// because they occur in the wrong active/inactive state do not by themselves disable a `once`
+/// toggling trigger.)
+///
+/// The mode of the completed `TogglingTrigger` should not be confused with the mode of each component
+/// criterion, which controls how often that individual criterion reports matches to the toggling
+/// trigger. In fact, component criteria should almost always be repeating even when the
+/// `TogglingTrigger` itself is configured with [`TogglingTriggerCriteria::once`] or
+/// [`TogglingTrigger::once`]. If an underlying criterion uses
+/// [`TriggerMode::Once`](super::TriggerMode::Once), that criterion can be consumed by a match that
+/// the toggling trigger ignores because it occurred in the wrong state. For example, a once-only
+/// activation criterion can match while the toggling trigger is already active; the toggling trigger
+/// will correctly ignore that activation match, but the activation criterion may never report
+/// another match.
+///
+/// [`TogglingTrigger::new`] is also available for all-at-once construction of a complete
+/// `TogglingTrigger`.
+///
+/// ## Example
+///
+/// ```rust
+/// use ixa::{Context, ContextEntitiesExt, define_entity, define_property, IxaEvent};
+/// use ixa::triggers::{
+///     ContextTriggersExt, PropertyValueCountTrigger, TogglingTriggerCriteria,
+/// };
+///
+/// define_entity!(Person);
+/// define_property!(
+///     enum InfectionStatus {
+///         Susceptible,
+///         Infectious,
+///     },
+///     Person,
+///     default_const = InfectionStatus::Susceptible
+/// );
+///
+/// #[derive(IxaEvent)]
+/// struct InterventionActivated {
+///     count: usize,
+/// }
+///
+/// #[derive(IxaEvent)]
+/// struct InterventionDeactivated {
+///     count: usize,
+/// }
+///
+/// let mut context = Context::new();
+///
+/// context.register_trigger(TogglingTriggerCriteria::new(
+///     PropertyValueCountTrigger::changes_to(
+///         InfectionStatus::Infectious,
+///         10,
+///     ),
+///     PropertyValueCountTrigger::changes_to(
+///         InfectionStatus::Infectious,
+///         25,
+///     ),
+/// ).emit_with(
+///     |event| InterventionActivated { count: event.count },
+///     |event| InterventionDeactivated { count: event.count },
+/// ));
+///
+/// context.subscribe_to_event(|_context, _event: InterventionActivated| {
+///     // respond when the intervention becomes active
+/// });
+///
+/// context.subscribe_to_event(|_context, _event: InterventionDeactivated| {
+///     // respond when the intervention becomes inactive
+/// });
+/// ```
 pub struct TogglingTriggerCriteria<AC, DC> {
     activation_criterion: AC,
     deactivation_criterion: DC,
@@ -305,8 +303,12 @@ where
     }
 }
 
+/// Composite trigger that toggles between inactive and active states.
+///
 /// A complete installable trigger specification that emits activation and deactivation events when
 /// its paired criteria cause state changes.
+///
+/// See [TogglingTriggerCriteria] for complete documentation.
 pub struct TogglingTrigger<AC, DC, ActiveEv, InactiveEv, MakeActive, MakeInactive> {
     activation_criterion: AC,
     deactivation_criterion: DC,


### PR DESCRIPTION
The complete documentation for each of the built-in trigger types was on the trigger type's submodule, but because these submodules are private, the docs aren't rendered. The trigger type itself is re-exported from the `trigger` module. This PR moves the complete docs to the trigger type itself, where it is accessible. 