### PR TITLE
feat: add scheduled shutdown helper

### DIFF
--- a/docs/book/models/disease_model/src/main.rs
+++ b/docs/book/models/disease_model/src/main.rs
@@ -14,11 +14,8 @@ static MAX_TIME: f64 = 200.0;
 
 fn main() {
     let result = run_with_args(|context: &mut Context, _args, _| {
-        // Add a plan to shut down the simulation after `max_time`, regardless of
-        // what else is happening in the model.
-        context.add_plan(MAX_TIME, |context| {
-            context.shutdown();
-        });
+        // Cap the run without keeping an otherwise completed simulation alive.
+        context.schedule_shutdown(MAX_TIME);
         people::init(context);
         transmission_manager::init(context);
         infection_manager::init(context);

--- a/docs/book/src/topics/reports.md
+++ b/docs/book/src/topics/reports.md
@@ -282,8 +282,10 @@ within the model so that we write only exactly the data we need.
 | 4.0      | 661               | 226            | 113             |
 | &vellip; | &vellip;          | &vellip;       | &vellip;        |
 
-The `MAX_TIME` is set to 300 for this model, so this will result in only 301
-rows of data (counting "day 0").
+The `MAX_TIME` is set to 300 for this model. Since the shutdown scheduled by
+`schedule_shutdown` is passive, the simulation ends with the last infection
+attempt, just before `MAX_TIME`, so this will result in only 300 rows of data,
+one for each day from day 0 through day 299.
 
 ### Aggregation
 
@@ -436,8 +438,8 @@ fn write_aggregate_sir_report_item(context: &mut Context) {
 
 Exercise:
 
-1. The `aggregate_sir_report` is 301 lines long, one row every day until
-   `MAX_TIME=300`, but most of the rows are of the form `#, 0, 0, 1000`, because
+1. The `aggregate_sir_report` is 300 lines long, one row for every day of the
+   simulation, but most of the rows are of the form `#, 0, 0, 1000`, because
    the entire population is recovered long before we reach `MAX_TIME`. This is
    pretty typical of periodic reports—you get a lot of data you don't need at
    the end of the simulation. Add a simple filter to

--- a/examples/basic-infection/src/lib.rs
+++ b/examples/basic-infection/src/lib.rs
@@ -20,7 +20,6 @@ pub fn initialize(context: &mut Context) {
     incidence_report::init(context).unwrap_or_else(|e| {
         eprintln!("failed to init incidence_report: {}", e);
     });
-    context.add_plan(MAX_TIME, |context| {
-        context.shutdown();
-    });
+    // Cap the run without keeping an otherwise completed simulation alive.
+    context.schedule_shutdown(MAX_TIME);
 }

--- a/examples/births-deaths/src/lib.rs
+++ b/examples/births-deaths/src/lib.rs
@@ -37,7 +37,6 @@ pub fn initialize(context: &mut Context, output_path: &Path) {
     transmission_manager::init(context);
     infection_manager::init(context);
 
-    context.add_plan(parameters.max_time, |context| {
-        context.shutdown();
-    });
+    // Cap the run without keeping an otherwise completed simulation alive.
+    context.schedule_shutdown(parameters.max_time);
 }

--- a/integration-tests/ixa-wasm-tests/src/lib.rs
+++ b/integration-tests/ixa-wasm-tests/src/lib.rs
@@ -22,9 +22,8 @@ pub fn initialize(context: &mut Context) {
     transmission_manager::init(context);
     infection_manager::init(context);
 
-    context.add_plan(MAX_TIME, |context| {
-        context.shutdown();
-    });
+    // Cap the run without keeping an otherwise completed simulation alive.
+    context.schedule_shutdown(MAX_TIME);
 }
 
 // Ensure that errors are reported in console

--- a/ixa-bench/src/reference_sir/sir_ixa.rs
+++ b/ixa-bench/src/reference_sir/sir_ixa.rs
@@ -239,9 +239,8 @@ impl InfectionLoop for Context {
             self.infect_person(p, None);
         }
 
-        self.add_plan(max_time, |context| {
-            context.shutdown();
-        });
+        // Cap the run without keeping an otherwise completed simulation alive.
+        self.schedule_shutdown(max_time);
 
         debug_assert_eq!(
             self.infected_people(),

--- a/src/context.rs
+++ b/src/context.rs
@@ -335,6 +335,40 @@ impl Context {
         self.add_passive_plan_with_phase(time, callback, ExecutionPhase::Normal)
     }
 
+    /// Schedule [`Context::shutdown`] at the specified maximum simulation time.
+    ///
+    /// The shutdown request is scheduled through [`Context::add_passive_plan`],
+    /// so it does not keep the simulation timeline alive when non-passive work is
+    /// exhausted before `time`. If execution reaches `time`, normal shutdown
+    /// finishes queued callbacks and regular plans at that time before running
+    /// shutdown-time plans. If execution ends earlier, the future passive
+    /// shutdown plan remains queued like any other future passive plan.
+    ///
+    /// This schedules the shutdown request itself. Use [`Context::add_shutdown_plan`]
+    /// to schedule work that should run during normal shutdown.
+    ///
+    /// Returns a [`PlanId`] that can be passed to [`Context::cancel_plan`].
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use ixa::Context;
+    ///
+    /// let mut context = Context::new();
+    /// context.schedule_shutdown(10.0);
+    /// context.add_plan(20.0, |_| {});
+    ///
+    /// context.execute();
+    /// assert_eq!(context.get_current_time(), 10.0);
+    /// ```
+    ///
+    /// # Panics
+    ///
+    /// Panics if `time` is in the past, infinite, or NaN.
+    pub fn schedule_shutdown(&mut self, time: f64) -> PlanId {
+        self.add_passive_plan(time, Context::shutdown)
+    }
+
     /// Add a passive plan to the future event list at the specified time and
     /// with the specified phase.
     ///
@@ -736,6 +770,12 @@ pub trait ContextBase: Sized {
         callback: impl FnOnce(&mut Context) + 'static,
         phase: ExecutionPhase,
     ) -> PlanId;
+    /// Schedule normal shutdown as a passive plan at the specified maximum time.
+    ///
+    /// See [`Context::schedule_shutdown`] for full behavior and panic semantics.
+    fn schedule_shutdown(&mut self, time: f64) -> PlanId {
+        self.add_passive_plan(time, Context::shutdown)
+    }
     fn add_shutdown_plan(&mut self, callback: impl FnOnce(&mut Context) + 'static) -> PlanId;
     fn add_shutdown_plan_with_phase(
         &mut self,
@@ -1508,6 +1548,54 @@ mod tests {
 
         assert_eq!(context.get_current_time(), 2.0);
         assert_eq!(*context.get_data_mut(ComponentA), vec![1, 2, 3]);
+    }
+
+    #[test]
+    fn scheduled_shutdown_stops_at_requested_time_and_drains_current_time_work() {
+        let mut context = Context::new();
+        add_plan(&mut context, 1.0, 1);
+        context.schedule_shutdown(2.0);
+        add_plan(&mut context, 2.0, 2);
+        add_plan(&mut context, 3.0, 3);
+
+        context.execute();
+
+        assert_eq!(context.get_current_time(), 2.0);
+        assert_eq!(*context.get_data_mut(ComponentA), vec![1, 2]);
+
+        context.execute();
+
+        assert_eq!(context.get_current_time(), 3.0);
+        assert_eq!(*context.get_data_mut(ComponentA), vec![1, 2, 3]);
+    }
+
+    #[test]
+    fn scheduled_shutdown_does_not_keep_the_timeline_alive() {
+        let mut context = Context::new();
+        context.schedule_shutdown(5.0);
+
+        context.execute();
+
+        assert_eq!(context.get_current_time(), 0.0);
+
+        add_plan(&mut context, 10.0, 1);
+        context.execute();
+
+        assert_eq!(context.get_current_time(), 5.0);
+        assert_eq!(*context.get_data_mut(ComponentA), Vec::<u32>::new());
+    }
+
+    #[test]
+    fn scheduled_shutdown_can_be_cancelled() {
+        let mut context = Context::new();
+        let shutdown_plan = context.schedule_shutdown(2.0);
+        add_plan(&mut context, 3.0, 1);
+        context.cancel_plan(&shutdown_plan);
+
+        context.execute();
+
+        assert_eq!(context.get_current_time(), 3.0);
+        assert_eq!(*context.get_data_mut(ComponentA), vec![1]);
     }
 
     #[test]

--- a/src/plugin_context.rs
+++ b/src/plugin_context.rs
@@ -86,6 +86,8 @@ mod test_plugin_context {
                 },
                 crate::ExecutionPhase::Last,
             );
+            let shutdown_plan = self.schedule_shutdown(2.0);
+            self.cancel_plan(&shutdown_plan);
             self.add_periodic_plan_with_phase(
                 1.0,
                 |context| {


### PR DESCRIPTION
  ## Summary

  - Add `Context::schedule_shutdown(time)` as a passive maximum-time cap.
  - Expose the helper through `ContextBase` and `PluginContext`.
  - Return a cancelable `PlanId` and inherit existing timed-plan validation.
  - Add tests for maximum-time shutdown, passive behavior, cancellation, and
    generic context access.
  - Migrate existing maximum-time shutdown patterns in examples, documentation,
    WASM tests, and benchmarks.

  Because the shutdown plan is passive, it does not keep an otherwise completed
  simulation alive solely to reach the configured maximum time.