### PR TITLE
feat: accept Into<f64> at numeric API boundaries

### DIFF
--- a/integration-tests/ixa-macro-tests/tests/macros.rs
+++ b/integration-tests/ixa-macro-tests/tests/macros.rs
@@ -1,12 +1,30 @@
 #[cfg(test)]
 mod tests {
-    use std::cell::RefCell;
+    use std::cell::{Cell, RefCell};
     use std::hash::{Hash, Hasher};
     use std::rc::Rc;
 
     use ixa::prelude::*;
     use ixa::{HashSet, IxaEvent};
     use serde::{Deserialize, Serialize};
+
+    struct CountingF64 {
+        value: f64,
+        conversions: Rc<Cell<usize>>,
+    }
+
+    impl CountingF64 {
+        fn new(value: f64, conversions: Rc<Cell<usize>>) -> Self {
+            Self { value, conversions }
+        }
+    }
+
+    impl From<CountingF64> for f64 {
+        fn from(value: CountingF64) -> Self {
+            value.conversions.set(value.conversions.get() + 1);
+            value.value
+        }
+    }
 
     define_entity!(Person);
 
@@ -445,6 +463,16 @@ mod tests {
             macro_named_value_change_handler,
         );
 
+        let period_conversions = Rc::new(Cell::new(0));
+        track_periodic_value_change_counts!(
+            ctx,
+            Person,
+            MacroInfectionStatus,
+            CountingF64::new(1.0, Rc::clone(&period_conversions)),
+            |_context, _counter| {},
+        );
+        assert_eq!(period_conversions.get(), 1);
+
         let person = ctx
             .add_entity(with!(
                 Person,
@@ -519,5 +547,24 @@ mod tests {
 
         context.execute();
         assert_eq!(*observed_records.borrow(), vec![0.75]);
+    }
+
+    #[test]
+    fn schedule_relative_converts_wrapped_delay_once() {
+        let mut context = Context::new();
+        let conversions = Rc::new(Cell::new(0));
+        let records = Rc::new(RefCell::new(Vec::new()));
+        let observed_records = Rc::clone(&records);
+
+        schedule_relative!(
+            &mut context,
+            CountingF64::new(1.25, Rc::clone(&conversions)),
+            record_current_time,
+            records
+        );
+
+        context.execute();
+        assert_eq!(conversions.get(), 1);
+        assert_eq!(*observed_records.borrow(), vec![1.25]);
     }
 }

--- a/src/context.rs
+++ b/src/context.rs
@@ -289,18 +289,41 @@ impl Context {
     /// Add a plan to the future event list at the specified time in the normal
     /// phase
     ///
+    /// The supplied time is converted to `f64` before validation.
+    ///
+    /// ```
+    /// use ixa::Context;
+    ///
+    /// struct ModelTime(f64);
+    ///
+    /// impl From<ModelTime> for f64 {
+    ///     fn from(time: ModelTime) -> Self {
+    ///         time.0
+    ///     }
+    /// }
+    ///
+    /// let mut context = Context::new();
+    /// context.add_plan(ModelTime(1.0), |_| {});
+    /// ```
+    ///
     /// Returns a [`PlanId`] for the newly-added plan that can be used to cancel it
     /// if needed.
     /// # Panics
     ///
     /// Panics if time is in the past, infinite, or NaN.
-    pub fn add_plan(&mut self, time: f64, callback: impl FnOnce(&mut Context) + 'static) -> PlanId {
+    pub fn add_plan(
+        &mut self,
+        time: impl Into<f64>,
+        callback: impl FnOnce(&mut Context) + 'static,
+    ) -> PlanId {
         self.add_plan_with_phase(time, callback, ExecutionPhase::Normal)
     }
 
     /// Add a plan to the future event list at the specified time and with the
     /// specified phase (first, normal, or last among plans at the
     /// specified time)
+    ///
+    /// The supplied time is converted to `f64` before validation.
     ///
     /// Returns a [`PlanId`] for the newly-added plan that can be used to cancel it
     /// if needed.
@@ -309,11 +332,11 @@ impl Context {
     /// Panics if time is in the past, infinite, or NaN.
     pub fn add_plan_with_phase(
         &mut self,
-        time: f64,
+        time: impl Into<f64>,
         callback: impl FnOnce(&mut Context) + 'static,
         phase: ExecutionPhase,
     ) -> PlanId {
-        self.add_plan_with_phase_and_passivity(time, callback, phase, false)
+        self.add_plan_with_phase_and_passivity(time.into(), callback, phase, false)
     }
 
     /// Add a passive plan to the future event list at the specified time in the
@@ -322,6 +345,8 @@ impl Context {
     /// Passive plans execute like regular plans but do not keep the simulation
     /// timeline alive.
     ///
+    /// The supplied time is converted to `f64` before validation.
+    ///
     /// Returns a [`PlanId`] for the newly-added plan that can be used to cancel it
     /// if needed.
     /// # Panics
@@ -329,7 +354,7 @@ impl Context {
     /// Panics if time is in the past, infinite, or NaN.
     pub fn add_passive_plan(
         &mut self,
-        time: f64,
+        time: impl Into<f64>,
         callback: impl FnOnce(&mut Context) + 'static,
     ) -> PlanId {
         self.add_passive_plan_with_phase(time, callback, ExecutionPhase::Normal)
@@ -341,6 +366,8 @@ impl Context {
     /// Passive plans execute like regular plans but do not keep the simulation
     /// timeline alive.
     ///
+    /// The supplied time is converted to `f64` before validation.
+    ///
     /// Returns a [`PlanId`] for the newly-added plan that can be used to cancel it
     /// if needed.
     /// # Panics
@@ -348,11 +375,11 @@ impl Context {
     /// Panics if time is in the past, infinite, or NaN.
     pub fn add_passive_plan_with_phase(
         &mut self,
-        time: f64,
+        time: impl Into<f64>,
         callback: impl FnOnce(&mut Context) + 'static,
         phase: ExecutionPhase,
     ) -> PlanId {
-        self.add_plan_with_phase_and_passivity(time, callback, phase, true)
+        self.add_plan_with_phase_and_passivity(time.into(), callback, phase, true)
     }
 
     fn add_plan_with_phase_and_passivity(
@@ -433,6 +460,8 @@ impl Context {
     /// still run during that execution pass. Future passive periodic plans
     /// remain queued and may run if later non-passive work is scheduled.
     ///
+    /// The supplied period is converted to `f64` before validation.
+    ///
     /// Notes:
     /// * The first periodic plan is scheduled at time `0.0`. If `set_start_time` was
     ///   set to a positive value, this will currently panic because the first plan
@@ -443,10 +472,11 @@ impl Context {
     /// Panics if plan period is negative, infinite, or NaN.
     pub fn add_periodic_plan_with_phase(
         &mut self,
-        period: f64,
+        period: impl Into<f64>,
         callback: impl Fn(&mut Context) + 'static,
         phase: ExecutionPhase,
     ) {
+        let period = period.into();
         assert!(
             period > 0.0 && !period.is_nan() && !period.is_infinite(),
             "Period must be greater than 0"
@@ -564,6 +594,8 @@ impl Context {
 
     /// Set the start time for the simulation. Must be finite.
     ///
+    /// The supplied start time is converted to `f64` before validation.
+    ///
     /// * Call before `Context.execute()`.
     /// * `start_time` must be finite (not NaN or infinite).
     /// * May be called only once.
@@ -577,7 +609,8 @@ impl Context {
     /// * the start time was already set.
     /// * `Context::execute()` has been called.
     /// * `start_time` is later than the earliest scheduled plan time.
-    pub fn set_start_time(&mut self, start_time: f64) {
+    pub fn set_start_time(&mut self, start_time: impl Into<f64>) {
+        let start_time = start_time.into();
         assert!(
             !start_time.is_nan() && !start_time.is_infinite(),
             "Start time {start_time} must be finite"
@@ -718,21 +751,25 @@ pub trait ContextBase: Sized {
     ) -> EventListenerId<E>;
     fn unsubscribe_from_event<E: IxaEvent>(&mut self, listener_id: &EventListenerId<E>) -> bool;
     fn emit_event<E: IxaEvent>(&mut self, event: E);
-    fn add_plan(&mut self, time: f64, callback: impl FnOnce(&mut Context) + 'static) -> PlanId;
+    fn add_plan(
+        &mut self,
+        time: impl Into<f64>,
+        callback: impl FnOnce(&mut Context) + 'static,
+    ) -> PlanId;
     fn add_plan_with_phase(
         &mut self,
-        time: f64,
+        time: impl Into<f64>,
         callback: impl FnOnce(&mut Context) + 'static,
         phase: ExecutionPhase,
     ) -> PlanId;
     fn add_passive_plan(
         &mut self,
-        time: f64,
+        time: impl Into<f64>,
         callback: impl FnOnce(&mut Context) + 'static,
     ) -> PlanId;
     fn add_passive_plan_with_phase(
         &mut self,
-        time: f64,
+        time: impl Into<f64>,
         callback: impl FnOnce(&mut Context) + 'static,
         phase: ExecutionPhase,
     ) -> PlanId;
@@ -744,7 +781,7 @@ pub trait ContextBase: Sized {
     ) -> PlanId;
     fn add_periodic_plan_with_phase(
         &mut self,
-        period: f64,
+        period: impl Into<f64>,
         callback: impl Fn(&mut Context) + 'static,
         phase: ExecutionPhase,
     );
@@ -766,13 +803,13 @@ impl ContextBase for Context {
             fn subscribe_to_event<E: IxaEvent>(&mut self, handler: impl Fn(&mut Context, E) + 'static) -> EventListenerId<E>;
             fn unsubscribe_from_event<E: IxaEvent>(&mut self, listener_id: &EventListenerId<E>) -> bool;
             fn emit_event<E: IxaEvent>(&mut self, event: E);
-            fn add_plan(&mut self, time: f64, callback: impl FnOnce(&mut Context) + 'static) -> PlanId;
-            fn add_plan_with_phase(&mut self, time: f64, callback: impl FnOnce(&mut Context) + 'static, phase: ExecutionPhase) -> PlanId;
-            fn add_passive_plan(&mut self, time: f64, callback: impl FnOnce(&mut Context) + 'static) -> PlanId;
-            fn add_passive_plan_with_phase(&mut self, time: f64, callback: impl FnOnce(&mut Context) + 'static, phase: ExecutionPhase) -> PlanId;
+            fn add_plan(&mut self, time: impl Into<f64>, callback: impl FnOnce(&mut Context) + 'static) -> PlanId;
+            fn add_plan_with_phase(&mut self, time: impl Into<f64>, callback: impl FnOnce(&mut Context) + 'static, phase: ExecutionPhase) -> PlanId;
+            fn add_passive_plan(&mut self, time: impl Into<f64>, callback: impl FnOnce(&mut Context) + 'static) -> PlanId;
+            fn add_passive_plan_with_phase(&mut self, time: impl Into<f64>, callback: impl FnOnce(&mut Context) + 'static, phase: ExecutionPhase) -> PlanId;
             fn add_shutdown_plan(&mut self, callback: impl FnOnce(&mut Context) + 'static) -> PlanId;
             fn add_shutdown_plan_with_phase(&mut self, callback: impl FnOnce(&mut Context) + 'static, phase: ExecutionPhase) -> PlanId;
-            fn add_periodic_plan_with_phase(&mut self, period: f64, callback: impl Fn(&mut Context) + 'static, phase: ExecutionPhase);
+            fn add_periodic_plan_with_phase(&mut self, period: impl Into<f64>, callback: impl Fn(&mut Context) + 'static, phase: ExecutionPhase);
             fn cancel_plan(&mut self, plan_id: &PlanId);
             fn queue_callback(&mut self, callback: impl FnOnce(&mut Context) + 'static);
             fn get_data_mut<T: DataPlugin>(&mut self, plugin: T) -> &mut T::DataContainer;
@@ -801,6 +838,15 @@ mod tests {
     use crate::{
         define_data_plugin, define_entity, define_property, with, ContextEntitiesExt, IxaEvent,
     };
+
+    #[derive(Clone, Copy)]
+    struct WrappedF64(f64);
+
+    impl From<WrappedF64> for f64 {
+        fn from(value: WrappedF64) -> Self {
+            value.0
+        }
+    }
 
     define_data_plugin!(ComponentA, Vec<u32>, vec![]);
     define_data_plugin!(UnsubscribeHookObservations, Vec<bool>, vec![]);
@@ -881,6 +927,45 @@ mod tests {
         )
     }
 
+    fn add_wrapped_plan_through_context_base(context: &mut impl ContextBase, value: u32) {
+        context.add_plan(WrappedF64(0.0), move |context| {
+            context.get_data_mut(ComponentA).push(value);
+        });
+    }
+
+    #[test]
+    fn time_boundaries_accept_into_f64() {
+        let mut context = Context::new();
+        context.set_start_time(WrappedF64(0.0));
+
+        add_wrapped_plan_through_context_base(&mut context, 1);
+        context.add_plan_with_phase(
+            WrappedF64(0.0),
+            |context| context.get_data_mut(ComponentA).push(2),
+            ExecutionPhase::First,
+        );
+        context.add_passive_plan(WrappedF64(0.0), |context| {
+            context.get_data_mut(ComponentA).push(3);
+        });
+        context.add_passive_plan_with_phase(
+            WrappedF64(0.0),
+            |context| context.get_data_mut(ComponentA).push(4),
+            ExecutionPhase::Last,
+        );
+        context.add_periodic_plan_with_phase(
+            WrappedF64(1.0),
+            |context| context.get_data_mut(ComponentA).push(5),
+            ExecutionPhase::Normal,
+        );
+
+        context.execute();
+
+        let mut observed = context.get_data(ComponentA).clone();
+        observed.sort_unstable();
+        assert_eq!(observed, vec![1, 2, 3, 4, 5]);
+        assert_eq!(context.get_start_time(), Some(0.0));
+    }
+
     #[test]
     #[should_panic(expected = "Time inf is invalid")]
     fn infinite_plan_time() {
@@ -893,6 +978,13 @@ mod tests {
     fn nan_plan_time() {
         let mut context = Context::new();
         add_plan(&mut context, f64::NAN, 0);
+    }
+
+    #[test]
+    #[should_panic(expected = "Time NaN is invalid")]
+    fn wrapped_nan_plan_time_panics() {
+        let mut context = Context::new();
+        context.add_plan(WrappedF64(f64::NAN), |_| {});
     }
 
     #[test]

--- a/src/entity/context_extension.rs
+++ b/src/entity/context_extension.rs
@@ -128,6 +128,8 @@ pub trait ContextEntitiesExt {
 
     /// Tracks periodic value change counts for a newly created counter.
     ///
+    /// The supplied period is converted to `f64` before validation.
+    ///
     /// Also panics if `period` is not finite and strictly positive.
     ///
     /// Recording starts at `ExecutionPhase::First` at simulation start time. The
@@ -145,8 +147,11 @@ pub trait ContextEntitiesExt {
     ///     },
     /// );
     /// ```
-    fn track_periodic_value_change_counts<E, PL, P, F>(&mut self, period: f64, handler: F)
-    where
+    fn track_periodic_value_change_counts<E, PL, P, F>(
+        &mut self,
+        period: impl Into<f64>,
+        handler: F,
+    ) where
         E: Entity,
         PL: PropertyList<E> + Eq + Hash,
         P: Property<E> + Eq + Hash,
@@ -390,13 +395,17 @@ impl ContextEntitiesExt for Context {
         }
     }
 
-    fn track_periodic_value_change_counts<E, PL, P, F>(&mut self, period: f64, handler: F)
-    where
+    fn track_periodic_value_change_counts<E, PL, P, F>(
+        &mut self,
+        period: impl Into<f64>,
+        handler: F,
+    ) where
         E: Entity,
         PL: PropertyList<E> + Eq + Hash,
         P: IndexableProperty<E>,
         F: Fn(&mut Context, &mut StratifiedValueChangeCounter<E, PL, P>) + 'static,
     {
+        let period = period.into();
         assert!(
             period > 0.0 && !period.is_nan() && !period.is_infinite(),
             "Period must be greater than 0"
@@ -632,6 +641,15 @@ mod tests {
         Person,
         default_const = CounterStratum(false)
     );
+
+    #[derive(Clone, Copy)]
+    struct WrappedF64(f64);
+
+    impl From<WrappedF64> for f64 {
+        fn from(value: WrappedF64) -> Self {
+            value.0
+        }
+    }
 
     define_property!(
         enum InfectionStatus {
@@ -1414,6 +1432,27 @@ mod tests {
 
         let property_value_store = context.get_property_value_store::<Person, CounterValue>();
         assert_eq!(property_value_store.value_change_counters.len(), 2);
+    }
+
+    #[test]
+    fn track_periodic_value_change_counts_accepts_into_f64() {
+        let mut context = Context::new();
+        let observed_times = Rc::new(RefCell::new(Vec::new()));
+        let observed_times_clone = Rc::clone(&observed_times);
+
+        context.track_periodic_value_change_counts::<Person, (CounterStratum,), CounterValue, _>(
+            WrappedF64(1.0),
+            move |context, _counter| {
+                observed_times_clone
+                    .borrow_mut()
+                    .push(context.get_current_time());
+            },
+        );
+        context.add_plan(1.0, |_| {});
+
+        context.execute();
+
+        assert_eq!(*observed_times.borrow(), vec![0.0, 1.0]);
     }
 
     #[test]

--- a/src/macros/schedule_relative.rs
+++ b/src/macros/schedule_relative.rs
@@ -14,7 +14,9 @@
 ///
 /// ```ignore
 /// {
-///     let time = context.get_current_time() + my_delay;
+///     let current_time = context.get_current_time();
+///     let delay: f64 = my_delay.into();
+///     let time = current_time + delay;
 ///     context.add_plan(time, move |context| {
 ///         my_handler(context, arg1, arg2, arg3)
 ///     })
@@ -24,7 +26,9 @@
 macro_rules! schedule_relative {
     ($context:expr, $delay:expr, $action:expr $(, $arg:expr)* $(,)?) => {
         {
-            let time = ($context).get_current_time() + $delay;
+            let current_time = ($context).get_current_time();
+            let delay: f64 = ::core::convert::Into::into($delay);
+            let time = current_time + delay;
             ($context).add_plan(time, move |context| {
                 ($action)(context $(, $arg)*)
             })

--- a/src/macros/value_change_counts.rs
+++ b/src/macros/value_change_counts.rs
@@ -1,7 +1,7 @@
 /// Tracks periodic value change counts with concise entity, property, and strata syntax.
 ///
 /// The strata list is optional. Omitting it, or passing `[]`, uses the empty
-/// property list `()`.
+/// property list `()`. The period may be any value that converts into `f64`.
 ///
 /// ```ignore
 /// track_periodic_value_change_counts!(

--- a/src/random/context_ext.rs
+++ b/src/random/context_ext.rs
@@ -126,14 +126,37 @@ pub trait ContextRandomExt: ContextBase {
         self.sample(rng_id, |rng| rng.random_range(range))
     }
 
-    /// Gets a random boolean value which is true with probability `p`
-    /// using the generator associated with the given [`RngId`].
-    /// Note that this will panic if `set_base_random_seed` was not called yet.
+    /// Gets a random boolean value which is true with probability `p` using the
+    /// generator associated with the given [`RngId`]. The supplied probability
+    /// is converted to `f64` before sampling.
+    ///
+    /// ```
+    /// use ixa::{define_rng, Context, ContextRandomExt};
+    ///
+    /// define_rng!(ExampleRng);
+    ///
+    /// struct Probability(f64);
+    ///
+    /// impl From<Probability> for f64 {
+    ///     fn from(probability: Probability) -> Self {
+    ///         probability.0
+    ///     }
+    /// }
+    ///
+    /// let mut context = Context::new();
+    /// context.init_random(42);
+    /// assert!(context.sample_bool(ExampleRng, Probability(1.0)));
+    /// ```
+    ///
+    /// # Panics
+    ///
+    /// Panics if the converted probability is outside `[0.0, 1.0]` or is NaN.
     #[must_use]
-    fn sample_bool<R: RngId + 'static>(&self, rng_id: R, p: f64) -> bool
+    fn sample_bool<R: RngId + 'static>(&self, rng_id: R, p: impl Into<f64>) -> bool
     where
         R::RngType: Rng,
     {
+        let p = p.into();
         self.sample(rng_id, |rng| rng.random_bool(p))
     }
 
@@ -171,6 +194,14 @@ mod test {
 
     define_rng!(FooRng);
     define_rng!(BarRng);
+
+    struct Probability(f64);
+
+    impl From<Probability> for f64 {
+        fn from(probability: Probability) -> Self {
+            probability.0
+        }
+    }
 
     #[test]
     fn get_rng_basic() {
@@ -364,6 +395,24 @@ mod test {
         let mut context = Context::new();
         context.init_random(42);
         let _r: bool = context.sample_bool(FooRng, 0.5);
+    }
+
+    #[test]
+    fn sample_bool_accepts_into_f64_without_extra_turbofish() {
+        let mut context = Context::new();
+        context.init_random(42);
+
+        assert!(!context.sample_bool::<FooRng>(FooRng, Probability(0.0)));
+        assert!(context.sample_bool::<FooRng>(FooRng, Probability(1.0)));
+    }
+
+    #[test]
+    #[should_panic(expected = "outside range [0.0, 1.0]")]
+    fn sample_bool_rejects_wrapped_invalid_probability() {
+        let mut context = Context::new();
+        context.init_random(42);
+
+        let _ = context.sample_bool(FooRng, Probability(1.1));
     }
 
     #[test]

--- a/src/triggers/mod.rs
+++ b/src/triggers/mod.rs
@@ -259,6 +259,81 @@ mod tests {
         phase: ExecutionPhase,
     }
 
+    #[derive(Clone, Copy)]
+    struct WrappedF64(f64);
+
+    impl From<WrappedF64> for f64 {
+        fn from(value: WrappedF64) -> Self {
+            value.0
+        }
+    }
+
+    #[test]
+    fn time_trigger_builders_accept_into_f64() {
+        let mut context = Context::new();
+        let observed = Rc::new(RefCell::new(Vec::new()));
+
+        TimeTrigger::at(WrappedF64(0.5)).install(&mut context, {
+            let observed = Rc::clone(&observed);
+            move |_context, event| {
+                observed.borrow_mut().push((event.time, event.phase));
+            }
+        });
+        TimeTrigger::at_phase(WrappedF64(0.5), ExecutionPhase::Last).install(&mut context, {
+            let observed = Rc::clone(&observed);
+            move |_context, event| {
+                observed.borrow_mut().push((event.time, event.phase));
+            }
+        });
+
+        context.execute();
+
+        assert_eq!(
+            *observed.borrow(),
+            vec![(0.5, ExecutionPhase::Normal), (0.5, ExecutionPhase::Last),]
+        );
+    }
+
+    #[test]
+    fn periodic_time_trigger_builders_accept_into_f64() {
+        let mut context = Context::new();
+        let observed = Rc::new(RefCell::new(Vec::new()));
+
+        PeriodicTimeTrigger::every(WrappedF64(1.0))
+            .start_at(WrappedF64(0.5))
+            .install(&mut context, {
+                let observed = Rc::clone(&observed);
+                move |_context, event| {
+                    observed
+                        .borrow_mut()
+                        .push(("at", event.time, event.period, event.phase));
+                }
+            });
+        PeriodicTimeTrigger::every_with_phase(WrappedF64(1.0), ExecutionPhase::Last)
+            .start_with_delay(WrappedF64(0.5))
+            .install(&mut context, {
+                let observed = Rc::clone(&observed);
+                move |_context, event| {
+                    observed
+                        .borrow_mut()
+                        .push(("delay", event.time, event.period, event.phase));
+                }
+            });
+        context.add_plan(1.5, |_| {});
+
+        context.execute();
+
+        assert_eq!(
+            *observed.borrow(),
+            vec![
+                ("at", 0.5, 1.0, ExecutionPhase::Normal),
+                ("delay", 0.5, 1.0, ExecutionPhase::Last),
+                ("at", 1.5, 1.0, ExecutionPhase::Normal),
+                ("delay", 1.5, 1.0, ExecutionPhase::Last),
+            ]
+        );
+    }
+
     #[test]
     fn register_property_value_count_trigger() {
         let mut context = Context::new();
@@ -777,6 +852,12 @@ mod tests {
     #[should_panic(expected = "delay must be greater than or equal to 0")]
     fn periodic_time_trigger_infinite_delay_panics() {
         let _ = PeriodicTimeTrigger::every(1.0).start_with_delay(f64::INFINITY);
+    }
+
+    #[test]
+    #[should_panic(expected = "delay must be greater than or equal to 0")]
+    fn periodic_time_trigger_rejects_wrapped_invalid_delay() {
+        let _ = PeriodicTimeTrigger::every(1.0).start_with_delay(WrappedF64(-1.0));
     }
 
     #[test]

--- a/src/triggers/periodic_time.rs
+++ b/src/triggers/periodic_time.rs
@@ -43,6 +43,7 @@
 //! The period must be positive, finite, and not NaN. A delay must be non-negative, finite, and not
 //! NaN. An absolute start time must be finite and not NaN; the context validates at trigger
 //! installation that it is not in the past.
+//! Builder inputs are converted to `f64` before these checks are applied.
 //!
 //! Since time is monotonic, this criterion does not use [`Direction`](super::Direction) or
 //! [`TriggerMode`](super::TriggerMode). It emits whenever its periodic schedule executes. If several
@@ -104,7 +105,8 @@ pub struct PeriodicTimeTriggerEvent {
 
 impl PeriodicTimeTrigger {
     #[must_use]
-    pub fn every(period: f64) -> Self {
+    pub fn every(period: impl Into<f64>) -> Self {
+        let period = period.into();
         validate_period(period);
         Self {
             period,
@@ -114,7 +116,8 @@ impl PeriodicTimeTrigger {
     }
 
     #[must_use]
-    pub fn every_with_phase(period: f64, phase: ExecutionPhase) -> Self {
+    pub fn every_with_phase(period: impl Into<f64>, phase: ExecutionPhase) -> Self {
+        let period = period.into();
         validate_period(period);
         Self {
             period,
@@ -130,7 +133,8 @@ impl PeriodicTimeTrigger {
     }
 
     #[must_use]
-    pub fn start_with_delay(mut self, delay: f64) -> Self {
+    pub fn start_with_delay(mut self, delay: impl Into<f64>) -> Self {
+        let delay = delay.into();
         assert!(
             delay >= 0.0 && !delay.is_nan() && !delay.is_infinite(),
             "delay must be greater than or equal to 0"
@@ -140,7 +144,8 @@ impl PeriodicTimeTrigger {
     }
 
     #[must_use]
-    pub fn start_at(mut self, start_time: f64) -> Self {
+    pub fn start_at(mut self, start_time: impl Into<f64>) -> Self {
+        let start_time = start_time.into();
         assert!(
             !start_time.is_nan(),
             "start_time {start_time} is invalid: cannot be NaN"

--- a/src/triggers/time.rs
+++ b/src/triggers/time.rs
@@ -32,6 +32,7 @@
 //! [`context.add_plan_with_phase`](crate::Context::add_plan_with_phase).
 //!
 //! [`TimeTrigger::at`] uses [`ExecutionPhase::Normal`](crate::ExecutionPhase::Normal).
+//! Constructor time inputs are converted to `f64` and validated when the trigger is installed.
 //! Since time is monotonic, this criterion does not use [`Direction`](super::Direction) or
 //! [`TriggerMode`](super::TriggerMode). It emits once, when its scheduled plan executes. If several
 //! plans are scheduled for the same time, the selected [`ExecutionPhase`](crate::ExecutionPhase)
@@ -80,16 +81,19 @@ pub struct TimeTriggerEvent {
 
 impl TimeTrigger {
     #[must_use]
-    pub fn at(at: f64) -> Self {
+    pub fn at(at: impl Into<f64>) -> Self {
         Self {
-            at,
+            at: at.into(),
             phase: ExecutionPhase::Normal,
         }
     }
 
     #[must_use]
-    pub fn at_phase(at: f64, phase: ExecutionPhase) -> Self {
-        Self { at, phase }
+    pub fn at_phase(at: impl Into<f64>, phase: ExecutionPhase) -> Self {
+        Self {
+            at: at.into(),
+            phase,
+        }
     }
 
     #[must_use]


### PR DESCRIPTION
  ## Summary

  - Accept `impl Into<f64>` in public APIs for:
    - context scheduling and simulation start times
    - time and periodic trigger builders
    - random boolean probabilities
    - periodic entity value-change tracking
  - Support wrapped numeric values in the related scheduling and tracking macros.
  - Convert values exactly once at the public boundary while retaining internal
    `f64` storage.
  - Preserve existing validation and panic behavior.
  - Add documentation and regression tests using typed numeric wrappers.

  ## Motivation

  Models commonly wrap numeric values in domain-specific types, such as validated
  probabilities or sortable model times. These changes allow callers to pass such
  types directly without manually converting them to `f64`.

  Existing `f64` call sites remain source-compatible.