### PR TITLE
chore: Refactor `add_entity` and index maintenance

### DIFF
--- a/ixa-bench/Cargo.toml
+++ b/ixa-bench/Cargo.toml
@@ -105,6 +105,11 @@ path = "criterion/set_property.rs"
 harness = false
 
 [[bench]]
+name = "add_entity"
+path = "criterion/add_entity.rs"
+harness = false
+
+[[bench]]
 name = "property_semantics"
 path = "criterion/property_semantics.rs"
 harness = false

--- a/ixa-bench/criterion/add_entity.rs
+++ b/ixa-bench/criterion/add_entity.rs
@@ -1,0 +1,319 @@
+use std::hint::black_box;
+
+use criterion::{criterion_group, criterion_main, BatchSize, Criterion, Throughput};
+use ixa::prelude::*;
+
+const ENTITY_COUNT: usize = 100_000;
+
+define_entity!(WideEntity);
+define_entity!(NarrowEntity);
+
+define_property!(
+    struct TargetValue(u8),
+    WideEntity,
+    default_const = TargetValue(0)
+);
+define_property!(
+    struct AuxiliaryValueOne(u8),
+    WideEntity,
+    default_const = AuxiliaryValueOne(0)
+);
+define_property!(
+    struct AuxiliaryValueTwo(u8),
+    WideEntity,
+    default_const = AuxiliaryValueTwo(0)
+);
+define_property!(
+    struct AdditionalValueOne(u8),
+    WideEntity,
+    default_const = AdditionalValueOne(0)
+);
+define_property!(
+    struct AdditionalValueTwo(u8),
+    WideEntity,
+    default_const = AdditionalValueTwo(0)
+);
+define_property!(
+    struct AdditionalValueThree(u8),
+    WideEntity,
+    default_const = AdditionalValueThree(0)
+);
+define_property!(
+    struct AdditionalValueFour(u8),
+    WideEntity,
+    default_const = AdditionalValueFour(0)
+);
+define_property!(
+    struct AdditionalValueFive(u8),
+    WideEntity,
+    default_const = AdditionalValueFive(0)
+);
+
+impl_property!(TargetValue, NarrowEntity, default_const = TargetValue(0));
+impl_property!(
+    AuxiliaryValueOne,
+    NarrowEntity,
+    default_const = AuxiliaryValueOne(0)
+);
+impl_property!(
+    AuxiliaryValueTwo,
+    NarrowEntity,
+    default_const = AuxiliaryValueTwo(0)
+);
+
+fn initialize_context_for_no_indexes_explicit_nondefault_wide() -> Context {
+    let mut context = Context::new();
+    context
+        .add_entity(with!(
+            WideEntity,
+            TargetValue(1),
+            AuxiliaryValueOne(1),
+            AuxiliaryValueTwo(1),
+        ))
+        .unwrap();
+    context
+}
+
+fn initialize_context_for_one_full_index_explicit_nondefault_wide() -> Context {
+    let mut context = Context::new();
+    context.index_property::<WideEntity, TargetValue>();
+    context
+        .add_entity(with!(
+            WideEntity,
+            TargetValue(1),
+            AuxiliaryValueOne(1),
+            AuxiliaryValueTwo(1),
+        ))
+        .unwrap();
+    context
+}
+
+fn initialize_context_for_three_full_indexes_explicit_nondefault_wide() -> Context {
+    let mut context = Context::new();
+    context.index_property::<WideEntity, TargetValue>();
+    context.index_property::<WideEntity, AuxiliaryValueOne>();
+    context.index_property::<WideEntity, AuxiliaryValueTwo>();
+    context
+        .add_entity(with!(
+            WideEntity,
+            TargetValue(1),
+            AuxiliaryValueOne(1),
+            AuxiliaryValueTwo(1),
+        ))
+        .unwrap();
+    context
+}
+
+fn initialize_context_for_one_value_count_index_explicit_nondefault_wide() -> Context {
+    let mut context = Context::new();
+    context.index_property_counts::<WideEntity, TargetValue>();
+    context
+        .add_entity(with!(
+            WideEntity,
+            TargetValue(1),
+            AuxiliaryValueOne(1),
+            AuxiliaryValueTwo(1),
+        ))
+        .unwrap();
+    context
+}
+
+fn initialize_context_for_one_full_index_omitted_default_wide() -> Context {
+    let mut context = Context::new();
+    context.index_property::<WideEntity, TargetValue>();
+    context
+        .add_entity(with!(
+            WideEntity,
+            AuxiliaryValueOne(1),
+            AuxiliaryValueTwo(1),
+        ))
+        .unwrap();
+    context
+}
+
+fn initialize_context_for_one_full_index_explicit_default_wide() -> Context {
+    let mut context = Context::new();
+    context.index_property::<WideEntity, TargetValue>();
+    context
+        .add_entity(with!(
+            WideEntity,
+            TargetValue(0),
+            AuxiliaryValueOne(1),
+            AuxiliaryValueTwo(1),
+        ))
+        .unwrap();
+    context
+}
+
+fn initialize_context_for_one_full_index_explicit_nondefault_narrow() -> Context {
+    let mut context = Context::new();
+    context.index_property::<NarrowEntity, TargetValue>();
+    context
+        .add_entity(with!(
+            NarrowEntity,
+            TargetValue(1),
+            AuxiliaryValueOne(1),
+            AuxiliaryValueTwo(1),
+        ))
+        .unwrap();
+    context
+}
+
+fn criterion_benchmark(c: &mut Criterion) {
+    let mut group = c.benchmark_group("add_entity");
+    group.throughput(Throughput::Elements(ENTITY_COUNT as u64));
+
+    group.bench_function("no_indexes_explicit_nondefault_wide", |bencher| {
+        bencher.iter_batched_ref(
+            initialize_context_for_no_indexes_explicit_nondefault_wide,
+            |context| {
+                for _ in 0..ENTITY_COUNT {
+                    black_box(
+                        context
+                            .add_entity(with!(
+                                WideEntity,
+                                TargetValue(1),
+                                AuxiliaryValueOne(1),
+                                AuxiliaryValueTwo(1),
+                            ))
+                            .unwrap(),
+                    );
+                }
+            },
+            BatchSize::PerIteration,
+        );
+    });
+
+    group.bench_function("one_full_index_explicit_nondefault_wide", |bencher| {
+        bencher.iter_batched_ref(
+            initialize_context_for_one_full_index_explicit_nondefault_wide,
+            |context| {
+                for _ in 0..ENTITY_COUNT {
+                    black_box(
+                        context
+                            .add_entity(with!(
+                                WideEntity,
+                                TargetValue(1),
+                                AuxiliaryValueOne(1),
+                                AuxiliaryValueTwo(1),
+                            ))
+                            .unwrap(),
+                    );
+                }
+            },
+            BatchSize::PerIteration,
+        );
+    });
+
+    group.bench_function("three_full_indexes_explicit_nondefault_wide", |bencher| {
+        bencher.iter_batched_ref(
+            initialize_context_for_three_full_indexes_explicit_nondefault_wide,
+            |context| {
+                for _ in 0..ENTITY_COUNT {
+                    black_box(
+                        context
+                            .add_entity(with!(
+                                WideEntity,
+                                TargetValue(1),
+                                AuxiliaryValueOne(1),
+                                AuxiliaryValueTwo(1),
+                            ))
+                            .unwrap(),
+                    );
+                }
+            },
+            BatchSize::PerIteration,
+        );
+    });
+
+    group.bench_function(
+        "one_value_count_index_explicit_nondefault_wide",
+        |bencher| {
+            bencher.iter_batched_ref(
+                initialize_context_for_one_value_count_index_explicit_nondefault_wide,
+                |context| {
+                    for _ in 0..ENTITY_COUNT {
+                        black_box(
+                            context
+                                .add_entity(with!(
+                                    WideEntity,
+                                    TargetValue(1),
+                                    AuxiliaryValueOne(1),
+                                    AuxiliaryValueTwo(1),
+                                ))
+                                .unwrap(),
+                        );
+                    }
+                },
+                BatchSize::PerIteration,
+            );
+        },
+    );
+
+    group.bench_function("one_full_index_omitted_default_wide", |bencher| {
+        bencher.iter_batched_ref(
+            initialize_context_for_one_full_index_omitted_default_wide,
+            |context| {
+                for _ in 0..ENTITY_COUNT {
+                    black_box(
+                        context
+                            .add_entity(with!(
+                                WideEntity,
+                                AuxiliaryValueOne(1),
+                                AuxiliaryValueTwo(1),
+                            ))
+                            .unwrap(),
+                    );
+                }
+            },
+            BatchSize::PerIteration,
+        );
+    });
+
+    group.bench_function("one_full_index_explicit_default_wide", |bencher| {
+        bencher.iter_batched_ref(
+            initialize_context_for_one_full_index_explicit_default_wide,
+            |context| {
+                for _ in 0..ENTITY_COUNT {
+                    black_box(
+                        context
+                            .add_entity(with!(
+                                WideEntity,
+                                TargetValue(0),
+                                AuxiliaryValueOne(1),
+                                AuxiliaryValueTwo(1),
+                            ))
+                            .unwrap(),
+                    );
+                }
+            },
+            BatchSize::PerIteration,
+        );
+    });
+
+    group.bench_function("one_full_index_explicit_nondefault_narrow", |bencher| {
+        bencher.iter_batched_ref(
+            initialize_context_for_one_full_index_explicit_nondefault_narrow,
+            |context| {
+                for _ in 0..ENTITY_COUNT {
+                    black_box(
+                        context
+                            .add_entity(with!(
+                                NarrowEntity,
+                                TargetValue(1),
+                                AuxiliaryValueOne(1),
+                                AuxiliaryValueTwo(1),
+                            ))
+                            .unwrap(),
+                    );
+                }
+            },
+            BatchSize::PerIteration,
+        );
+    });
+
+    group.finish();
+}
+
+criterion_group!(add_entity_benches, criterion_benchmark);
+criterion_main!(add_entity_benches);

--- a/src/entity/context_extension.rs
+++ b/src/entity/context_extension.rs
@@ -5,6 +5,7 @@ use smallvec::SmallVec;
 use crate::entity::entity_set::{EntitySet, EntitySetIterator, SourceSet};
 use crate::entity::events::{EntityCreatedEvent, PartialPropertyChangeEventBox};
 use crate::entity::index::{IndexCountResult, IndexSetResult, PropertyIndexType};
+use crate::entity::multi_property::multi_property_id_for_property_type_id;
 use crate::entity::property::{IndexableProperty, Property};
 use crate::entity::property_list::{PropertyInitializationList, PropertyList};
 use crate::entity::query::Query;
@@ -13,6 +14,57 @@ use crate::entity::{Entity, EntityId, PopulationIterator};
 use crate::rand::Rng;
 use crate::random::sample_multiple_from_known_length;
 use crate::{warn, Context, ContextRandomExt, ExecutionPhase, IxaError, RngId};
+
+fn create_property_index<E, P>(context: &mut Context, requested: PropertyIndexType)
+where
+    E: Entity,
+    P: IndexableProperty<E>,
+{
+    debug_assert_ne!(requested, PropertyIndexType::Unindexed);
+
+    if let Some((representative_id, representative_name)) =
+        multi_property_id_for_property_type_id(E::id(), P::type_id())
+    {
+        if representative_id != P::id() {
+            panic!(
+                "Cannot index multi-property {} because it is equivalent to representative \
+                 multi-property {}.",
+                P::name(),
+                representative_name,
+            );
+        }
+    }
+
+    let current = context.get_property_value_store::<E, P>().index_type();
+    let current_satisfies_request = current == requested
+        || matches!(
+            (current, requested),
+            (
+                PropertyIndexType::FullIndex,
+                PropertyIndexType::ValueCountIndex,
+            )
+        );
+
+    if current_satisfies_request {
+        return;
+    }
+
+    let mut new_index = requested
+        .new_property_index::<E, P>()
+        .expect("an indexed request must construct an index");
+
+    // Populate while detached so a panic from allocation or property computation leaves the
+    // previously installed index and dispatcher state unchanged.
+    for entity_id in context.get_entity_iterator::<E>() {
+        let value: P = context.get_property(entity_id);
+        new_index.add_entity(&value, entity_id);
+    }
+
+    context
+        .entity_store
+        .get_property_store_mut::<E>()
+        .install_property_index::<P>(Some(new_index));
+}
 
 fn handle_periodic_value_change_count_event<E, PL, P, F>(
     context: &mut Context,
@@ -263,13 +315,24 @@ impl ContextEntitiesExt for Context {
             self.entity_store.get_property_store_mut::<E>(),
         );
 
-        // Keep all enabled indexes caught up as entities are created.
-        let context_ptr: *const Context = self;
-        let property_store = self.entity_store.get_property_store_mut::<E>();
-        // SAFETY: We create a shared `&Context` for read-only property access while mutably
-        // borrowing the property store to update index internals.
-        unsafe {
-            property_store.index_unindexed_entities_for_all_properties(&*context_ptr);
+        // All explicit values are now available, so derived and multi-property dispatchers see
+        // the entity's complete initialized state.
+        let index_count = self
+            .entity_store
+            .get_property_store::<E>()
+            .index_new_entity_fns
+            .len();
+
+        for index in 0..index_count {
+            let dispatch = self
+                .entity_store
+                .get_property_store::<E>()
+                .index_new_entity_fns[index]
+                .1;
+
+            // Copy the function pointer so the immutable PropertyStore borrow ends before dispatch
+            // mutably borrows the Context.
+            dispatch(self, new_entity_id);
         }
 
         // Emit an `EntityCreatedEvent<Entity>`.
@@ -364,30 +427,11 @@ impl ContextEntitiesExt for Context {
     }
 
     fn index_property<E: Entity, P: IndexableProperty<E>>(&mut self) {
-        let property_id = P::id();
-        let context_ptr: *const Context = self;
-        let property_store = self.entity_store.get_property_store_mut::<E>();
-        property_store.set_property_indexed::<P>(PropertyIndexType::FullIndex);
-        // SAFETY: This only creates a shared reference to `Context` while mutably borrowing
-        // the property store to update index internals.
-        unsafe {
-            property_store.index_unindexed_entities_for_property_id(&*context_ptr, property_id);
-        }
+        create_property_index::<E, P>(self, PropertyIndexType::FullIndex);
     }
 
     fn index_property_counts<E: Entity, P: IndexableProperty<E>>(&mut self) {
-        let property_id = P::id();
-        let context_ptr: *const Context = self;
-        let property_store = self.entity_store.get_property_store_mut::<E>();
-        let current_index_type = property_store.get::<P>().index_type();
-        if current_index_type != PropertyIndexType::FullIndex {
-            property_store.set_property_indexed::<P>(PropertyIndexType::ValueCountIndex);
-            // SAFETY: This only creates a shared reference to `Context` while mutably borrowing
-            // the property store to update index internals.
-            unsafe {
-                property_store.index_unindexed_entities_for_property_id(&*context_ptr, property_id);
-            }
-        }
+        create_property_index::<E, P>(self, PropertyIndexType::ValueCountIndex);
     }
 
     fn track_periodic_value_change_counts<E, PL, P, F>(&mut self, period: f64, handler: F)
@@ -971,6 +1015,7 @@ mod tests {
     #[test]
     fn get_derived_property_multiple_deps() {
         let mut context = Context::new();
+        context.index_property::<Person, RiskLevel>();
 
         let expected_high_id: PersonId = context
             .add_entity(with!(
@@ -1003,6 +1048,48 @@ mod tests {
         assert_eq!(actual_med, RiskLevel::Medium);
         let actual_low: RiskLevel = context.get_property(expected_low_id);
         assert_eq!(actual_low, RiskLevel::Low);
+
+        assert_eq!(
+            context
+                .query(with!(Person, RiskLevel::High))
+                .into_iter()
+                .collect::<IndexSet<_>>(),
+            [expected_high_id].into_iter().collect::<IndexSet<_>>(),
+        );
+        assert_eq!(
+            context
+                .query(with!(Person, RiskLevel::Medium))
+                .into_iter()
+                .collect::<IndexSet<_>>(),
+            [expected_med_id].into_iter().collect::<IndexSet<_>>(),
+        );
+        assert_eq!(
+            context
+                .query(with!(Person, RiskLevel::Low))
+                .into_iter()
+                .collect::<IndexSet<_>>(),
+            [expected_low_id].into_iter().collect::<IndexSet<_>>(),
+        );
+    }
+
+    #[test]
+    fn indexed_constant_default_handles_sparse_creation_paths() {
+        let mut context = Context::new();
+        context.index_property::<Person, IsRunner>();
+
+        let omitted = context.add_entity(with!(Person, Age(20))).unwrap();
+        let explicit = context
+            .add_entity(with!(Person, Age(21), IsRunner(false)))
+            .unwrap();
+
+        let matching = context
+            .query(with!(Person, IsRunner(false)))
+            .into_iter()
+            .collect::<IndexSet<_>>();
+        assert_eq!(
+            matching,
+            [omitted, explicit].into_iter().collect::<IndexSet<_>>()
+        );
     }
 
     #[test]

--- a/src/entity/events.rs
+++ b/src/entity/events.rs
@@ -200,10 +200,13 @@ mod tests {
     #[test]
     fn observe_entity_addition() {
         let mut context = Context::new();
+        context.index_property::<Person, Age>();
 
         let flag = Rc::new(RefCell::new(false));
         let flag_clone = flag.clone();
-        context.subscribe_to_event(move |_context, event: EntityCreatedEvent<Person>| {
+        context.subscribe_to_event(move |context, event: EntityCreatedEvent<Person>| {
+            let matching = context.query(with!(Person, Age(18)));
+            assert!(matching.contains(event.entity_id));
             *flag_clone.borrow_mut() = true;
             assert_eq!(event.entity_id.0, 0);
         });

--- a/src/entity/index/full_index.rs
+++ b/src/entity/index/full_index.rs
@@ -13,10 +13,6 @@ use crate::prelude::{IndexableProperty, Property};
 #[derive(Default)]
 pub struct FullIndex<E: Entity, P: Property<E>> {
     data: HashMap<P, IndexSet<EntityId<E>>>,
-
-    // The largest person ID that has been indexed. Used so that we
-    // can lazily index when a person is added.
-    pub(in crate::entity) max_indexed: usize,
 }
 
 impl<E: Entity, P: IndexableProperty<E>> FullIndex<E, P> {
@@ -24,7 +20,6 @@ impl<E: Entity, P: IndexableProperty<E>> FullIndex<E, P> {
     pub fn new() -> Self {
         Self {
             data: HashMap::default(),
-            max_indexed: 0,
         }
     }
 
@@ -78,14 +73,6 @@ where
 
     fn add_entity(&mut self, value: &P, entity_id: EntityId<E>) {
         FullIndex::add_entity(self, value, entity_id);
-    }
-
-    fn max_indexed(&self) -> usize {
-        self.max_indexed
-    }
-
-    fn set_max_indexed(&mut self, max_indexed: usize) {
-        self.max_indexed = max_indexed;
     }
 }
 

--- a/src/entity/index/mod.rs
+++ b/src/entity/index/mod.rs
@@ -2,7 +2,7 @@
 
 use crate::entity::{Entity, EntityId};
 use crate::hashing::IndexSet;
-use crate::prelude::Property;
+use crate::prelude::{IndexableProperty, Property};
 
 mod full_index;
 mod value_count_index;
@@ -35,6 +35,21 @@ pub enum PropertyIndexType {
     ValueCountIndex,
 }
 
+impl PropertyIndexType {
+    /// Constructs an unattached empty index of this type. Returns `None` only for `Unindexed`.
+    pub(crate) fn new_property_index<E, P>(self) -> Option<Box<dyn PropertyIndex<E, P>>>
+    where
+        E: Entity,
+        P: IndexableProperty<E>,
+    {
+        match self {
+            Self::Unindexed => None,
+            Self::FullIndex => Some(Box::new(FullIndex::<E, P>::new())),
+            Self::ValueCountIndex => Some(Box::new(ValueCountIndex::<E, P>::new())),
+        }
+    }
+}
+
 pub trait PropertyIndex<E: Entity, P: Property<E>> {
     #[must_use]
     fn index_type(&self) -> PropertyIndexType;
@@ -48,9 +63,4 @@ pub trait PropertyIndex<E: Entity, P: Property<E>> {
     fn remove_entity(&mut self, value: &P, entity_id: EntityId<E>);
 
     fn add_entity(&mut self, value: &P, entity_id: EntityId<E>);
-
-    #[must_use]
-    fn max_indexed(&self) -> usize;
-
-    fn set_max_indexed(&mut self, max_indexed: usize);
 }

--- a/src/entity/index/value_count_index.rs
+++ b/src/entity/index/value_count_index.rs
@@ -13,7 +13,6 @@ use crate::prelude::{IndexableProperty, Property};
 #[derive(Default)]
 pub struct ValueCountIndex<E: Entity, P: Property<E>> {
     data: HashMap<P, usize>,
-    pub(in crate::entity) max_indexed: usize,
     _phantom: PhantomData<E>,
 }
 
@@ -22,7 +21,6 @@ impl<E: Entity, P: IndexableProperty<E>> ValueCountIndex<E, P> {
     pub fn new() -> Self {
         Self {
             data: HashMap::default(),
-            max_indexed: 0,
             _phantom: PhantomData,
         }
     }
@@ -79,21 +77,12 @@ where
     fn add_entity(&mut self, value: &P, entity_id: EntityId<E>) {
         ValueCountIndex::add_entity(self, value, entity_id);
     }
-
-    fn max_indexed(&self) -> usize {
-        self.max_indexed
-    }
-
-    fn set_max_indexed(&mut self, max_indexed: usize) {
-        self.max_indexed = max_indexed;
-    }
 }
 
 #[cfg(test)]
 mod tests {
     use crate::entity::index::ValueCountIndex;
-    use crate::entity::PropertyIndexType;
-    use crate::hashing::one_shot_128;
+    use crate::hashing::{one_shot_128, IndexSet};
     use crate::prelude::*;
 
     define_entity!(Person);
@@ -110,10 +99,9 @@ mod tests {
     #[test]
     fn test_multi_property_index_typed_api() {
         let mut context = Context::new();
-        let property_store = context.entity_store.get_property_store_mut::<Person>();
 
         assert_ne!(AWH::type_id(), WHA::type_id());
-        property_store.set_property_indexed::<AWH>(PropertyIndexType::ValueCountIndex);
+        context.index_property_counts::<Person, AWH>();
 
         context
             .add_entity(with!(Person, Age(1u8), Weight(2u8), Height(3u8)))
@@ -178,6 +166,58 @@ mod tests {
         context.index_property_counts::<Person, Age>();
 
         assert_eq!(context.query_entity_count(with!(Person, Age(10))), 2);
+
+        context.index_property_counts::<Person, Age>();
+        assert_eq!(context.query_entity_count(with!(Person, Age(10))), 2);
+    }
+
+    #[test]
+    fn value_count_index_can_be_replaced_with_full_index() {
+        let mut context = Context::new();
+        let first = context.add_entity(with!(Person, Age(10))).unwrap();
+        let second = context.add_entity(with!(Person, Age(10))).unwrap();
+        let other = context.add_entity(with!(Person, Age(20))).unwrap();
+
+        context.index_property_counts::<Person, Age>();
+        assert_eq!(context.query_entity_count(with!(Person, Age(10))), 2);
+        assert_eq!(context.query_entity_count(with!(Person, Age(20))), 1);
+
+        context.index_property::<Person, Age>();
+
+        let matching = context
+            .query(with!(Person, Age(10)))
+            .into_iter()
+            .collect::<IndexSet<_>>();
+        assert_eq!(
+            matching,
+            [first, second].into_iter().collect::<IndexSet<_>>()
+        );
+
+        let third = context.add_entity(with!(Person, Age(10))).unwrap();
+        let matching = context
+            .query(with!(Person, Age(10)))
+            .into_iter()
+            .collect::<IndexSet<_>>();
+        assert_eq!(
+            matching,
+            [first, second, third].into_iter().collect::<IndexSet<_>>()
+        );
+        assert_eq!(context.query_entity_count(with!(Person, Age(10))), 3);
+        assert!(!matching.contains(&other));
+
+        context.index_property::<Person, Age>();
+        let after_repeated_request = context
+            .query(with!(Person, Age(10)))
+            .into_iter()
+            .collect::<IndexSet<_>>();
+        assert_eq!(after_repeated_request, matching);
+
+        context.index_property_counts::<Person, Age>();
+        let after_count_request = context
+            .query(with!(Person, Age(10)))
+            .into_iter()
+            .collect::<IndexSet<_>>();
+        assert_eq!(after_count_request, matching);
     }
 
     #[test]

--- a/src/entity/property_store.rs
+++ b/src/entity/property_store.rs
@@ -36,15 +36,34 @@ use std::sync::{LazyLock, Mutex, OnceLock};
 use crate::entity::entity::Entity;
 use crate::entity::entity_store::register_property_with_entity;
 use crate::entity::events::PartialPropertyChangeEventBox;
-use crate::entity::index::{FullIndex, IndexCountResult, IndexSetResult, ValueCountIndex};
-use crate::entity::multi_property::multi_property_id_for_property_type_id;
+use crate::entity::index::{IndexCountResult, IndexSetResult, PropertyIndex};
 use crate::entity::property::{IndexableProperty, Property};
 use crate::entity::property_list::PropertyList;
 use crate::entity::property_value_store::PropertyValueStore;
 use crate::entity::property_value_store_core::PropertyValueStoreCore;
 use crate::entity::value_change_counter::StratifiedValueChangeCounter;
-use crate::entity::{EntityId, PropertyIndexType};
-use crate::Context;
+use crate::entity::EntityId;
+use crate::{Context, ContextEntitiesExt};
+
+pub(in crate::entity) type IndexNewEntityFn<E> = fn(&mut Context, EntityId<E>);
+
+fn index_new_entity<E, P>(context: &mut Context, entity_id: EntityId<E>)
+where
+    E: Entity,
+    P: IndexableProperty<E>,
+{
+    // This may compute a derived or multi-property. `P` is copied, so no reference into Context
+    // survives into the subsequent mutable borrow.
+    let value: P = context.get_property(entity_id);
+
+    let property_value_store = context.get_property_value_store_mut::<E, P>();
+    let index = property_value_store
+        .index
+        .as_mut()
+        .expect("index_new_entity dispatch invoked for an unindexed property");
+
+    index.add_entity(&value, entity_id);
+}
 
 /// A map from Entity ID to a count of the properties already associated with the entity. The value for the key is
 /// equivalent to the next property ID that will be assigned to the next property that requests an ID. Each `Entity`
@@ -209,6 +228,10 @@ pub fn initialize_property_id<E: Entity>(property_id: &AtomicUsize) -> usize {
 pub struct PropertyStore<E: Entity> {
     /// A vector of `Box<PropertyValueStoreCore<E, P>>`, type-erased to `Box<dyn PropertyValueStore<E>>`
     items: Vec<Box<dyn PropertyValueStore<E>>>,
+
+    /// One entry for every property whose `PropertyValueStoreCore` currently has an index.
+    /// The property ID supports removal without relying on deduplicable function addresses.
+    pub(in crate::entity) index_new_entity_fns: Vec<(usize, IndexNewEntityFn<E>)>,
 }
 
 impl<E: Entity> Default for PropertyStore<E> {
@@ -244,7 +267,10 @@ impl<E: Entity> PropertyStore<E> {
             })
             .collect();
 
-        Self { items }
+        Self {
+            items,
+            index_new_entity_fns: Vec::new(),
+        }
     }
 
     /// Fetches an immutable reference to the `PropertyValueStoreCore<E, P>`.
@@ -343,58 +369,55 @@ impl<E: Entity> PropertyStore<E> {
     #[cfg(test)]
     #[must_use]
     pub fn is_property_indexed<P: Property<E>>(&self) -> bool {
-        self.items
-            .get(P::id())
-            .unwrap_or_else(|| panic!("No registered property {} found with id = {:?}. You must use the `define_property!` macro to create a registered property.", P::name(), P::id()))
-            .index_type()
-            != PropertyIndexType::Unindexed
+        self.get::<P>().index.is_some()
     }
 
-    /// Sets the index type for `P`. Passing `PropertyIndexType::Unindexed` removes any existing index for `P`.
-    ///
-    /// Equivalent multi-properties do not share index storage. Only the representative
-    /// multi-property for an equivalent set can be indexed.
-    pub fn set_property_indexed<P: IndexableProperty<E>>(&mut self, index_type: PropertyIndexType) {
-        if index_type != PropertyIndexType::Unindexed {
-            if let Some((representative_id, representative_name)) =
-                multi_property_id_for_property_type_id(E::id(), P::type_id())
-            {
-                if representative_id != P::id() {
-                    panic!(
-                        "Cannot index multi-property {} because it is equivalent to representative multi-property {}. Index the representative multi-property instead.",
-                        P::name(),
-                        representative_name
-                    );
-                }
-            }
+    pub(in crate::entity) fn install_property_index<P>(
+        &mut self,
+        new_index: Option<Box<dyn PropertyIndex<E, P>>>,
+    ) where
+        P: IndexableProperty<E>,
+    {
+        let property_id = P::id();
+        let was_indexed = self.get::<P>().index.is_some();
+        let will_be_indexed = new_index.is_some();
+
+        // Property IDs are stable dispatcher identities; function-pointer addresses are not,
+        // because the linker may deduplicate distinct monomorphizations.
+        let dispatcher_position = self
+            .index_new_entity_fns
+            .iter()
+            .position(|(id, _)| *id == property_id);
+
+        if was_indexed {
+            assert!(
+                dispatcher_position.is_some(),
+                "indexed property missing its index_new_entity dispatcher",
+            );
+        } else {
+            debug_assert!(dispatcher_position.is_none());
         }
 
-        let property_value_store = self.items
-            .get_mut(P::id())
-            .unwrap_or_else(|| panic!("No registered property {} found with id = {:?}. You must use the `define_property!` macro to create a registered property.", P::name(), P::id()));
-        let property_value_store = property_value_store
-            .as_any_mut()
-            .downcast_mut::<PropertyValueStoreCore<E, P>>()
-            .unwrap_or_else(|| {
-                panic!(
-                    "Property type at index {:?} does not match registered property type. You must use the `define_property!` macro to create a registered property.",
-                    P::id()
-                )
-            });
-        match index_type {
-            PropertyIndexType::Unindexed => {
-                property_value_store.index = None;
+        // Reserve before replacing a valid index so allocation failure cannot leave the index
+        // installed without its dispatcher.
+        if !was_indexed && will_be_indexed {
+            self.index_new_entity_fns.reserve(1);
+        }
+
+        // All invariant checks and potentially allocating preparation are complete. Replacing the
+        // installed index is the commit point.
+        self.get_mut::<P>().index = new_index;
+
+        match (was_indexed, will_be_indexed) {
+            (false, true) => {
+                self.index_new_entity_fns
+                    .push((property_id, index_new_entity::<E, P> as IndexNewEntityFn<E>));
             }
-            PropertyIndexType::FullIndex => {
-                if property_value_store.index_type() != PropertyIndexType::FullIndex {
-                    property_value_store.index = Some(Box::new(FullIndex::<E, P>::new()));
-                }
+            (true, false) => {
+                self.index_new_entity_fns
+                    .swap_remove(dispatcher_position.unwrap());
             }
-            PropertyIndexType::ValueCountIndex => {
-                if property_value_store.index_type() != PropertyIndexType::ValueCountIndex {
-                    property_value_store.index = Some(Box::new(ValueCountIndex::<E, P>::new()));
-                }
-            }
+            _ => {}
         }
     }
 
@@ -413,23 +436,6 @@ impl<E: Entity> PropertyStore<E> {
             PL,
             P,
         >::new()))
-    }
-
-    /// Updates the index of the property having the given ID for any entities that have been added to the context
-    /// since the last time the index was updated.
-    pub fn index_unindexed_entities_for_property_id(
-        &mut self,
-        context: &Context,
-        property_id: usize,
-    ) {
-        self.items[property_id].index_unindexed_entities(context)
-    }
-
-    /// Updates all indexed properties for any entities that have been added since the last update.
-    pub fn index_unindexed_entities_for_all_properties(&mut self, context: &Context) {
-        for store in &mut self.items {
-            store.index_unindexed_entities(context);
-        }
     }
 
     #[must_use]
@@ -455,11 +461,13 @@ impl<E: Entity> PropertyStore<E> {
 mod tests {
     #![allow(dead_code)]
     use std::any::Any;
+    use std::panic::{catch_unwind, AssertUnwindSafe};
 
     use super::*;
-    use crate::entity::index::{IndexCountResult, IndexSetResult};
+    use crate::entity::index::{FullIndex, IndexCountResult, IndexSetResult, ValueCountIndex};
+    use crate::entity::PropertyIndexType;
     use crate::prelude::*;
-    use crate::{define_entity, define_property, with, Context};
+    use crate::{define_derived_property, define_entity, define_property, with, Context};
 
     define_entity!(Person);
 
@@ -474,6 +482,19 @@ mod tests {
         default_const = InfectionStatus::Susceptible
     );
     define_property!(struct Vaccinated(bool), Person, default_const = Vaccinated(false));
+    define_property!(struct PanicDependency(u8), Person, default_const = PanicDependency(0));
+
+    define_derived_property!(
+        struct PanickingDerived(u8),
+        Person,
+        [PanicDependency],
+        [],
+        |dependency| {
+            let dependency: PanicDependency = dependency;
+            assert_ne!(dependency, PanicDependency(255), "sentinel property value");
+            PanickingDerived(dependency.0)
+        }
+    );
 
     #[test]
     fn property_store_default_matches_new() {
@@ -481,6 +502,121 @@ mod tests {
         assert_eq!(
             property_store.items.len(),
             get_registered_property_count::<Person>()
+        );
+    }
+
+    #[test]
+    fn install_property_index_maintains_active_dispatchers() {
+        let mut context = Context::new();
+
+        {
+            let property_store = context.entity_store.get_property_store_mut::<Person>();
+            assert_eq!(property_store.index_new_entity_fns.len(), 0);
+
+            property_store.install_property_index::<Age>(Some(Box::new(ValueCountIndex::new())));
+            assert_eq!(property_store.index_new_entity_fns.len(), 1);
+
+            property_store.install_property_index::<Age>(Some(Box::new(ValueCountIndex::new())));
+            assert_eq!(property_store.index_new_entity_fns.len(), 1);
+
+            property_store.install_property_index::<Age>(Some(Box::new(FullIndex::new())));
+            assert_eq!(property_store.index_new_entity_fns.len(), 1);
+
+            property_store.install_property_index::<Age>(None);
+            assert_eq!(property_store.index_new_entity_fns.len(), 0);
+
+            property_store.install_property_index::<Age>(Some(Box::new(ValueCountIndex::new())));
+            property_store.install_property_index::<Vaccinated>(Some(Box::new(FullIndex::new())));
+            property_store.install_property_index::<Age>(None);
+
+            assert_eq!(property_store.index_new_entity_fns.len(), 1);
+            assert_eq!(property_store.index_new_entity_fns[0].0, Vaccinated::id());
+        }
+
+        context.add_entity(with!(Person, Age(10))).unwrap();
+        let property_store = context.entity_store.get_property_store::<Person>();
+        assert_eq!(
+            property_store.get::<Age>().index_type(),
+            PropertyIndexType::Unindexed
+        );
+        assert_eq!(
+            property_store.get_index_count_for_query_parts(
+                Vaccinated::id(),
+                &[&Vaccinated(false) as &dyn Any],
+            ),
+            IndexCountResult::Count(1),
+        );
+    }
+
+    #[test]
+    fn failed_replacement_keeps_old_index_and_dispatcher() {
+        let mut context = Context::new();
+        let ordinary = context
+            .add_entity(with!(Person, Age(10), PanicDependency(10)))
+            .unwrap();
+        let sentinel = context
+            .add_entity(with!(Person, Age(20), PanicDependency(255)))
+            .unwrap();
+
+        let mut old_index = ValueCountIndex::<Person, PanickingDerived>::new();
+        old_index.add_entity(&PanickingDerived(10), ordinary);
+        old_index.add_entity(&PanickingDerived(255), sentinel);
+        context
+            .entity_store
+            .get_property_store_mut::<Person>()
+            .install_property_index::<PanickingDerived>(Some(Box::new(old_index)));
+
+        let (old_type, old_dispatcher_count, old_dispatcher_property_id) = {
+            let property_store = context.entity_store.get_property_store::<Person>();
+            (
+                property_store.get::<PanickingDerived>().index_type(),
+                property_store.index_new_entity_fns.len(),
+                property_store.index_new_entity_fns[0].0,
+            )
+        };
+        assert_eq!(old_type, PropertyIndexType::ValueCountIndex);
+        assert_eq!(
+            context.query_entity_count(with!(Person, PanickingDerived(10))),
+            1
+        );
+        assert_eq!(
+            context.query_entity_count(with!(Person, PanickingDerived(255))),
+            1
+        );
+
+        let result = catch_unwind(AssertUnwindSafe(|| {
+            context.index_property::<Person, PanickingDerived>();
+        }));
+        assert!(result.is_err());
+
+        let property_store = context.entity_store.get_property_store::<Person>();
+        assert_eq!(
+            property_store.get::<PanickingDerived>().index_type(),
+            old_type
+        );
+        assert_eq!(
+            property_store.index_new_entity_fns.len(),
+            old_dispatcher_count
+        );
+        assert_eq!(
+            property_store.index_new_entity_fns[0].0,
+            old_dispatcher_property_id
+        );
+        assert_eq!(
+            context.query_entity_count(with!(Person, PanickingDerived(10))),
+            1
+        );
+        assert_eq!(
+            context.query_entity_count(with!(Person, PanickingDerived(255))),
+            1
+        );
+
+        context
+            .add_entity(with!(Person, Age(30), PanicDependency(10)))
+            .unwrap();
+        assert_eq!(
+            context.query_entity_count(with!(Person, PanickingDerived(10))),
+            2
         );
     }
 

--- a/src/entity/property_value_store.rs
+++ b/src/entity/property_value_store.rs
@@ -1,4 +1,3 @@
-#![allow(unused)]
 /*!
 
 The `PropertyValueStore` trait is the type-erased interface to property value storage.
@@ -12,18 +11,14 @@ Responsibilities:
 
 use std::any::Any;
 
-use log::{error, trace};
-
 use crate::entity::events::{
-    PartialPropertyChangeEvent, PartialPropertyChangeEventBox, PartialPropertyChangeEventCore,
-    PropertyChangeEvent,
+    PartialPropertyChangeEventBox, PartialPropertyChangeEventCore, PropertyChangeEvent,
 };
-use crate::entity::index::{IndexCountResult, IndexSetResult, PropertyIndexType};
+use crate::entity::index::{IndexCountResult, IndexSetResult};
 use crate::entity::property::Property;
 use crate::entity::property_value_store_core::PropertyValueStoreCore;
 use crate::entity::{Entity, EntityId};
-use crate::hashing::IndexSet;
-use crate::{Context, ContextEntitiesExt};
+use crate::Context;
 
 /// The `PropertyValueStore` trait defines the type-erased interface to the concrete property value storage.
 pub(crate) trait PropertyValueStore<E: Entity>: Any {
@@ -50,13 +45,6 @@ pub(crate) trait PropertyValueStore<E: Entity>: Any {
     fn get_index_set_for_query_parts(&self, parts: &[&dyn Any]) -> IndexSetResult<'_, E>;
 
     fn get_index_count_for_query_parts(&self, parts: &[&dyn Any]) -> IndexCountResult;
-
-    /// Returns the index type used by this `PropertyValueStore` instance.
-    fn index_type(&self) -> PropertyIndexType;
-
-    /// Updates the index for any entities that have been added to the context since the last time the index was
-    /// updated.
-    fn index_unindexed_entities(&mut self, context: &Context);
 }
 
 impl<E: Entity, P: Property<E>> PropertyValueStore<E> for PropertyValueStoreCore<E, P> {
@@ -115,42 +103,6 @@ impl<E: Entity, P: Property<E>> PropertyValueStore<E> for PropertyValueStoreCore
                     index.get_index_count_result(&value)
                 }),
             None => IndexCountResult::Unsupported,
-        }
-    }
-
-    fn index_type(&self) -> PropertyIndexType {
-        self.index_type()
-    }
-
-    fn index_unindexed_entities(&mut self, context: &Context) {
-        let current_pop = context.get_entity_count::<E>();
-        let Some(index) = self.index.as_ref() else {
-            return;
-        };
-        let max_indexed = match index.max_indexed() {
-            max_indexed if max_indexed >= current_pop => return,
-            max_indexed => max_indexed,
-        };
-        trace!(
-            "{}: indexing unindexed entity {}..<{}",
-            P::name(),
-            max_indexed,
-            current_pop
-        );
-
-        for id in max_indexed..current_pop {
-            let entity_id = EntityId::new(id);
-            let value = if P::is_derived() {
-                P::compute_derived(context, entity_id)
-            } else {
-                self.get(entity_id)
-            };
-            if let Some(index) = self.index.as_mut() {
-                index.add_entity(&value, entity_id);
-            }
-        }
-        if let Some(index) = self.index.as_mut() {
-            index.set_max_indexed(current_pop);
         }
     }
 }


### PR DESCRIPTION
This PR is stacked on top of the fix of #1007.

Continues the evolution of the indexing subsystem to move implementation that depends on details of concrete index types closer to those concrete types. This makes it easier to add other kinds of indexes in the future.

Replaced lazy index watermark catch-up with eager index maintenance. New entities update only active indexes after all property values are initialized. `PropertyStore` now maintains a list of function pointers for index maintenance for only those properties that are being indexed. This is more efficient than unconditionally refreshing the index for every property based on `max_indexed`, but at the price of slower access to each index. (See "Performance Analysis" below.) This removes the unsafe `Context` aliasing and obsolete watermark machinery while preserving index idempotence and value-count-to-full-index upgrades.

# Performance Analysis

The benchmarks cover different combinations of number of properties (8/"wide", 3/"narrow"), number of properties indexed (0, 1, 3), and number of explicit/non-default values (0, 1).  These benchmarks should also be sufficient to detect any performance regressions once we implement `PropertyInitializedEvent<E, P>`.

They show ~15% performance improvement in the typical case, ~40% improvement for the best case, and a ~12% *slowdown* in the full indexed case.

The new implementation avoids visiting every unindexed property, but each active index is now somewhat more expensive to dispatch (necessary to avoid overlapping borrows). The refactor substantially improves the cost per unindexed property, ~1.1–1.5 ns per entity per unindexed property, while adding roughly 4–5 ns per full-index dispatcher due to repeated registry access and downcasting.

## Real models

The `cfa-evd-2025-interventions` model is a branching model, so `add_entity` is called during simulation. Observed ~3.5% slowdown, statistically meaningful.

The `ixa-epi-covid` model loads the entire population and does not have an indexed property. Any real effect should show up in faster population load times. Observed 2.6% faster load times, which is actually within the noise. No meaningful difference in runtimes.

# Open Questions and Issues

## Any Changes to User Guide Docs?

The old implementation has a pretty simple performance story for index maintenance: performance of `add_property` wasn't really affected by existence of an index. This PR changes this story, speeding up the unindexed case at the cost of introducing a slowdown for each indexed property. So the question is, is it worth discussing this performance story in The Ixa Book?

Actually, the more important guidance seems to me to be, "For best performance, wait until you load the population data before creating new indexes," because it's more efficient to index a property for the entire population at once than to construct it one `add_entity` call at a time. Of course, this advice doesn't apply for, say, a branching model that grows the population over the course of the simulation.