### PR TITLE
fix: Eagerly compute property value count indexes

### DIFF
--- a/src/entity/context_extension.rs
+++ b/src/entity/context_extension.rs
@@ -376,10 +376,17 @@ impl ContextEntitiesExt for Context {
     }
 
     fn index_property_counts<E: Entity, P: IndexableProperty<E>>(&mut self) {
+        let property_id = P::id();
+        let context_ptr: *const Context = self;
         let property_store = self.entity_store.get_property_store_mut::<E>();
         let current_index_type = property_store.get::<P>().index_type();
         if current_index_type != PropertyIndexType::FullIndex {
             property_store.set_property_indexed::<P>(PropertyIndexType::ValueCountIndex);
+            // SAFETY: This only creates a shared reference to `Context` while mutably borrowing
+            // the property store to update index internals.
+            unsafe {
+                property_store.index_unindexed_entities_for_property_id(&*context_ptr, property_id);
+            }
         }
     }
 

--- a/src/entity/index/value_count_index.rs
+++ b/src/entity/index/value_count_index.rs
@@ -143,6 +143,61 @@ mod tests {
     }
 
     #[test]
+    fn enabling_multi_property_value_count_index_indexes_existing_entities() {
+        let mut context = Context::new();
+
+        context
+            .add_entity(with!(Person, Age(1u8), Weight(2u8), Height(3u8)))
+            .unwrap();
+        context
+            .add_entity(with!(Person, Age(1u8), Weight(2u8), Height(3u8)))
+            .unwrap();
+        context
+            .add_entity(with!(Person, Age(3u8), Weight(2u8), Height(1u8)))
+            .unwrap();
+
+        context.index_property_counts::<Person, AWH>();
+
+        assert_eq!(
+            context.query_entity_count(with!(Person, Age(1u8), Weight(2u8), Height(3u8))),
+            2
+        );
+        assert_eq!(
+            context.query_entity_count(with!(Person, Age(3u8), Weight(2u8), Height(1u8))),
+            1
+        );
+    }
+
+    #[test]
+    fn enabling_value_count_index_indexes_existing_entities() {
+        let mut context = Context::new();
+
+        context.add_entity(with!(Person, Age(10))).unwrap();
+        context.add_entity(with!(Person, Age(10))).unwrap();
+
+        context.index_property_counts::<Person, Age>();
+
+        assert_eq!(context.query_entity_count(with!(Person, Age(10))), 2);
+    }
+
+    #[test]
+    fn changing_existing_entity_before_adding_another_does_not_double_count() {
+        let mut context = Context::new();
+
+        let first = context.add_entity(with!(Person, Age(10))).unwrap();
+        context.add_entity(with!(Person, Age(10))).unwrap();
+
+        context.index_property_counts::<Person, Age>();
+        context.set_property(first, Age(20));
+
+        // Adding another entity must not count the changed entity a second time.
+        context.add_entity(with!(Person, Age(10))).unwrap();
+
+        assert_eq!(context.query_entity_count(with!(Person, Age(20))), 1);
+        assert_eq!(context.query_entity_count(with!(Person, Age(10))), 2);
+    }
+
+    #[test]
     fn test_index_value_compute_same_values() {
         let value = one_shot_128(&"test value");
         let value2 = one_shot_128(&"test value");


### PR DESCRIPTION
Fixes a correctness bug and adds regression tests for an issue with value count indexes. Apparently we failed to initialize the index upon creation. Consequently, it's possible for a value count index to incorrectly count the number of entities with particular values.

The fix is simple: just compute the index when it is created.