### PR TITLE
feat: Deprecate the plan module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Deprecated
+
+- `ixa::plan::PlanId`; use `ixa::PlanId` instead ([#977](https://github.com/CDCgov/ixa/issues/977))
+
 ## [2.1.0](https://github.com/CDCgov/ixa/compare/ixa-v2.0.0...ixa-v2.1.0) - 2026-06-29
 
 ### Added

--- a/examples/births-deaths/README.md
+++ b/examples/births-deaths/README.md
@@ -198,7 +198,7 @@ fn cancel_recovery_plans(context: &mut Context, person_id: PersonId) {
     let plans_set = plans_data_container
         .plans_map
         .get(&person_id)
-        .unwrap_or(&HashSet::<plan::PlanId>::new())
+        .unwrap_or(&HashSet::<PlanId>::new())
         .clone();
 
     for plan_id in plans_set {

--- a/examples/births-deaths/src/infection_manager.rs
+++ b/examples/births-deaths/src/infection_manager.rs
@@ -1,7 +1,6 @@
 use ixa::entity::events::PropertyChangeEvent;
-use ixa::plan::PlanId;
 use ixa::prelude::*;
-use ixa::{HashMap, HashMapExt, HashSet, HashSetExt};
+use ixa::{HashMap, HashMapExt, HashSet, HashSetExt, PlanId};
 use rand_distr::Exp;
 
 use crate::population_manager::{Alive, InfectionStatus, Person, PersonId};

--- a/integration-tests/ixa-macro-tests/tests/macros.rs
+++ b/integration-tests/ixa-macro-tests/tests/macros.rs
@@ -5,7 +5,7 @@ mod tests {
     use std::rc::Rc;
 
     use ixa::prelude::*;
-    use ixa::HashSet;
+    use ixa::{HashSet, IxaEvent};
     use serde::{Deserialize, Serialize};
 
     define_entity!(Person);
@@ -208,6 +208,15 @@ mod tests {
 
     // Test rng macro
     define_rng!(TestRngId);
+
+    #[derive(ixa::IxaEvent)]
+    struct PreludeTestEvent;
+
+    #[test]
+    fn prelude_exports_cancellation_ids() {
+        let _: Option<PlanId> = None;
+        let _: Option<EventListenerId<PreludeTestEvent>> = None;
+    }
 
     fn as_context(context: &mut Context) -> &mut Context {
         context

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -70,10 +70,13 @@ pub use network::{ContextNetworkExt, Edge, EdgeType};
 pub mod macros;
 
 pub mod plan_queue;
+pub use plan_queue::PlanId;
+
 /// Compatibility re-exports for plan-related public API.
 ///
-/// The plan queue implementation lives in [`crate::plan_queue`]. This module is
-/// retained so existing `ixa::plan::PlanId` imports continue to work.
+/// This module is retained so existing `ixa::plan::PlanId` imports continue to
+/// work. Use [`crate::PlanId`] instead.
+#[deprecated(note = "use `ixa::PlanId` instead")]
 pub mod plan {
     pub use crate::plan_queue::PlanId;
 }

--- a/src/plan_queue.rs
+++ b/src/plan_queue.rs
@@ -1,8 +1,8 @@
-//! A priority queue that stores scheduled simulation plans.
+//! Implementation details for Ixa's plan queues.
 //!
-//! Defines [`PlanQueue`], which stores regular time-ordered plans and
-//! shutdown-time plans. Both queues share a single [`PlanId`] allocator and
-//! cancellation map.
+//! [`PlanId`] is the only public item in this module. The queues store regular
+//! time-ordered plans and shutdown-time plans, sharing a single `PlanId`
+//! allocator and cancellation map.
 
 use std::cmp::Ordering;
 use std::collections::BinaryHeap;
@@ -271,7 +271,20 @@ impl Ord for PlanSchedule {
     }
 }
 
-/// A unique identifier for a plan added to a [`PlanQueue`].
+/// A unique identifier for a plan scheduled on a [`Context`].
+///
+/// `PlanId` values are returned by [`Context::add_plan`] and related scheduling
+/// methods, and can be passed to [`Context::cancel_plan`].
+///
+/// # Examples
+///
+/// ```
+/// use ixa::{Context, PlanId};
+///
+/// let mut context = Context::new();
+/// let plan_id: PlanId = context.add_plan(1.0, |_| {});
+/// context.cancel_plan(&plan_id);
+/// ```
 #[derive(Clone, Copy, Debug, Hash, Eq, PartialEq)]
 pub struct PlanId(pub(crate) u64);
 

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -1,4 +1,4 @@
-pub use crate::context::Context;
+pub use crate::context::{Context, EventListenerId};
 pub use crate::entity::events::{EntityCreatedEvent, PropertyChangeEvent};
 pub use crate::entity::property::{IndexableProperty, Property};
 pub use crate::entity::{ContextEntitiesExt, Entity, EntityId};
@@ -12,5 +12,6 @@ pub use crate::{
     define_data_plugin, define_derived_property, define_edge_type, define_entity,
     define_global_property, define_multi_property, define_property, define_report, define_rng,
     impl_edge_type, impl_entity, impl_property, impl_property_eq, impl_property_eq_hash,
-    impl_property_hash, schedule_relative, track_periodic_value_change_counts, with, PluginContext,
+    impl_property_hash, schedule_relative, track_periodic_value_change_counts, with, PlanId,
+    PluginContext,
 };


### PR DESCRIPTION
 ## Summary

  - Re-export `PlanId` from the `ixa` crate root.
  - Deprecate `ixa::plan::PlanId` in favor of `ixa::PlanId`.
  - Update the births/deaths example, README, rustdoc, and changelog.
  - Retain legacy modules for 2.x; their removal remains a planned 3.0 breaking change.