### PR TITLE
chore: add startup-time plans

### DIFF
--- a/src/context.rs
+++ b/src/context.rs
@@ -117,8 +117,8 @@ enum ShutdownStatus {
 ///
 /// Provides core simulation services including
 /// * Maintaining a notion of time
-/// * Scheduling events to occur at some point in the future and executing them
-///   at that time
+/// * Scheduling regular work on the simulation timeline
+/// * Scheduling work for the startup and shutdown lifecycle stages
 /// * Holding data that can be accessed by simulation modules
 ///
 /// Simulations are constructed out of a series of interacting modules that
@@ -126,14 +126,16 @@ enum ShutdownStatus {
 /// store data in the simulation using the [`DataPlugin`] trait that allows them
 /// to retrieve data by type.
 ///
-/// The future event list of the simulation is a queue of `Callback` objects -
-/// called `plans` - that will assume control of the [`Context`] at a future point
-/// in time and execute the logic in the associated `FnOnce(&mut Context)`
-/// closure. Modules can add plans to this queue through the [`Context`].
+/// The future event list of the simulation is a queue of regular plans that
+/// assume control of the [`Context`] at a specified simulation time and execute
+/// the logic in an associated `FnOnce(&mut Context)` closure. Modules can also
+/// schedule startup-time plans, which run once at the effective simulation start
+/// time before regular plans, and shutdown-time plans, which run after regular
+/// work for an execution pass is exhausted.
 ///
-/// The simulation also has a separate callback mechanism. Callbacks
-/// fire before the next timed event (even if it is scheduled for the
-/// current time). This allows modules to schedule actions for immediate
+/// The simulation also has a separate callback mechanism. Callbacks fire before
+/// the next plan selected for execution, including startup-time, regular, and
+/// shutdown-time plans. This allows modules to schedule actions for immediate
 /// execution but outside of the current iteration of the event loop.
 ///
 /// Modules can also emit 'events' that other modules can subscribe to handle by
@@ -151,6 +153,7 @@ pub struct Context {
     current_time: Option<f64>,
     start_time: Option<f64>,
     shutdown_status: ShutdownStatus,
+    startup_complete: bool,
     execution_profiler: ExecutionProfilingCollector,
     pub(crate) print_execution_statistics: bool,
 }
@@ -180,6 +183,7 @@ impl Context {
             current_time: None,
             start_time: None,
             shutdown_status: ShutdownStatus::None,
+            startup_complete: false,
             execution_profiler: ExecutionProfilingCollector::new(),
             print_execution_statistics: false,
         }
@@ -375,6 +379,44 @@ impl Context {
         );
         self.plan_queue
             .add_plan(time, Box::new(callback), phase, is_passive)
+    }
+
+    /// Add a plan to execute during startup-time in the normal phase.
+    ///
+    /// Startup-time plans execute at the effective simulation start time before
+    /// any regular plan. They are ordered by phase and insertion order.
+    ///
+    /// Returns a [`PlanId`] for the newly-added plan that can be used to cancel it
+    /// if needed.
+    ///
+    /// # Panics
+    ///
+    /// Panics if startup-time plans have already been exhausted.
+    pub fn add_startup_plan(&mut self, callback: impl FnOnce(&mut Context) + 'static) -> PlanId {
+        self.add_startup_plan_with_phase(callback, ExecutionPhase::Normal)
+    }
+
+    /// Add a plan to execute during startup-time with the specified phase.
+    ///
+    /// Startup-time plans execute at the effective simulation start time before
+    /// any regular plan. They are ordered by phase and insertion order.
+    ///
+    /// Returns a [`PlanId`] for the newly-added plan that can be used to cancel it
+    /// if needed.
+    ///
+    /// # Panics
+    ///
+    /// Panics if startup-time plans have already been exhausted.
+    pub fn add_startup_plan_with_phase(
+        &mut self,
+        callback: impl FnOnce(&mut Context) + 'static,
+        phase: ExecutionPhase,
+    ) -> PlanId {
+        assert!(
+            !self.startup_complete,
+            "Startup-time plans cannot be added after startup has completed."
+        );
+        self.plan_queue.add_startup_plan(Box::new(callback), phase)
     }
 
     /// Add a plan to execute during shutdown-time in the normal phase.
@@ -607,8 +649,8 @@ impl Context {
         self.start_time
     }
 
-    /// Execute the simulation until callbacks and plans are exhausted and shutdown
-    /// work is complete.
+    /// Execute the simulation until startup work, callbacks, and plans are
+    /// exhausted and shutdown work is complete.
     pub fn execute(&mut self) {
         trace!("entering event loop");
 
@@ -652,8 +694,23 @@ impl Context {
             return;
         }
 
-        // No callback is available, so the shutdown status determines which
-        // plan queue, if any, can provide the next unit of work.
+        // A stopped status is a manual-step transition of its own. Do not run
+        // startup work until a later step, matching the existing stopped-state
+        // behavior.
+        if self.shutdown_status != ShutdownStatus::Stopped && !self.startup_complete {
+            self.current_time
+                .get_or_insert(self.start_time.unwrap_or(0.0));
+            if let Some(plan) = self.plan_queue.pop_next_startup() {
+                trace!("calling startup-time plan");
+                (plan.data)(self);
+                return;
+            }
+
+            self.startup_complete = true;
+        }
+
+        // No callback or startup-time plan is available, so the shutdown status
+        // determines which plan queue, if any, can provide the next unit of work.
         match self.shutdown_status {
             ShutdownStatus::None => {
                 // Normal execution may advance simulation time to the next
@@ -736,6 +793,12 @@ pub trait ContextBase: Sized {
         callback: impl FnOnce(&mut Context) + 'static,
         phase: ExecutionPhase,
     ) -> PlanId;
+    fn add_startup_plan(&mut self, callback: impl FnOnce(&mut Context) + 'static) -> PlanId;
+    fn add_startup_plan_with_phase(
+        &mut self,
+        callback: impl FnOnce(&mut Context) + 'static,
+        phase: ExecutionPhase,
+    ) -> PlanId;
     fn add_shutdown_plan(&mut self, callback: impl FnOnce(&mut Context) + 'static) -> PlanId;
     fn add_shutdown_plan_with_phase(
         &mut self,
@@ -770,6 +833,8 @@ impl ContextBase for Context {
             fn add_plan_with_phase(&mut self, time: f64, callback: impl FnOnce(&mut Context) + 'static, phase: ExecutionPhase) -> PlanId;
             fn add_passive_plan(&mut self, time: f64, callback: impl FnOnce(&mut Context) + 'static) -> PlanId;
             fn add_passive_plan_with_phase(&mut self, time: f64, callback: impl FnOnce(&mut Context) + 'static, phase: ExecutionPhase) -> PlanId;
+            fn add_startup_plan(&mut self, callback: impl FnOnce(&mut Context) + 'static) -> PlanId;
+            fn add_startup_plan_with_phase(&mut self, callback: impl FnOnce(&mut Context) + 'static, phase: ExecutionPhase) -> PlanId;
             fn add_shutdown_plan(&mut self, callback: impl FnOnce(&mut Context) + 'static) -> PlanId;
             fn add_shutdown_plan_with_phase(&mut self, callback: impl FnOnce(&mut Context) + 'static, phase: ExecutionPhase) -> PlanId;
             fn add_periodic_plan_with_phase(&mut self, period: f64, callback: impl Fn(&mut Context) + 'static, phase: ExecutionPhase);
@@ -874,6 +939,25 @@ mod tests {
     ) -> PlanId {
         context.add_passive_plan_with_phase(
             time,
+            move |context| {
+                context.get_data_mut(ComponentA).push(value);
+            },
+            phase,
+        )
+    }
+
+    fn add_startup_plan(context: &mut Context, value: u32) -> PlanId {
+        context.add_startup_plan(move |context| {
+            context.get_data_mut(ComponentA).push(value);
+        })
+    }
+
+    fn add_startup_plan_with_phase(
+        context: &mut Context,
+        value: u32,
+        phase: ExecutionPhase,
+    ) -> PlanId {
+        context.add_startup_plan_with_phase(
             move |context| {
                 context.get_data_mut(ComponentA).push(value);
             },
@@ -1363,6 +1447,185 @@ mod tests {
         context.shutdown();
         context.execute();
         assert_eq!(*obs_data.borrow(), 1);
+    }
+
+    #[test]
+    fn startup_time_plans_run_before_regular_plans_across_phases() {
+        let mut context = Context::new();
+        context.set_start_time(-2.0);
+        add_plan_with_phase(&mut context, -2.0, 4, ExecutionPhase::First);
+        add_plan(&mut context, -2.0, 5);
+        add_plan_with_phase(&mut context, -2.0, 6, ExecutionPhase::Last);
+        add_startup_plan_with_phase(&mut context, 3, ExecutionPhase::Last);
+        add_startup_plan_with_phase(&mut context, 1, ExecutionPhase::First);
+        add_startup_plan(&mut context, 2);
+
+        context.execute();
+
+        assert_eq!(context.get_current_time(), -2.0);
+        assert_eq!(*context.get_data_mut(ComponentA), vec![1, 2, 3, 4, 5, 6]);
+    }
+
+    #[test]
+    fn startup_plan_observes_effective_start_time() {
+        let mut context = Context::new();
+        context.set_start_time(-2.0);
+        let observed_time = Rc::new(RefCell::new(f64::NAN));
+        let observed_time_clone = Rc::clone(&observed_time);
+        context.add_startup_plan(move |context| {
+            *observed_time_clone.borrow_mut() = context.get_current_time();
+        });
+
+        context.execute();
+
+        assert_eq!(*observed_time.borrow(), -2.0);
+    }
+
+    #[test]
+    fn startup_plans_drain_before_dynamically_scheduled_regular_plans() {
+        let mut context = Context::new();
+        context.add_startup_plan(|context| {
+            context.get_data_mut(ComponentA).push(1);
+            context.queue_callback(|context| {
+                context.get_data_mut(ComponentA).push(2);
+            });
+            let time = context.get_current_time();
+            add_plan(context, time, 4);
+        });
+        add_startup_plan(&mut context, 3);
+
+        context.execute();
+
+        assert_eq!(*context.get_data_mut(ComponentA), vec![1, 2, 3, 4]);
+    }
+
+    #[test]
+    fn startup_plan_can_schedule_another_startup_plan() {
+        let mut context = Context::new();
+        context.add_startup_plan(|context| {
+            context.get_data_mut(ComponentA).push(1);
+            context.add_startup_plan(|context| {
+                context.get_data_mut(ComponentA).push(3);
+            });
+        });
+        add_startup_plan(&mut context, 2);
+        add_plan(&mut context, 0.0, 4);
+
+        context.execute();
+
+        assert_eq!(*context.get_data_mut(ComponentA), vec![1, 2, 3, 4]);
+    }
+
+    #[test]
+    fn startup_plan_can_be_canceled() {
+        let mut context = Context::new();
+        let canceled = add_startup_plan(&mut context, 1);
+        context.cancel_plan(&canceled);
+        add_startup_plan(&mut context, 2);
+
+        context.execute();
+
+        assert_eq!(*context.get_data_mut(ComponentA), vec![2]);
+    }
+
+    #[test]
+    fn startup_plans_run_once_across_multiple_execute_calls() {
+        let mut context = Context::new();
+        add_startup_plan(&mut context, 1);
+        add_plan(&mut context, 0.0, 2);
+
+        context.execute();
+        add_plan(&mut context, 0.0, 3);
+        context.execute();
+
+        assert_eq!(*context.get_data_mut(ComponentA), vec![1, 2, 3]);
+    }
+
+    #[test]
+    #[should_panic(expected = "Startup-time plans cannot be added after startup has completed.")]
+    fn add_startup_plan_after_startup_panics() {
+        let mut context = Context::new();
+        context.execute();
+
+        context.add_startup_plan_with_phase(|_| {}, ExecutionPhase::First);
+    }
+
+    #[test]
+    fn shutdown_during_startup_waits_for_startup_plans() {
+        let mut context = Context::new();
+        context.add_startup_plan(|context| {
+            context.get_data_mut(ComponentA).push(1);
+            context.shutdown();
+        });
+        add_startup_plan(&mut context, 2);
+        add_plan(&mut context, 0.0, 3);
+        add_plan(&mut context, 1.0, 4);
+        context.add_shutdown_plan(|context| {
+            context.get_data_mut(ComponentA).push(5);
+        });
+
+        context.execute();
+        assert_eq!(*context.get_data_mut(ComponentA), vec![1, 2, 3, 5]);
+
+        context.execute();
+        assert_eq!(*context.get_data_mut(ComponentA), vec![1, 2, 3, 5, 4]);
+    }
+
+    #[test]
+    fn abort_during_startup_resumes_remaining_startup_plans() {
+        let mut context = Context::new();
+        context.add_startup_plan(|context| {
+            context.get_data_mut(ComponentA).push(1);
+            context.abort();
+        });
+        add_startup_plan(&mut context, 2);
+        add_plan(&mut context, 0.0, 3);
+
+        context.execute();
+        assert_eq!(*context.get_data_mut(ComponentA), vec![1]);
+
+        context.execute();
+        assert_eq!(*context.get_data_mut(ComponentA), vec![1, 2, 3]);
+    }
+
+    #[test]
+    fn execute_single_step_prioritizes_startup_plans_and_callbacks() {
+        let mut context = Context::new();
+        context.set_start_time(-2.0);
+        context.add_startup_plan(|context| {
+            assert_eq!(context.get_current_time(), -2.0);
+            context.get_data_mut(ComponentA).push(1);
+            context.queue_callback(|context| {
+                context.get_data_mut(ComponentA).push(2);
+            });
+        });
+        add_startup_plan(&mut context, 3);
+        add_plan(&mut context, -2.0, 4);
+
+        context.execute_single_step();
+        assert_eq!(*context.get_data_mut(ComponentA), vec![1]);
+
+        context.execute_single_step();
+        assert_eq!(*context.get_data_mut(ComponentA), vec![1, 2]);
+
+        context.execute_single_step();
+        assert_eq!(*context.get_data_mut(ComponentA), vec![1, 2, 3]);
+
+        context.execute_single_step();
+        assert_eq!(*context.get_data_mut(ComponentA), vec![1, 2, 3, 4]);
+        assert!(context.startup_complete);
+    }
+
+    #[test]
+    #[should_panic(expected = "Startup-time plans cannot be added after startup has completed.")]
+    fn add_startup_plan_after_single_step_completion_panics() {
+        let mut context = Context::new();
+        context.add_startup_plan(|_| {});
+
+        context.execute_single_step();
+        context.execute_single_step();
+
+        context.add_startup_plan(|_| {});
     }
 
     #[test]

--- a/src/context.rs
+++ b/src/context.rs
@@ -83,34 +83,43 @@ impl Display for ExecutionPhase {
     }
 }
 
-/// Tracks event-loop shutdown state and the current shutdown lifecycle phase.
+/// Tracks the current event-loop lifecycle state.
 ///
-/// This is private implementation state, not public API. `Context::shutdown`
-/// requests normal shutdown and `Context::abort` requests an immediate stop of
-/// the current `execute` loop. The stopped status is deliberately cleared when a
-/// later `execute` call begins.
+/// This is private implementation state, not public API. Startup, regular, and
+/// shutdown work are separate states so their plan phases cannot interleave.
+/// The startup-specific stopped states preserve where execution must resume
+/// after an abort without requiring a separate startup-progress flag.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
-enum ShutdownStatus {
-    /// Normal execution; no shutdown has been requested.
-    None,
+enum EventLoopStatus {
+    /// Drain startup-time plans, then begin regular plan execution.
+    StartupTimePlans,
+    /// Drain startup-time plans, then begin normal shutdown.
+    StartupTimePlansThenShutdown,
+    /// Execute regular plans and advance simulation time.
+    RegularPlans,
     /// Normal shutdown requested or in progress.
     ///
     /// In this state, callbacks still run first, but regular plans are executed
     /// only if they are scheduled at `Context::current_time`. Simulation time is
     /// not advanced.
-    Normal,
-    /// Drain the distinguished shutdown-time plan queue.
+    NormalShutdown,
+    /// Drain the shutdown-time plan queue.
     ///
     /// Once this state is reached, regular plans are not inspected again during
     /// the same execution pass, even if shutdown-time work schedules a regular
     /// plan at the current simulation time. Callbacks are still executed.
     ShutdownTimePlans,
-    /// Stop the current `execute` event loop.
+    /// Stop the current `execute` event loop, then resume regular execution.
     ///
     /// This is set by `Context::abort` and when the shutdown-time queue is
     /// exhausted. Manual `execute_single_step` calls clear this state when there
     /// is no callback to run.
     Stopped,
+    /// Stop the current `execute` event loop, then resume startup.
+    StoppedDuringStartup,
+    /// Stop the current `execute` event loop, then resume startup followed by
+    /// normal shutdown.
+    StoppedDuringStartupThenShutdown,
 }
 
 /// A manager for the state of a discrete-event simulation
@@ -152,8 +161,7 @@ pub struct Context {
     pub(crate) global_properties: Vec<OnceCell<Box<dyn Any>>>,
     current_time: Option<f64>,
     start_time: Option<f64>,
-    shutdown_status: ShutdownStatus,
-    startup_complete: bool,
+    event_loop_status: EventLoopStatus,
     execution_profiler: ExecutionProfilingCollector,
     pub(crate) print_execution_statistics: bool,
 }
@@ -182,8 +190,7 @@ impl Context {
             global_properties,
             current_time: None,
             start_time: None,
-            shutdown_status: ShutdownStatus::None,
-            startup_complete: false,
+            event_loop_status: EventLoopStatus::StartupTimePlans,
             execution_profiler: ExecutionProfilingCollector::new(),
             print_execution_statistics: false,
         }
@@ -413,7 +420,13 @@ impl Context {
         phase: ExecutionPhase,
     ) -> PlanId {
         assert!(
-            !self.startup_complete,
+            matches!(
+                self.event_loop_status,
+                EventLoopStatus::StartupTimePlans
+                    | EventLoopStatus::StartupTimePlansThenShutdown
+                    | EventLoopStatus::StoppedDuringStartup
+                    | EventLoopStatus::StoppedDuringStartupThenShutdown
+            ),
             "Startup-time plans cannot be added after startup has completed."
         );
         self.plan_queue.add_startup_plan(Box::new(callback), phase)
@@ -573,23 +586,68 @@ impl Context {
     /// Request normal shutdown.
     ///
     /// Normal shutdown stops simulation time from advancing. Execution continues
-    /// through queued callbacks, regular plans at the current time, and then
-    /// shutdown-time plans. Calling `shutdown` during shutdown-time execution
-    /// does not return execution to regular current-time plans.
+    /// through queued callbacks and startup-time plans, followed by regular plans
+    /// at the current time and then shutdown-time plans. Calling `shutdown` during
+    /// shutdown-time execution does not return execution to regular current-time
+    /// plans.
     pub fn shutdown(&mut self) {
         trace!("shutdown context");
-        if self.shutdown_status == ShutdownStatus::None {
-            self.shutdown_status = ShutdownStatus::Normal;
+        match self.event_loop_status {
+            EventLoopStatus::StartupTimePlans => {
+                self.event_loop_status = EventLoopStatus::StartupTimePlansThenShutdown;
+            }
+            EventLoopStatus::RegularPlans => {
+                self.event_loop_status = EventLoopStatus::NormalShutdown;
+            }
+            EventLoopStatus::StartupTimePlansThenShutdown
+            | EventLoopStatus::NormalShutdown
+            | EventLoopStatus::ShutdownTimePlans
+            | EventLoopStatus::Stopped
+            | EventLoopStatus::StoppedDuringStartup
+            | EventLoopStatus::StoppedDuringStartupThenShutdown => {}
         }
     }
 
     /// Stop the current event loop immediately.
     ///
-    /// Abort only stops the current `execute` loop. The stopped status is cleared
-    /// when `execute` is called again.
+    /// Abort only stops the current `execute` loop. A later `execute` call
+    /// resumes startup if it was interrupted; otherwise it resumes regular plan
+    /// execution.
     pub fn abort(&mut self) {
         trace!("abort context");
-        self.shutdown_status = ShutdownStatus::Stopped;
+        self.event_loop_status = match self.event_loop_status {
+            EventLoopStatus::StartupTimePlans => EventLoopStatus::StoppedDuringStartup,
+            EventLoopStatus::StartupTimePlansThenShutdown => {
+                EventLoopStatus::StoppedDuringStartupThenShutdown
+            }
+            EventLoopStatus::Stopped
+            | EventLoopStatus::StoppedDuringStartup
+            | EventLoopStatus::StoppedDuringStartupThenShutdown => self.event_loop_status,
+            EventLoopStatus::RegularPlans
+            | EventLoopStatus::NormalShutdown
+            | EventLoopStatus::ShutdownTimePlans => EventLoopStatus::Stopped,
+        };
+    }
+
+    /// Resume the lifecycle state that was interrupted by an abort.
+    ///
+    /// Returns `true` when a stopped state was consumed.
+    fn resume_from_stop(&mut self) -> bool {
+        let resumed_status = match self.event_loop_status {
+            EventLoopStatus::Stopped => EventLoopStatus::RegularPlans,
+            EventLoopStatus::StoppedDuringStartup => EventLoopStatus::StartupTimePlans,
+            EventLoopStatus::StoppedDuringStartupThenShutdown => {
+                EventLoopStatus::StartupTimePlansThenShutdown
+            }
+            EventLoopStatus::StartupTimePlans
+            | EventLoopStatus::StartupTimePlansThenShutdown
+            | EventLoopStatus::RegularPlans
+            | EventLoopStatus::NormalShutdown
+            | EventLoopStatus::ShutdownTimePlans => return false,
+        };
+
+        self.event_loop_status = resumed_status;
+        true
     }
 
     /// Get the current simulation time
@@ -654,9 +712,7 @@ impl Context {
     pub fn execute(&mut self) {
         trace!("entering event loop");
 
-        if self.shutdown_status == ShutdownStatus::Stopped {
-            self.shutdown_status = ShutdownStatus::None;
-        }
+        self.resume_from_stop();
 
         if self.current_time.is_none() {
             self.current_time = Some(self.start_time.unwrap_or(0.0));
@@ -664,8 +720,7 @@ impl Context {
 
         // Start plan loop
         loop {
-            if self.shutdown_status == ShutdownStatus::Stopped {
-                self.shutdown_status = ShutdownStatus::None;
+            if self.resume_from_stop() {
                 break;
             }
 
@@ -683,7 +738,7 @@ impl Context {
         }
     }
 
-    /// Executes a single callback, plan, or shutdown status transition.
+    /// Executes a single callback, plan, or event-loop status transition.
     pub fn execute_single_step(&mut self) {
         // Callbacks always have priority over plan selection. This remains true
         // even in `Stopped` during manual stepping; `Stopped` only stops the
@@ -694,25 +749,22 @@ impl Context {
             return;
         }
 
-        // A stopped status is a manual-step transition of its own. Do not run
-        // startup work until a later step, matching the existing stopped-state
-        // behavior.
-        if self.shutdown_status != ShutdownStatus::Stopped && !self.startup_complete {
-            self.current_time
-                .get_or_insert(self.start_time.unwrap_or(0.0));
-            if let Some(plan) = self.plan_queue.pop_next_startup() {
-                trace!("calling startup-time plan");
-                (plan.data)(self);
-                return;
+        // No callback is available, so the lifecycle state determines which plan
+        // queue, if any, can provide the next unit of work.
+        match self.event_loop_status {
+            EventLoopStatus::StartupTimePlans | EventLoopStatus::StartupTimePlansThenShutdown => {
+                self.current_time
+                    .get_or_insert(self.start_time.unwrap_or(0.0));
+                if let Some(plan) = self.plan_queue.pop_next_startup() {
+                    trace!("calling startup-time plan");
+                    (plan.data)(self);
+                } else if self.event_loop_status == EventLoopStatus::StartupTimePlansThenShutdown {
+                    self.event_loop_status = EventLoopStatus::NormalShutdown;
+                } else {
+                    self.event_loop_status = EventLoopStatus::RegularPlans;
+                }
             }
-
-            self.startup_complete = true;
-        }
-
-        // No callback or startup-time plan is available, so the shutdown status
-        // determines which plan queue, if any, can provide the next unit of work.
-        match self.shutdown_status {
-            ShutdownStatus::None => {
+            EventLoopStatus::RegularPlans => {
                 // Normal execution may advance simulation time to the next
                 // regular plan only while non-passive regular work remains. Once no
                 // non-passive regular plans remain, enter normal shutdown to drain
@@ -722,10 +774,10 @@ impl Context {
                     self.current_time = Some(plan.time);
                     (plan.data)(self);
                 } else {
-                    self.shutdown_status = ShutdownStatus::Normal;
+                    self.event_loop_status = EventLoopStatus::NormalShutdown;
                 }
             }
-            ShutdownStatus::Normal => {
+            EventLoopStatus::NormalShutdown => {
                 // Normal shutdown drains only regular plans scheduled at the
                 // current simulation time. Future regular plans must remain in
                 // the queue so a later `execute` call can run them.
@@ -733,24 +785,26 @@ impl Context {
                     trace!("calling plan at {:.6}", plan.time);
                     (plan.data)(self);
                 } else {
-                    self.shutdown_status = ShutdownStatus::ShutdownTimePlans;
+                    self.event_loop_status = EventLoopStatus::ShutdownTimePlans;
                 }
             }
-            ShutdownStatus::ShutdownTimePlans => {
+            EventLoopStatus::ShutdownTimePlans => {
                 // Once shutdown-time draining begins, do not return to the
                 // regular plan queue during this execution pass.
                 if let Some(plan) = self.plan_queue.pop_next_shutdown() {
                     trace!("calling shutdown-time plan");
                     (plan.data)(self);
                 } else {
-                    self.shutdown_status = ShutdownStatus::Stopped;
+                    self.event_loop_status = EventLoopStatus::Stopped;
                 }
             }
-            ShutdownStatus::Stopped => {
+            EventLoopStatus::Stopped
+            | EventLoopStatus::StoppedDuringStartup
+            | EventLoopStatus::StoppedDuringStartupThenShutdown => {
                 // `execute` exits before calling `execute_single_step` in this
-                // state. This arm supports manual single-step use after a prior
-                // stop by consuming the stopped status when no callback exists.
-                self.shutdown_status = ShutdownStatus::None;
+                // state. This arm supports manual single-step use after an abort
+                // by consuming the stopped status when no callback exists.
+                self.resume_from_stop();
             }
         }
     }
@@ -1589,6 +1643,70 @@ mod tests {
     }
 
     #[test]
+    fn startup_plan_can_be_added_while_startup_is_stopped() {
+        let mut context = Context::new();
+        context.add_startup_plan(|context| {
+            context.get_data_mut(ComponentA).push(1);
+            context.abort();
+        });
+
+        context.execute();
+        add_startup_plan(&mut context, 2);
+        context.execute();
+
+        assert_eq!(*context.get_data_mut(ComponentA), vec![1, 2]);
+    }
+
+    #[test]
+    fn startup_plan_can_be_added_after_abort_before_execute() {
+        let mut context = Context::new();
+        context.abort();
+        add_startup_plan(&mut context, 1);
+
+        context.execute();
+
+        assert_eq!(*context.get_data_mut(ComponentA), vec![1]);
+    }
+
+    #[test]
+    fn startup_plan_can_be_added_after_pending_shutdown_is_aborted() {
+        let mut context = Context::new();
+        context.shutdown();
+        context.abort();
+        add_startup_plan(&mut context, 1);
+        add_plan(&mut context, 0.0, 2);
+
+        context.execute();
+
+        assert_eq!(*context.get_data_mut(ComponentA), vec![1, 2]);
+    }
+
+    #[test]
+    fn abort_during_startup_preserves_pending_shutdown() {
+        let mut context = Context::new();
+        context.add_startup_plan(|context| {
+            context.get_data_mut(ComponentA).push(1);
+            context.shutdown();
+            context.abort();
+        });
+        add_startup_plan(&mut context, 2);
+        add_plan(&mut context, 0.0, 3);
+        add_plan(&mut context, 1.0, 4);
+        context.add_shutdown_plan(|context| {
+            context.get_data_mut(ComponentA).push(5);
+        });
+
+        context.execute();
+        assert_eq!(*context.get_data_mut(ComponentA), vec![1]);
+
+        context.execute();
+        assert_eq!(*context.get_data_mut(ComponentA), vec![1, 2, 3, 5]);
+
+        context.execute();
+        assert_eq!(*context.get_data_mut(ComponentA), vec![1, 2, 3, 5, 4]);
+    }
+
+    #[test]
     fn execute_single_step_prioritizes_startup_plans_and_callbacks() {
         let mut context = Context::new();
         context.set_start_time(-2.0);
@@ -1612,8 +1730,11 @@ mod tests {
         assert_eq!(*context.get_data_mut(ComponentA), vec![1, 2, 3]);
 
         context.execute_single_step();
+        assert_eq!(*context.get_data_mut(ComponentA), vec![1, 2, 3]);
+        assert_eq!(context.event_loop_status, EventLoopStatus::RegularPlans);
+
+        context.execute_single_step();
         assert_eq!(*context.get_data_mut(ComponentA), vec![1, 2, 3, 4]);
-        assert!(context.startup_complete);
     }
 
     #[test]
@@ -1859,9 +1980,18 @@ mod tests {
 
         context.execute_single_step();
         assert_eq!(*context.get_data_mut(ComponentA), Vec::<u32>::new());
+        assert_eq!(context.event_loop_status, EventLoopStatus::RegularPlans);
 
         context.execute_single_step();
         assert_eq!(*context.get_data_mut(ComponentA), Vec::<u32>::new());
+        assert_eq!(context.event_loop_status, EventLoopStatus::NormalShutdown);
+
+        context.execute_single_step();
+        assert_eq!(*context.get_data_mut(ComponentA), Vec::<u32>::new());
+        assert_eq!(
+            context.event_loop_status,
+            EventLoopStatus::ShutdownTimePlans
+        );
 
         context.execute_single_step();
         assert_eq!(*context.get_data_mut(ComponentA), vec![1]);
@@ -1881,6 +2011,11 @@ mod tests {
 
         context.execute_single_step();
         assert_eq!(*context.get_data_mut(ComponentA), vec![1]);
+        assert_eq!(context.event_loop_status, EventLoopStatus::StartupTimePlans);
+
+        context.execute_single_step();
+        assert_eq!(*context.get_data_mut(ComponentA), vec![1]);
+        assert_eq!(context.event_loop_status, EventLoopStatus::RegularPlans);
 
         context.execute_single_step();
         assert_eq!(*context.get_data_mut(ComponentA), vec![1, 2]);
@@ -2185,8 +2320,8 @@ mod tests {
     }
 
     #[test]
-    fn shutdown_status_reset() {
-        // This test verifies that shutdown_status is properly reset after
+    fn event_loop_status_reset() {
+        // This test verifies that event_loop_status is properly reset after
         // being acted upon. This allows the context to be reused after shutdown.
         let mut context = Context::new();
         let _: PersonId = context.add_entity(with!(Person, Age(50))).unwrap();
@@ -2207,14 +2342,14 @@ mod tests {
         });
 
         // Second execute - should execute the new plan
-        // If shutdown_status wasn't reset, this would immediately break
+        // If event_loop_status wasn't reset, this would immediately break
         // without executing the plan, leaving population at 1.
         context.execute();
         assert_eq!(context.get_current_time(), 2.0);
         assert_eq!(
             context.get_entity_count::<Person>(),
             2,
-            "If this fails, shutdown_status was not properly reset"
+            "If this fails, event_loop_status was not properly reset"
         );
     }
 }

--- a/src/plan_queue.rs
+++ b/src/plan_queue.rs
@@ -1,8 +1,8 @@
 //! Implementation details for Ixa's plan queues.
 //!
 //! [`PlanId`] is the only public item in this module. The queues store regular
-//! time-ordered plans and shutdown-time plans, sharing a single `PlanId`
-//! allocator and cancellation map.
+//! time-ordered plans, startup-time plans, and shutdown-time plans, sharing a
+//! single `PlanId` allocator and cancellation map.
 
 use std::cmp::Ordering;
 use std::collections::BinaryHeap;
@@ -18,21 +18,30 @@ struct QueuedPlan {
     is_passive: bool,
 }
 
+#[derive(Clone, Copy)]
+enum DistinguishedQueue {
+    Startup,
+    Shutdown,
+}
+
 /// A priority queue that stores scheduled plans.
 ///
 /// Regular plans are ordered by simulation time, execution phase, and plan ID.
-/// Shutdown-time plans are ordered by execution phase and plan ID; their stored
-/// time is only an internal constant and has no simulation-time meaning.
+/// Startup-time and shutdown-time plans are ordered by execution phase and plan
+/// ID; their stored time is only an internal constant and has no simulation-time
+/// meaning.
 pub(crate) struct PlanQueue {
     queue: BinaryHeap<PlanSchedule>,
+    startup_queue: BinaryHeap<PlanSchedule>,
     shutdown_queue: BinaryHeap<PlanSchedule>,
     data_map: HashMap<u64, QueuedPlan>,
-    /// Count of scheduled plans excluding passive and shutdown-time plans.
+    /// Count of scheduled plans excluding passive, startup-time, and shutdown-time plans.
     regular_plan_count: usize,
     /// The next plan ID that will be issued.
     next_plan_id: u64,
     /// Tracks the high water mark of plans in flight (scheduled but not yet executed).
-    /// This is the max of the two heap lengths, not of `self.data_map.len()`.
+    /// This is calculated from the combined lengths of the three heaps, not
+    /// from `self.data_map.len()`.
     #[cfg(feature = "profiling")]
     pub(crate) max_plans_in_flight: u64,
     #[cfg(feature = "profiling")]
@@ -45,6 +54,7 @@ impl PlanQueue {
     pub(crate) fn new() -> PlanQueue {
         PlanQueue {
             queue: BinaryHeap::new(),
+            startup_queue: BinaryHeap::new(),
             shutdown_queue: BinaryHeap::new(),
             data_map: HashMap::new(),
             regular_plan_count: 0,
@@ -90,6 +100,19 @@ impl PlanQueue {
         PlanId(plan_id)
     }
 
+    /// Add a startup-time plan.
+    ///
+    /// Startup-time plans have no simulation time. They are ordered by phase and
+    /// plan ID.
+    pub(crate) fn add_startup_plan(
+        &mut self,
+        callback: BoxedCallback,
+        phase: ExecutionPhase,
+    ) -> PlanId {
+        trace!("adding startup-time plan");
+        self.add_distinguished_plan(callback, phase, DistinguishedQueue::Startup)
+    }
+
     /// Add a shutdown-time plan.
     ///
     /// Shutdown-time plans have no simulation time. They are ordered by phase and
@@ -100,12 +123,25 @@ impl PlanQueue {
         phase: ExecutionPhase,
     ) -> PlanId {
         trace!("adding shutdown-time plan");
+        self.add_distinguished_plan(callback, phase, DistinguishedQueue::Shutdown)
+    }
+
+    fn add_distinguished_plan(
+        &mut self,
+        callback: BoxedCallback,
+        phase: ExecutionPhase,
+        queue: DistinguishedQueue,
+    ) -> PlanId {
         let plan_id = self.next_plan_id;
-        self.shutdown_queue.push(PlanSchedule {
+        let schedule = PlanSchedule {
             plan_id,
             time: 0.0,
             phase,
-        });
+        };
+        match queue {
+            DistinguishedQueue::Startup => self.startup_queue.push(schedule),
+            DistinguishedQueue::Shutdown => self.shutdown_queue.push(schedule),
+        }
         self.data_map.insert(
             plan_id,
             QueuedPlan {
@@ -119,7 +155,7 @@ impl PlanQueue {
         PlanId(plan_id)
     }
 
-    /// Cancel a plan that has been added to either queue.
+    /// Cancel a plan that has been added to any queue.
     pub(crate) fn cancel_plan(&mut self, plan_id: &PlanId) -> Option<BoxedCallback> {
         trace!("cancel plan {plan_id:?}");
         // Delete the plan from the map, but leave in the heap. It will be skipped
@@ -146,11 +182,12 @@ impl PlanQueue {
         None
     }
 
-    /// Completely empties the queue, including the plans scheduled at shutdown time.
+    /// Completely empties every queue, including startup-time and shutdown-time plans.
     #[allow(dead_code)]
     pub(crate) fn clear(&mut self) {
         self.data_map.clear();
         self.queue.clear();
+        self.startup_queue.clear();
         self.shutdown_queue.clear();
         self.regular_plan_count = 0;
         self.next_plan_id = 0;
@@ -225,30 +262,51 @@ impl PlanQueue {
         }
     }
 
+    /// Retrieve the next startup-time plan.
+    ///
+    /// Returns the next startup-time plan if it exists or else `None` if the
+    /// startup-time queue is empty.
+    pub(crate) fn pop_next_startup(&mut self) -> Option<Plan> {
+        trace!("getting next startup-time plan");
+        self.pop_next_distinguished(DistinguishedQueue::Startup)
+    }
+
     /// Retrieve the next shutdown-time plan.
     ///
     /// Returns the next shutdown-time plan if it exists or else `None` if the
     /// shutdown-time queue is empty.
     pub(crate) fn pop_next_shutdown(&mut self) -> Option<Plan> {
         trace!("getting next shutdown-time plan");
-        std::iter::from_fn(|| self.shutdown_queue.pop()).find_map(|entry| {
+        self.pop_next_distinguished(DistinguishedQueue::Shutdown)
+    }
+
+    fn pop_next_distinguished(&mut self, queue: DistinguishedQueue) -> Option<Plan> {
+        loop {
+            let entry = match queue {
+                DistinguishedQueue::Startup => self.startup_queue.pop(),
+                DistinguishedQueue::Shutdown => self.shutdown_queue.pop(),
+            }?;
+
             // If there's no `data_map` entry, the plan has been canceled, so discard
             // and pop another plan.
-            let queued_plan = self.data_map.remove(&entry.plan_id)?;
+            let Some(queued_plan) = self.data_map.remove(&entry.plan_id) else {
+                continue;
+            };
             if !queued_plan.is_passive {
                 self.regular_plan_count -= 1;
             }
-            Some(Plan {
+            return Some(Plan {
                 time: entry.time,
                 data: queued_plan.callback,
-            })
-        })
+            });
+        }
     }
 
     fn update_profiling_high_water_marks(&mut self) {
         #[cfg(feature = "profiling")]
         {
-            let plans_in_flight = self.queue.len() + self.shutdown_queue.len();
+            let plans_in_flight =
+                self.queue.len() + self.startup_queue.len() + self.shutdown_queue.len();
             self.max_plans_in_flight = self.max_plans_in_flight.max(plans_in_flight as u64);
             self.max_memory_in_use = self
                 .max_memory_in_use
@@ -258,8 +316,10 @@ impl PlanQueue {
 
     #[cfg(feature = "profiling")]
     fn estimated_memory_in_use(&self) -> usize {
-        let queue_bytes =
-            (self.queue.capacity() + self.shutdown_queue.capacity()) * size_of::<PlanSchedule>();
+        let queue_bytes = (self.queue.capacity()
+            + self.startup_queue.capacity()
+            + self.shutdown_queue.capacity())
+            * size_of::<PlanSchedule>();
 
         let map_entry_bytes = self.data_map.capacity() * size_of::<(u64, QueuedPlan)>();
 
@@ -276,8 +336,8 @@ impl Default for PlanQueue {
 /// A time, id, and phase object used to order plans in a [`PlanQueue`].
 ///
 /// Regular [`PlanSchedule`] objects are sorted in increasing order of time,
-/// phase, and then plan id. Shutdown-time schedules all have the same internal
-/// time and are therefore sorted by phase and then plan id.
+/// phase, and then plan id. Startup-time and shutdown-time schedules all have
+/// the same internal time and are therefore sorted by phase and then plan id.
 #[derive(PartialEq, Debug, Clone, Copy)]
 pub(crate) struct PlanSchedule {
     pub plan_id: u64,
@@ -582,6 +642,20 @@ mod tests {
     }
 
     #[test]
+    fn startup_plans_do_not_affect_regular_count() {
+        let observed = Rc::new(RefCell::new(Vec::new()));
+        let mut context = Context::new();
+        let mut plan_queue = PlanQueue::new();
+        plan_queue.add_startup_plan(callback(1, Rc::clone(&observed)), ExecutionPhase::Normal);
+
+        assert_eq!(plan_queue.regular_plan_count, 0);
+        let next_plan = plan_queue.pop_next_startup().unwrap();
+        run_plan(next_plan, &mut context);
+        assert_eq!(plan_queue.regular_plan_count, 0);
+        assert_eq!(*observed.borrow(), vec![1]);
+    }
+
+    #[test]
     fn next_time_ignores_canceled_root() {
         let observed = Rc::new(RefCell::new(Vec::new()));
         let mut plan_queue = PlanQueue::new();
@@ -641,7 +715,26 @@ mod tests {
     }
 
     #[test]
-    fn plan_ids_are_shared_between_regular_and_shutdown_queues() {
+    fn startup_plans_use_phase_and_fifo_order() {
+        let observed = Rc::new(RefCell::new(Vec::new()));
+        let mut context = Context::new();
+        let mut plan_queue = PlanQueue::new();
+        plan_queue.add_startup_plan(callback(3, Rc::clone(&observed)), ExecutionPhase::Last);
+        plan_queue.add_startup_plan(callback(1, Rc::clone(&observed)), ExecutionPhase::First);
+        let canceled =
+            plan_queue.add_startup_plan(callback(2, Rc::clone(&observed)), ExecutionPhase::Normal);
+        plan_queue.add_startup_plan(callback(4, Rc::clone(&observed)), ExecutionPhase::Last);
+        plan_queue.cancel_plan(&canceled);
+
+        while let Some(plan) = plan_queue.pop_next_startup() {
+            run_plan(plan, &mut context);
+        }
+
+        assert_eq!(*observed.borrow(), vec![1, 3, 4]);
+    }
+
+    #[test]
+    fn plan_ids_are_shared_between_all_queues() {
         let observed = Rc::new(RefCell::new(Vec::new()));
         let mut plan_queue = PlanQueue::new();
         let regular_id = plan_queue.add_plan(
@@ -652,9 +745,13 @@ mod tests {
         );
         let shutdown_id =
             plan_queue.add_shutdown_plan(callback(2, Rc::clone(&observed)), ExecutionPhase::Normal);
+        let startup_id =
+            plan_queue.add_startup_plan(callback(3, Rc::clone(&observed)), ExecutionPhase::Normal);
 
         assert_ne!(regular_id, shutdown_id);
+        assert_ne!(shutdown_id, startup_id);
         assert_eq!(regular_id.0, 0);
         assert_eq!(shutdown_id.0, 1);
+        assert_eq!(startup_id.0, 2);
     }
 }

--- a/src/plan_queue.rs
+++ b/src/plan_queue.rs
@@ -18,12 +18,6 @@ struct QueuedPlan {
     is_passive: bool,
 }
 
-#[derive(Clone, Copy)]
-enum DistinguishedQueue {
-    Startup,
-    Shutdown,
-}
-
 /// A priority queue that stores scheduled plans.
 ///
 /// Regular plans are ordered by simulation time, execution phase, and plan ID.
@@ -110,7 +104,23 @@ impl PlanQueue {
         phase: ExecutionPhase,
     ) -> PlanId {
         trace!("adding startup-time plan");
-        self.add_distinguished_plan(callback, phase, DistinguishedQueue::Startup)
+        let plan_id = self.next_plan_id;
+        self.startup_queue.push(PlanSchedule {
+            plan_id,
+            time: 0.0,
+            phase,
+        });
+        self.data_map.insert(
+            plan_id,
+            QueuedPlan {
+                callback,
+                is_passive: true,
+            },
+        );
+        self.next_plan_id += 1;
+        self.update_profiling_high_water_marks();
+
+        PlanId(plan_id)
     }
 
     /// Add a shutdown-time plan.
@@ -123,25 +133,12 @@ impl PlanQueue {
         phase: ExecutionPhase,
     ) -> PlanId {
         trace!("adding shutdown-time plan");
-        self.add_distinguished_plan(callback, phase, DistinguishedQueue::Shutdown)
-    }
-
-    fn add_distinguished_plan(
-        &mut self,
-        callback: BoxedCallback,
-        phase: ExecutionPhase,
-        queue: DistinguishedQueue,
-    ) -> PlanId {
         let plan_id = self.next_plan_id;
-        let schedule = PlanSchedule {
+        self.shutdown_queue.push(PlanSchedule {
             plan_id,
             time: 0.0,
             phase,
-        };
-        match queue {
-            DistinguishedQueue::Startup => self.startup_queue.push(schedule),
-            DistinguishedQueue::Shutdown => self.shutdown_queue.push(schedule),
-        }
+        });
         self.data_map.insert(
             plan_id,
             QueuedPlan {
@@ -268,7 +265,19 @@ impl PlanQueue {
     /// startup-time queue is empty.
     pub(crate) fn pop_next_startup(&mut self) -> Option<Plan> {
         trace!("getting next startup-time plan");
-        self.pop_next_distinguished(DistinguishedQueue::Startup)
+        loop {
+            let entry = self.startup_queue.pop()?;
+
+            // If there's no `data_map` entry, the plan has been canceled, so discard
+            // and pop another plan.
+            let Some(queued_plan) = self.data_map.remove(&entry.plan_id) else {
+                continue;
+            };
+            return Some(Plan {
+                time: entry.time,
+                data: queued_plan.callback,
+            });
+        }
     }
 
     /// Retrieve the next shutdown-time plan.
@@ -277,24 +286,14 @@ impl PlanQueue {
     /// shutdown-time queue is empty.
     pub(crate) fn pop_next_shutdown(&mut self) -> Option<Plan> {
         trace!("getting next shutdown-time plan");
-        self.pop_next_distinguished(DistinguishedQueue::Shutdown)
-    }
-
-    fn pop_next_distinguished(&mut self, queue: DistinguishedQueue) -> Option<Plan> {
         loop {
-            let entry = match queue {
-                DistinguishedQueue::Startup => self.startup_queue.pop(),
-                DistinguishedQueue::Shutdown => self.shutdown_queue.pop(),
-            }?;
+            let entry = self.shutdown_queue.pop()?;
 
             // If there's no `data_map` entry, the plan has been canceled, so discard
             // and pop another plan.
             let Some(queued_plan) = self.data_map.remove(&entry.plan_id) else {
                 continue;
             };
-            if !queued_plan.is_passive {
-                self.regular_plan_count -= 1;
-            }
             return Some(Plan {
                 time: entry.time,
                 data: queued_plan.callback,

--- a/src/plugin_context.rs
+++ b/src/plugin_context.rs
@@ -76,6 +76,15 @@ mod test_plugin_context {
             self.add_plan(1.0, |context| {
                 assert_eq!(context.get_my_data(), 42);
             });
+            self.add_startup_plan(|context| {
+                assert_eq!(context.get_my_data(), 42);
+            });
+            self.add_startup_plan_with_phase(
+                |context| {
+                    assert_eq!(context.get_my_data(), 42);
+                },
+                crate::ExecutionPhase::First,
+            );
             self.add_passive_plan(1.0, |context| {
                 assert_eq!(context.get_my_data(), 42);
             });


### PR DESCRIPTION
## Summary

  This PR adds startup-time plans: one-shot lifecycle work that runs at the
  effective simulation start time—either the configured start time or `0.0`—
  before regular plans.

  - Add `Context::add_startup_plan` and
    `Context::add_startup_plan_with_phase`.
  - Expose startup-plan scheduling through `ContextBase` and `PluginContext`.
  - Expand the event-loop state machine to model startup, regular execution,
    shutdown, and abort/resume transitions explicitly.
  - Add a dedicated startup queue with shared plan IDs, cancellation, and
    profiling support.
  - Update the `Context` API documentation to describe the full simulation
    lifecycle.

## Behavior

  Startup-time plans:

  - Run once at the effective simulation start time before any regular plan.
  - Follow `ExecutionPhase` ordering, then insertion order within each phase.
  - Yield to queued callbacks, which retain priority over plan selection.
  - May schedule additional startup-time plans while startup is still active.
  - Can be canceled through their `PlanId`.
  - Resume on a later `execute` call when startup is interrupted by `abort`.
  - Finish draining before shutdown proceeds when shutdown is requested during
    startup.
  - Panic if added after startup has completed.