### PR TITLE
feat: Emit `PropertyInitializedEvent` in `add_event`

### DIFF
--- a/src/data_structures/bit_set.rs
+++ b/src/data_structures/bit_set.rs
@@ -1,0 +1,317 @@
+//! A semi-dynamic bit mask data structure the size of which is fixed at construction.
+//!
+//! Supports very efficient "is empty" check, `get`, and `set` operations. A `BitSet` allocates all
+//! of its storage up front. The storage is chunked into 64 bit words, which means allocated
+//! capacity can be greater than the value of `bit_count` the `BitSet` was constructed with. For
+//! simplicity, we allow the entire capacity to be used (with `set` and `get`). As a consequence,
+//! the actual value of `bit_count` the `BitSet` was constructed with is not recoverable after
+//! construction.
+//!
+//! ## Implementation
+//!
+//! Storage is inline for <=64 bits, which makes access and cloning very cheap for the
+//! overwhelmingly common case. Internally we use a `set_count` to make `is_empty` very fast
+//! independent of whether or not storage is inline.
+
+pub struct BitSet {
+    /// 64 bits inline or heap allocated spillover.
+    storage: Storage,
+    /// Count of set bits, for O(1) empty check. Maintained in mutation operations.
+    set_count: u32,
+}
+
+enum Storage {
+    /// Inline storage for bit counts <= 64. No heap allocation; `Clone` is a register copy.
+    Inline(u64),
+    /// Heap storage for bit counts > 64. Fixed length, allocated once.
+    Heap(Box<[u64]>),
+}
+
+impl BitSet {
+    pub fn new(bit_count: usize) -> Self {
+        let storage = if bit_count <= 64 {
+            Storage::Inline(0)
+        } else {
+            let num_words = bit_count.div_ceil(64);
+            Storage::Heap(vec![0u64; num_words].into_boxed_slice())
+        };
+        Self {
+            storage,
+            set_count: 0,
+        }
+    }
+
+    #[inline(always)]
+    pub fn is_empty(&self) -> bool {
+        self.set_count == 0
+    }
+
+    /// Clones this `BitSet` if it contains any set bits.
+    #[inline(always)]
+    pub fn clone_if_nonempty(&self) -> Option<Self> {
+        if self.is_empty() {
+            None
+        } else {
+            Some(self.clone())
+        }
+    }
+
+    /// Returns the total number of bits that can be stored in this `BitSet`.
+    #[inline(always)]
+    pub fn capacity(&self) -> usize {
+        match &self.storage {
+            Storage::Inline(_) => 64,
+            Storage::Heap(words) => words.len() * 64,
+        }
+    }
+
+    /// Returns `true` if the `n`th bit is set, `false` otherwise.
+    #[inline(always)]
+    pub fn get(&self, n: usize) -> bool {
+        match &self.storage {
+            Storage::Inline(word) => (word >> n) & 1 != 0,
+            Storage::Heap(words) => {
+                let word = n >> 6; // n / 64
+                let bit = n & 63; // n % 64
+                (words[word] >> bit) & 1 != 0
+            }
+        }
+    }
+
+    /// Sets the `n`th bit.
+    #[inline(always)]
+    pub fn set(&mut self, n: usize) {
+        match &mut self.storage {
+            Storage::Inline(word) => {
+                let mask = 1u64 << n;
+                if *word & mask == 0 {
+                    *word |= mask;
+                    self.set_count += 1;
+                }
+            }
+            Storage::Heap(words) => {
+                let idx = n >> 6;
+                let mask = 1u64 << (n & 63);
+                let prev = words[idx];
+                if prev & mask == 0 {
+                    words[idx] = prev | mask;
+                    self.set_count += 1;
+                }
+            }
+        }
+    }
+
+    /// Clears the `n`th bit.
+    #[inline(always)]
+    pub fn reset(&mut self, n: usize) {
+        match &mut self.storage {
+            Storage::Inline(word) => {
+                let mask = 1u64 << n;
+                if *word & mask != 0 {
+                    *word &= !mask;
+                    self.set_count -= 1;
+                }
+            }
+            Storage::Heap(words) => {
+                let idx = n >> 6;
+                let mask = 1u64 << (n & 63);
+                let prev = words[idx];
+                if prev & mask != 0 {
+                    words[idx] = prev & !mask;
+                    self.set_count -= 1;
+                }
+            }
+        }
+    }
+
+    /// Clears the entire `BitSet`, resetting every bit.
+    pub fn clear(&mut self) {
+        match &mut self.storage {
+            Storage::Inline(word) => *word = 0,
+            Storage::Heap(words) => {
+                for word in words.iter_mut() {
+                    *word = 0;
+                }
+            }
+        }
+        self.set_count = 0;
+    }
+}
+
+// We manually implement `Clone` in order to decorate with `#[inline]`. Deriving `Clone` would
+// generate essentially the same code but with weaker confidence of inlining. (Code complexity,
+// compiler version, platform, whether LTO is enabled, and other mysterious factors contribute
+// to the inlining decision threshold in the general case.)
+impl Clone for BitSet {
+    #[inline]
+    fn clone(&self) -> Self {
+        let storage = match &self.storage {
+            // Register copy, no allocation.
+            Storage::Inline(word) => Storage::Inline(*word),
+            // Allocates. Only reached for bit counts > 64.
+            Storage::Heap(words) => Storage::Heap(words.clone()),
+        };
+        Self {
+            storage,
+            set_count: self.set_count,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::BitSet;
+
+    #[test]
+    fn capacity_is_at_least_one_word_and_rounds_up_to_whole_words() {
+        for (bit_count, expected_capacity) in [
+            (0, 64),
+            (1, 64),
+            (64, 64),
+            (65, 128),
+            (128, 128),
+            (129, 192),
+        ] {
+            let bit_set = BitSet::new(bit_count);
+            assert_eq!(bit_set.capacity(), expected_capacity);
+            assert!(bit_set.is_empty());
+        }
+    }
+
+    #[test]
+    fn set_and_get_inline_bits() {
+        let mut bit_set = BitSet::new(64);
+
+        for bit in [0, 1, 31, 32, 63] {
+            assert!(!bit_set.get(bit));
+            bit_set.set(bit);
+            assert!(bit_set.get(bit));
+        }
+
+        assert!(!bit_set.is_empty());
+        assert!(!bit_set.get(2));
+        assert!(!bit_set.get(62));
+    }
+
+    #[test]
+    fn set_and_get_heap_bits_across_word_boundaries() {
+        let mut bit_set = BitSet::new(130);
+
+        for bit in [0, 63, 64, 65, 127, 128, 129, 191] {
+            assert!(!bit_set.get(bit));
+            bit_set.set(bit);
+            assert!(bit_set.get(bit));
+        }
+
+        assert!(!bit_set.is_empty());
+        assert!(!bit_set.get(1));
+        assert!(!bit_set.get(66));
+        assert!(!bit_set.get(190));
+    }
+
+    #[test]
+    fn repeated_set_and_reset_are_idempotent() {
+        let mut bit_set = BitSet::new(65);
+
+        bit_set.set(64);
+        bit_set.set(64);
+        bit_set.set(127);
+        bit_set.reset(64);
+        bit_set.reset(64);
+
+        assert!(!bit_set.get(64));
+        assert!(bit_set.get(127));
+        assert!(!bit_set.is_empty());
+
+        bit_set.reset(127);
+        assert!(bit_set.is_empty());
+
+        bit_set.reset(127);
+        assert!(bit_set.is_empty());
+    }
+
+    #[test]
+    fn clear_resets_inline_storage_and_allows_reuse() {
+        let mut bit_set = BitSet::new(64);
+        for bit in [0, 32, 63] {
+            bit_set.set(bit);
+        }
+
+        bit_set.clear();
+
+        assert!(bit_set.is_empty());
+        for bit in [0, 32, 63] {
+            assert!(!bit_set.get(bit));
+        }
+
+        bit_set.set(32);
+        assert!(bit_set.get(32));
+        assert!(!bit_set.is_empty());
+    }
+
+    #[test]
+    fn clear_resets_every_heap_word_and_allows_reuse() {
+        let mut bit_set = BitSet::new(192);
+        for bit in [0, 63, 64, 127, 128, 191] {
+            bit_set.set(bit);
+        }
+
+        bit_set.clear();
+
+        assert!(bit_set.is_empty());
+        for bit in [0, 63, 64, 127, 128, 191] {
+            assert!(!bit_set.get(bit));
+        }
+
+        bit_set.set(128);
+        assert!(bit_set.get(128));
+        assert!(!bit_set.is_empty());
+    }
+
+    #[test]
+    fn inline_clone_is_independent() {
+        assert_clone_is_independent(64, 1, 63);
+    }
+
+    #[test]
+    fn heap_clone_is_independent() {
+        assert_clone_is_independent(128, 64, 127);
+    }
+
+    #[test]
+    fn clone_if_nonempty_returns_none_for_empty_inline_and_heap_storage() {
+        assert!(BitSet::new(64).clone_if_nonempty().is_none());
+        assert!(BitSet::new(65).clone_if_nonempty().is_none());
+    }
+
+    #[test]
+    fn clone_if_nonempty_returns_an_independent_clone() {
+        let mut original = BitSet::new(65);
+        original.set(64);
+
+        let mut cloned = original.clone_if_nonempty().unwrap();
+        cloned.reset(64);
+        cloned.set(65);
+
+        assert!(original.get(64));
+        assert!(!original.get(65));
+        assert!(!cloned.get(64));
+        assert!(cloned.get(65));
+    }
+
+    fn assert_clone_is_independent(bit_count: usize, original_bit: usize, clone_bit: usize) {
+        let mut original = BitSet::new(bit_count);
+        original.set(original_bit);
+
+        let mut cloned = original.clone();
+        cloned.reset(original_bit);
+        cloned.set(clone_bit);
+
+        assert!(original.get(original_bit));
+        assert!(!original.get(clone_bit));
+        assert!(!cloned.get(original_bit));
+        assert!(cloned.get(clone_bit));
+        assert!(!original.is_empty());
+        assert!(!cloned.is_empty());
+    }
+}

--- a/src/data_structures/mod.rs
+++ b/src/data_structures/mod.rs
@@ -1,3 +1,4 @@
+pub mod bit_set;
 pub mod entity_map;
 pub mod entity_vec;
 pub mod value_vec;

--- a/src/entity/context_extension.rs
+++ b/src/entity/context_extension.rs
@@ -340,6 +340,8 @@ impl ContextEntitiesExt for Context {
             dispatch(self, new_entity_id);
         }
 
+        property_list.emit_initialized_events(self, new_entity_id);
+
         // Emit an `EntityCreatedEvent<Entity>`.
         self.emit_event(EntityCreatedEvent::<E>::new(new_entity_id));
 

--- a/src/entity/context_extension.rs
+++ b/src/entity/context_extension.rs
@@ -322,11 +322,16 @@ impl ContextEntitiesExt for Context {
 
         // All explicit values are now available, so derived and multi-property dispatchers see
         // the entity's complete initialized state.
-        let index_count = self
-            .entity_store
-            .get_property_store::<E>()
-            .index_new_entity_fns
-            .len();
+
+        // We simultaneously fetch the index count and bit mask of property initialized event
+        // subscriptions from the entity store without retaining a borrow of the store.
+        let (index_count, property_initialized_event_subscriptions) = {
+            let property_store = self.entity_store.get_property_store::<E>();
+            (
+                property_store.index_new_entity_fns.len(),
+                property_store.property_initialized_event_subscriptions,
+            )
+        };
 
         for index in 0..index_count {
             let dispatch = self
@@ -340,7 +345,13 @@ impl ContextEntitiesExt for Context {
             dispatch(self, new_entity_id);
         }
 
-        property_list.emit_initialized_events(self, new_entity_id);
+        if property_initialized_event_subscriptions != 0 {
+            property_list.emit_initialized_events(
+                self,
+                new_entity_id,
+                property_initialized_event_subscriptions,
+            );
+        }
 
         // Emit an `EntityCreatedEvent<Entity>`.
         self.emit_event(EntityCreatedEvent::<E>::new(new_entity_id));

--- a/src/entity/context_extension.rs
+++ b/src/entity/context_extension.rs
@@ -324,13 +324,15 @@ impl ContextEntitiesExt for Context {
         // All explicit values are now available, so derived and multi-property dispatchers see
         // the entity's complete initialized state.
 
-        // We simultaneously fetch the index count and bit mask of property initialized event
-        // subscriptions from the entity store without retaining a borrow of the store.
+        // We simultaneously fetch the index count and, when nonempty, clone the set of property
+        // initialized event subscriptions without retaining a borrow of the entity store.
         let (index_count, property_initialized_event_subscriptions) = {
             let property_store = self.entity_store.get_property_store::<E>();
             (
                 property_store.index_new_entity_fns.len(),
-                property_store.property_initialized_event_subscriptions,
+                property_store
+                    .property_initialized_event_subscriptions
+                    .clone_if_nonempty(),
             )
         };
 
@@ -346,11 +348,13 @@ impl ContextEntitiesExt for Context {
             dispatch(self, new_entity_id);
         }
 
-        if property_initialized_event_subscriptions != 0 {
+        if let Some(property_initialized_event_subscriptions) =
+            property_initialized_event_subscriptions
+        {
             property_list.emit_initialized_events(
                 self,
                 new_entity_id,
-                property_initialized_event_subscriptions,
+                &property_initialized_event_subscriptions,
             );
         }
 

--- a/src/entity/context_extension.rs
+++ b/src/entity/context_extension.rs
@@ -311,7 +311,8 @@ impl ContextEntitiesExt for Context {
         }
 
         // Now that we know we will succeed, we create the entity.
-        let new_entity_id = self.entity_store.new_entity_id::<E>();
+        let (new_entity_id, entity_created_event_subscribed) =
+            self.entity_store.new_entity_id::<E>();
 
         // Assign the properties in the list to the new entity.
         // This does not generate a property change event.
@@ -353,8 +354,9 @@ impl ContextEntitiesExt for Context {
             );
         }
 
-        // Emit an `EntityCreatedEvent<Entity>`.
-        self.emit_event(EntityCreatedEvent::<E>::new(new_entity_id));
+        if entity_created_event_subscribed {
+            self.emit_event(EntityCreatedEvent::<E>::new(new_entity_id));
+        }
 
         Ok(new_entity_id)
     }

--- a/src/entity/entity_store.rs
+++ b/src/entity/entity_store.rs
@@ -153,6 +153,9 @@ pub fn initialize_entity_index(plugin_index: &AtomicUsize) -> usize {
 pub struct EntityRecord {
     /// The total count of all entities of this type (i.e., the next index to assign).
     pub(crate) entity_count: usize,
+    /// Whether `EntityCreatedEvent` has any subscribers for this entity type. This is a performance
+    /// optimization for `add_entity`.
+    pub(in crate::entity) entity_created_event_subscribed: bool,
     /// Lazily initialized `Entity` instance.
     pub(crate) entity: OnceCell<Box<dyn Any>>,
     /// A type-erased `Box<PropertyStore<E>>`, lazily initialized.
@@ -163,6 +166,7 @@ impl EntityRecord {
     pub(crate) fn new() -> Self {
         Self {
             entity_count: 0,
+            entity_created_event_subscribed: false,
             entity: OnceCell::new(),
             property_store: OnceCell::new(),
         }
@@ -171,7 +175,7 @@ impl EntityRecord {
 
 /// A wrapper around a vector of entities.
 pub struct EntityStore {
-    items: Vec<EntityRecord>,
+    pub(in crate::entity) items: Vec<EntityRecord>,
 }
 
 impl Default for EntityStore {
@@ -236,13 +240,14 @@ impl EntityStore {
     }
 
     /// Creates a new `EntityId` for the given `Entity` type `E`.
-    /// Increments the entity counter and returns the next valid ID.
-    pub(crate) fn new_entity_id<E: Entity>(&mut self) -> EntityId<E> {
+    /// Increments the entity counter and returns the next valid ID together with whether
+    /// `EntityCreatedEvent<E>` has subscribers.
+    pub(crate) fn new_entity_id<E: Entity>(&mut self) -> (EntityId<E>, bool) {
         let index = E::id();
         let record = &mut self.items[index];
         let id = record.entity_count;
         record.entity_count += 1;
-        EntityId::new(id)
+        (EntityId::new(id), record.entity_created_event_subscribed)
     }
 
     /// Returns a total count of all created entities of type `E`.

--- a/src/entity/events.rs
+++ b/src/entity/events.rs
@@ -179,7 +179,7 @@ pub struct PropertyInitializedEvent<E: Entity, P: Property<E>> {
     pub value: P,
 }
 
-// Implemented manually to maintain the subscription mask through the event hooks.
+// Implemented manually to maintain the subscription bit set through the event hooks.
 impl<E: Entity, P: Property<E>> Clone for PropertyInitializedEvent<E, P> {
     fn clone(&self) -> Self {
         *self
@@ -195,7 +195,8 @@ impl<E: Entity, P: Property<E>> IxaEvent for PropertyInitializedEvent<E, P> {
                 context
                     .entity_store
                     .get_property_store_mut::<E>()
-                    .property_initialized_event_subscriptions |= 1_u32 << P::id();
+                    .property_initialized_event_subscriptions
+                    .set(P::id());
             }
             PropertyInitializationKind::Derived => {}
         }
@@ -209,7 +210,8 @@ impl<E: Entity, P: Property<E>> IxaEvent for PropertyInitializedEvent<E, P> {
                 context
                     .entity_store
                     .get_property_store_mut::<E>()
-                    .property_initialized_event_subscriptions &= !(1_u32 << P::id());
+                    .property_initialized_event_subscriptions
+                    .reset(P::id());
             }
             PropertyInitializationKind::Explicit
             | PropertyInitializationKind::Constant
@@ -481,42 +483,33 @@ mod tests {
     #[test]
     fn property_initialized_subscription_cache_tracks_listener_lifecycle() {
         let mut context = Context::new();
-        let bit = 1_u32 << <InitConstant as Property<InitializationPerson>>::id();
+        let property_id = <InitConstant as Property<InitializationPerson>>::id();
 
         let first = context.subscribe_to_event(
             |_context, _event: PropertyInitializedEvent<InitializationPerson, InitConstant>| {},
         );
-        assert_eq!(
-            context
-                .entity_store
-                .get_property_store::<InitializationPerson>()
-                .property_initialized_event_subscriptions
-                & bit,
-            bit
-        );
+        assert!(context
+            .entity_store
+            .get_property_store::<InitializationPerson>()
+            .property_initialized_event_subscriptions
+            .get(property_id));
 
         let second = context.subscribe_to_event(
             |_context, _event: PropertyInitializedEvent<InitializationPerson, InitConstant>| {},
         );
         assert!(context.unsubscribe_from_event(&first));
-        assert_eq!(
-            context
-                .entity_store
-                .get_property_store::<InitializationPerson>()
-                .property_initialized_event_subscriptions
-                & bit,
-            bit
-        );
+        assert!(context
+            .entity_store
+            .get_property_store::<InitializationPerson>()
+            .property_initialized_event_subscriptions
+            .get(property_id));
 
         assert!(context.unsubscribe_from_event(&second));
-        assert_eq!(
-            context
-                .entity_store
-                .get_property_store::<InitializationPerson>()
-                .property_initialized_event_subscriptions
-                & bit,
-            0
-        );
+        assert!(!context
+            .entity_store
+            .get_property_store::<InitializationPerson>()
+            .property_initialized_event_subscriptions
+            .get(property_id));
     }
 
     #[test]
@@ -525,18 +518,15 @@ mod tests {
         let listener = context.subscribe_to_event(
             |_context, _event: PropertyInitializedEvent<InitializationPerson, InitConstant>| {},
         );
-        let bit = 1_u32 << <InitConstant as Property<InitializationPerson>>::id();
+        let property_id = <InitConstant as Property<InitializationPerson>>::id();
 
         assert!(context.unsubscribe_from_event(&listener));
         assert!(!context.unsubscribe_from_event(&listener));
-        assert_eq!(
-            context
-                .entity_store
-                .get_property_store::<InitializationPerson>()
-                .property_initialized_event_subscriptions
-                & bit,
-            0
-        );
+        assert!(!context
+            .entity_store
+            .get_property_store::<InitializationPerson>()
+            .property_initialized_event_subscriptions
+            .get(property_id));
     }
 
     #[test]
@@ -546,13 +536,11 @@ mod tests {
             |_context, _event: PropertyInitializedEvent<InitializationPerson, InitDerived>| {},
         );
 
-        assert_eq!(
-            context
-                .entity_store
-                .get_property_store::<InitializationPerson>()
-                .property_initialized_event_subscriptions,
-            0
-        );
+        assert!(context
+            .entity_store
+            .get_property_store::<InitializationPerson>()
+            .property_initialized_event_subscriptions
+            .is_empty());
     }
 
     #[test]
@@ -565,15 +553,12 @@ mod tests {
             |_context, _event: PropertyInitializedEvent<InitializationPerson, InitRequired>| {},
         );
 
-        let expected = (1_u32 << <InitConstant as Property<InitializationPerson>>::id())
-            | (1_u32 << InitRequired::id());
-        assert_eq!(
-            context
-                .entity_store
-                .get_property_store::<InitializationPerson>()
-                .property_initialized_event_subscriptions,
-            expected
-        );
+        let subscriptions = &context
+            .entity_store
+            .get_property_store::<InitializationPerson>()
+            .property_initialized_event_subscriptions;
+        assert!(subscriptions.get(<InitConstant as Property<InitializationPerson>>::id()));
+        assert!(subscriptions.get(InitRequired::id()));
     }
 
     #[test]
@@ -583,20 +568,16 @@ mod tests {
             |_context, _event: PropertyInitializedEvent<InitializationPerson, InitConstant>| {},
         );
 
-        assert_ne!(
-            context
-                .entity_store
-                .get_property_store::<InitializationPerson>()
-                .property_initialized_event_subscriptions,
-            0
-        );
-        assert_eq!(
-            context
-                .entity_store
-                .get_property_store::<OtherInitializationPerson>()
-                .property_initialized_event_subscriptions,
-            0
-        );
+        assert!(!context
+            .entity_store
+            .get_property_store::<InitializationPerson>()
+            .property_initialized_event_subscriptions
+            .is_empty());
+        assert!(context
+            .entity_store
+            .get_property_store::<OtherInitializationPerson>()
+            .property_initialized_event_subscriptions
+            .is_empty());
     }
 
     #[test]
@@ -604,13 +585,11 @@ mod tests {
         let mut context = Context::new();
         context.subscribe_to_event(|_context, _event: EntityCreatedEvent<InitializationPerson>| {});
 
-        assert_eq!(
-            context
-                .entity_store
-                .get_property_store::<InitializationPerson>()
-                .property_initialized_event_subscriptions,
-            0
-        );
+        assert!(context
+            .entity_store
+            .get_property_store::<InitializationPerson>()
+            .property_initialized_event_subscriptions
+            .is_empty());
     }
 
     #[test]

--- a/src/entity/events.rs
+++ b/src/entity/events.rs
@@ -1,7 +1,11 @@
 /*!
 
-`EntityCreatedEvent` and `EntityPropertyChangeEvent` types are emitted when an entity is created or an entity's
-property value is changed.
+Entity events report creation, explicitly supplied initial values, and later property changes:
+
+- [`EntityCreatedEvent`] is emitted when an entity has been created.
+- [`PropertyInitializedEvent`] is emitted for each non-default, non-derived property value
+  explicitly supplied during creation.
+- [`PropertyChangeEvent`] is emitted when a property is subsequently updated.
 
 Client code can subscribe to these events with the `Context::subscribe_to_event<IxaEvent>(handler)` method:
 
@@ -15,6 +19,13 @@ fn handle_infection_status_change(context: &mut Context, event: InfectionStatusE
 }
 // We do so by subscribing to this event.
 context.subscribe_to_event::<InfectionStatusEvent>(handle_infection_status_change);
+
+// Observe a non-default value explicitly supplied when a person is created.
+context.subscribe_to_event(
+    |_context, event: PropertyInitializedEvent<Person, InfectionStatus>| {
+        // ... use event.entity_id and event.value ...
+    },
+);
 ```
 
 
@@ -140,6 +151,22 @@ impl<E: Entity> EntityCreatedEvent<E> {
     }
 }
 
+/// Emitted for a non-default, non-derived property value supplied when an entity is created.
+#[derive(IxaEvent)]
+pub struct PropertyInitializedEvent<E: Entity, P: Property<E>> {
+    /// The newly created entity.
+    pub entity_id: EntityId<E>,
+    /// The initial property value supplied by the caller.
+    pub value: P,
+}
+
+impl<E: Entity, P: Property<E>> PropertyInitializedEvent<E, P> {
+    #[must_use]
+    pub fn new(entity_id: EntityId<E>, value: P) -> Self {
+        Self { entity_id, value }
+    }
+}
+
 /// Emitted when a property is updated.
 /// These should not be emitted outside this module.
 #[derive(IxaEvent)]
@@ -154,7 +181,7 @@ pub struct PropertyChangeEvent<E: Entity, P: Property<E>> {
 
 #[cfg(test)]
 mod tests {
-    use std::cell::RefCell;
+    use std::cell::{Cell, RefCell};
     use std::rc::Rc;
 
     use super::*;
@@ -196,6 +223,254 @@ mod tests {
     define_property!(struct IsRunner(bool), Person, default_const = IsRunner(false));
 
     define_property!(struct RunningShoes(u8), Person );
+
+    define_entity!(InitializationPerson);
+
+    define_property!(
+        struct InitConstant(u8),
+        InitializationPerson,
+        default_const = InitConstant(0)
+    );
+
+    define_property!(
+        struct InitSecond(u8),
+        InitializationPerson,
+        default_const = InitSecond(0)
+    );
+
+    define_property!(struct InitRequired(u8), InitializationPerson);
+
+    define_derived_property!(
+        struct InitDerived(u8),
+        InitializationPerson,
+        [InitConstant],
+        [],
+        |value| {
+            let value: InitConstant = value;
+            InitDerived(value.0 + 1)
+        }
+    );
+
+    #[test]
+    fn initialization_event_contains_nondefault_constant_value() {
+        let mut context = Context::new();
+        let received = Rc::new(RefCell::new(None));
+        let received_clone = received.clone();
+        context.subscribe_to_event(
+            move |context, event: PropertyInitializedEvent<InitializationPerson, InitConstant>| {
+                assert_eq!(
+                    context.get_property::<InitializationPerson, InitConstant>(event.entity_id),
+                    event.value
+                );
+                *received_clone.borrow_mut() = Some((event.entity_id, event.value));
+            },
+        );
+
+        let entity_id = context
+            .add_entity(with!(
+                InitializationPerson,
+                InitConstant(7),
+                InitRequired(11)
+            ))
+            .unwrap();
+        context.execute();
+
+        assert_eq!(*received.borrow(), Some((entity_id, InitConstant(7))));
+    }
+
+    #[test]
+    fn required_property_initialization_emits_without_default() {
+        let mut context = Context::new();
+        let received = Rc::new(RefCell::new(None));
+        let received_clone = received.clone();
+        context.subscribe_to_event(
+            move |_context, event: PropertyInitializedEvent<InitializationPerson, InitRequired>| {
+                *received_clone.borrow_mut() = Some(event.value);
+            },
+        );
+
+        context
+            .add_entity(with!(InitializationPerson, InitRequired(23)))
+            .unwrap();
+        context.execute();
+
+        assert_eq!(*received.borrow(), Some(InitRequired(23)));
+    }
+
+    #[test]
+    fn explicit_constant_default_does_not_emit_initialization_event() {
+        let mut context = Context::new();
+        context.subscribe_to_event(
+            |_context, _event: PropertyInitializedEvent<InitializationPerson, InitConstant>| {
+                panic!("the explicit default must not emit");
+            },
+        );
+
+        context
+            .add_entity(with!(
+                InitializationPerson,
+                InitConstant(0),
+                InitRequired(1)
+            ))
+            .unwrap();
+        context.execute();
+    }
+
+    #[test]
+    fn omitted_constant_default_does_not_emit_initialization_event() {
+        let mut context = Context::new();
+        context.subscribe_to_event(
+            |_context, _event: PropertyInitializedEvent<InitializationPerson, InitConstant>| {
+                panic!("an omitted property must not emit");
+            },
+        );
+
+        context
+            .add_entity(with!(InitializationPerson, InitRequired(1)))
+            .unwrap();
+        context.execute();
+    }
+
+    #[test]
+    fn derived_property_does_not_emit_initialization_event() {
+        let mut context = Context::new();
+        context.subscribe_to_event(
+            |_context, _event: PropertyInitializedEvent<InitializationPerson, InitDerived>| {
+                panic!("a dependent derived property must not emit");
+            },
+        );
+
+        context
+            .add_entity(with!(
+                InitializationPerson,
+                InitConstant(9),
+                InitRequired(1)
+            ))
+            .unwrap();
+        context.execute();
+    }
+
+    #[test]
+    fn initialization_events_are_queued_in_property_order_before_creation() {
+        let mut context = Context::new();
+        context.index_property::<InitializationPerson, InitConstant>();
+        context.index_property_counts::<InitializationPerson, InitSecond>();
+
+        let order = Rc::new(RefCell::new(Vec::new()));
+        let order_clone = order.clone();
+        context.subscribe_to_event(
+            move |context, event: PropertyInitializedEvent<InitializationPerson, InitConstant>| {
+                assert_eq!(
+                    context.query_entity_count(with!(InitializationPerson, event.value)),
+                    1
+                );
+                assert_eq!(
+                    context.query_entity_count(with!(InitializationPerson, InitSecond(4))),
+                    1
+                );
+                order_clone.borrow_mut().push("constant");
+            },
+        );
+
+        let order_clone = order.clone();
+        context.subscribe_to_event(
+            move |_context, _event: PropertyInitializedEvent<InitializationPerson, InitSecond>| {
+                order_clone.borrow_mut().push("second");
+            },
+        );
+
+        let order_clone = order.clone();
+        context.subscribe_to_event(
+            move |_context,
+                  _event: PropertyInitializedEvent<InitializationPerson, InitRequired>| {
+                order_clone.borrow_mut().push("required");
+            },
+        );
+
+        let order_clone = order.clone();
+        context.subscribe_to_event(
+            move |_context, _event: EntityCreatedEvent<InitializationPerson>| {
+                order_clone.borrow_mut().push("created");
+            },
+        );
+
+        context
+            .add_entity(with!(
+                InitializationPerson,
+                InitConstant(3),
+                InitSecond(4),
+                InitRequired(5)
+            ))
+            .unwrap();
+        assert!(order.borrow().is_empty());
+
+        context.execute();
+        assert_eq!(
+            *order.borrow(),
+            vec!["constant", "second", "required", "created"]
+        );
+    }
+
+    #[test]
+    fn initialization_event_runs_once_per_subscriber() {
+        let mut context = Context::new();
+        let count = Rc::new(Cell::new(0));
+        for _ in 0..2 {
+            let count_clone = count.clone();
+            context.subscribe_to_event(
+                move |_context,
+                      _event: PropertyInitializedEvent<InitializationPerson, InitConstant>| {
+                    count_clone.set(count_clone.get() + 1);
+                },
+            );
+        }
+
+        context
+            .add_entity(with!(
+                InitializationPerson,
+                InitConstant(2),
+                InitRequired(1)
+            ))
+            .unwrap();
+        context.execute();
+
+        assert_eq!(count.get(), 2);
+    }
+
+    #[test]
+    fn repeated_creation_emits_matching_entity_ids_and_values() {
+        let mut context = Context::new();
+        let received = Rc::new(RefCell::new(Vec::new()));
+        let received_clone = received.clone();
+        context.subscribe_to_event(
+            move |_context, event: PropertyInitializedEvent<InitializationPerson, InitConstant>| {
+                received_clone
+                    .borrow_mut()
+                    .push((event.entity_id, event.value));
+            },
+        );
+
+        let first = context
+            .add_entity(with!(
+                InitializationPerson,
+                InitConstant(5),
+                InitRequired(1)
+            ))
+            .unwrap();
+        let second = context
+            .add_entity(with!(
+                InitializationPerson,
+                InitConstant(8),
+                InitRequired(2)
+            ))
+            .unwrap();
+        context.execute();
+
+        assert_eq!(
+            *received.borrow(),
+            vec![(first, InitConstant(5)), (second, InitConstant(8))]
+        );
+    }
 
     #[test]
     fn observe_entity_addition() {

--- a/src/entity/events.rs
+++ b/src/entity/events.rs
@@ -40,7 +40,7 @@ because a non-derived p
 use smallbox::space::S4;
 use smallbox::SmallBox;
 
-use crate::entity::property::Property;
+use crate::entity::property::{Property, PropertyInitializationKind};
 use crate::entity::{ContextEntitiesExt, Entity, EntityId};
 use crate::{Context, IxaEvent};
 
@@ -152,12 +152,50 @@ impl<E: Entity> EntityCreatedEvent<E> {
 }
 
 /// Emitted for a non-default, non-derived property value supplied when an entity is created.
-#[derive(IxaEvent)]
 pub struct PropertyInitializedEvent<E: Entity, P: Property<E>> {
     /// The newly created entity.
     pub entity_id: EntityId<E>,
     /// The initial property value supplied by the caller.
     pub value: P,
+}
+
+// Implemented manually to maintain the subscription mask through the event hooks.
+impl<E: Entity, P: Property<E>> Clone for PropertyInitializedEvent<E, P> {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
+
+impl<E: Entity, P: Property<E>> Copy for PropertyInitializedEvent<E, P> {}
+
+impl<E: Entity, P: Property<E>> IxaEvent for PropertyInitializedEvent<E, P> {
+    fn on_subscribe(context: &mut Context) {
+        match P::initialization_kind() {
+            PropertyInitializationKind::Explicit | PropertyInitializationKind::Constant => {
+                context
+                    .entity_store
+                    .get_property_store_mut::<E>()
+                    .property_initialized_event_subscriptions |= 1_u32 << P::id();
+            }
+            PropertyInitializationKind::Derived => {}
+        }
+    }
+
+    fn on_unsubscribe(context: &mut Context) {
+        match P::initialization_kind() {
+            PropertyInitializationKind::Explicit | PropertyInitializationKind::Constant
+                if !context.has_event_handlers::<Self>() =>
+            {
+                context
+                    .entity_store
+                    .get_property_store_mut::<E>()
+                    .property_initialized_event_subscriptions &= !(1_u32 << P::id());
+            }
+            PropertyInitializationKind::Explicit
+            | PropertyInitializationKind::Constant
+            | PropertyInitializationKind::Derived => {}
+        }
+    }
 }
 
 impl<E: Entity, P: Property<E>> PropertyInitializedEvent<E, P> {
@@ -239,6 +277,13 @@ mod tests {
     );
 
     define_property!(struct InitRequired(u8), InitializationPerson);
+
+    define_entity!(OtherInitializationPerson);
+    crate::impl_property!(
+        InitConstant,
+        OtherInitializationPerson,
+        default_const = InitConstant(0)
+    );
 
     define_derived_property!(
         struct InitDerived(u8),
@@ -351,7 +396,7 @@ mod tests {
     }
 
     #[test]
-    fn initialization_events_are_queued_in_property_order_before_creation() {
+    fn initialization_events_are_queued_before_creation() {
         let mut context = Context::new();
         context.index_property::<InitializationPerson, InitConstant>();
         context.index_property_counts::<InitializationPerson, InitSecond>();
@@ -405,10 +450,181 @@ mod tests {
         assert!(order.borrow().is_empty());
 
         context.execute();
-        assert_eq!(
-            *order.borrow(),
-            vec!["constant", "second", "required", "created"]
+        let order = order.borrow();
+        assert_eq!(order.len(), 4);
+        assert_eq!(order[3], "created");
+        assert!(order[..3].contains(&"constant"));
+        assert!(order[..3].contains(&"second"));
+        assert!(order[..3].contains(&"required"));
+    }
+
+    #[test]
+    fn property_initialized_subscription_cache_tracks_listener_lifecycle() {
+        let mut context = Context::new();
+        let bit = 1_u32 << <InitConstant as Property<InitializationPerson>>::id();
+
+        let first = context.subscribe_to_event(
+            |_context, _event: PropertyInitializedEvent<InitializationPerson, InitConstant>| {},
         );
+        assert_eq!(
+            context
+                .entity_store
+                .get_property_store::<InitializationPerson>()
+                .property_initialized_event_subscriptions
+                & bit,
+            bit
+        );
+
+        let second = context.subscribe_to_event(
+            |_context, _event: PropertyInitializedEvent<InitializationPerson, InitConstant>| {},
+        );
+        assert!(context.unsubscribe_from_event(&first));
+        assert_eq!(
+            context
+                .entity_store
+                .get_property_store::<InitializationPerson>()
+                .property_initialized_event_subscriptions
+                & bit,
+            bit
+        );
+
+        assert!(context.unsubscribe_from_event(&second));
+        assert_eq!(
+            context
+                .entity_store
+                .get_property_store::<InitializationPerson>()
+                .property_initialized_event_subscriptions
+                & bit,
+            0
+        );
+    }
+
+    #[test]
+    fn property_initialized_subscription_cache_ignores_failed_unsubscription() {
+        let mut context = Context::new();
+        let listener = context.subscribe_to_event(
+            |_context, _event: PropertyInitializedEvent<InitializationPerson, InitConstant>| {},
+        );
+        let bit = 1_u32 << <InitConstant as Property<InitializationPerson>>::id();
+
+        assert!(context.unsubscribe_from_event(&listener));
+        assert!(!context.unsubscribe_from_event(&listener));
+        assert_eq!(
+            context
+                .entity_store
+                .get_property_store::<InitializationPerson>()
+                .property_initialized_event_subscriptions
+                & bit,
+            0
+        );
+    }
+
+    #[test]
+    fn property_initialized_subscription_cache_ignores_derived_property() {
+        let mut context = Context::new();
+        context.subscribe_to_event(
+            |_context, _event: PropertyInitializedEvent<InitializationPerson, InitDerived>| {},
+        );
+
+        assert_eq!(
+            context
+                .entity_store
+                .get_property_store::<InitializationPerson>()
+                .property_initialized_event_subscriptions,
+            0
+        );
+    }
+
+    #[test]
+    fn property_initialized_subscription_cache_tracks_distinct_properties() {
+        let mut context = Context::new();
+        context.subscribe_to_event(
+            |_context, _event: PropertyInitializedEvent<InitializationPerson, InitConstant>| {},
+        );
+        context.subscribe_to_event(
+            |_context, _event: PropertyInitializedEvent<InitializationPerson, InitRequired>| {},
+        );
+
+        let expected = (1_u32 << <InitConstant as Property<InitializationPerson>>::id())
+            | (1_u32 << InitRequired::id());
+        assert_eq!(
+            context
+                .entity_store
+                .get_property_store::<InitializationPerson>()
+                .property_initialized_event_subscriptions,
+            expected
+        );
+    }
+
+    #[test]
+    fn property_initialized_subscription_cache_is_scoped_to_entity_type() {
+        let mut context = Context::new();
+        context.subscribe_to_event(
+            |_context, _event: PropertyInitializedEvent<InitializationPerson, InitConstant>| {},
+        );
+
+        assert_ne!(
+            context
+                .entity_store
+                .get_property_store::<InitializationPerson>()
+                .property_initialized_event_subscriptions,
+            0
+        );
+        assert_eq!(
+            context
+                .entity_store
+                .get_property_store::<OtherInitializationPerson>()
+                .property_initialized_event_subscriptions,
+            0
+        );
+    }
+
+    #[test]
+    fn property_initialized_subscription_cache_ignores_unrelated_event() {
+        let mut context = Context::new();
+        context.subscribe_to_event(|_context, _event: EntityCreatedEvent<InitializationPerson>| {});
+
+        assert_eq!(
+            context
+                .entity_store
+                .get_property_store::<InitializationPerson>()
+                .property_initialized_event_subscriptions,
+            0
+        );
+    }
+
+    #[test]
+    fn property_initialized_subscription_cache_controls_delivery() {
+        let mut context = Context::new();
+        let count = Rc::new(Cell::new(0));
+        let count_clone = count.clone();
+        let listener = context.subscribe_to_event(
+            move |_context,
+                  _event: PropertyInitializedEvent<InitializationPerson, InitRequired>| {
+                count_clone.set(count_clone.get() + 1);
+            },
+        );
+
+        context
+            .add_entity(with!(
+                InitializationPerson,
+                InitConstant(1),
+                InitRequired(1)
+            ))
+            .unwrap();
+        context.execute();
+        assert_eq!(count.get(), 1);
+
+        assert!(context.unsubscribe_from_event(&listener));
+        context
+            .add_entity(with!(
+                InitializationPerson,
+                InitConstant(2),
+                InitRequired(2)
+            ))
+            .unwrap();
+        context.execute();
+        assert_eq!(count.get(), 1);
     }
 
     #[test]

--- a/src/entity/events.rs
+++ b/src/entity/events.rs
@@ -138,10 +138,30 @@ impl<E: Entity, P: Property<E>> PartialPropertyChangeEventCore<E, P> {
 
 /// Emitted when a new entity is created.
 /// These should not be emitted outside this module.
-#[derive(IxaEvent)]
 pub struct EntityCreatedEvent<E: Entity> {
     /// The [`EntityId<E>`] of the new entity.
     pub entity_id: EntityId<E>,
+}
+
+// Implemented manually to maintain the subscription flag through the event hooks.
+impl<E: Entity> Clone for EntityCreatedEvent<E> {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
+
+impl<E: Entity> Copy for EntityCreatedEvent<E> {}
+
+impl<E: Entity> IxaEvent for EntityCreatedEvent<E> {
+    fn on_subscribe(context: &mut Context) {
+        context.entity_store.items[E::id()].entity_created_event_subscribed = true;
+    }
+
+    fn on_unsubscribe(context: &mut Context) {
+        if !context.has_event_handlers::<Self>() {
+            context.entity_store.items[E::id()].entity_created_event_subscribed = false;
+        }
+    }
 }
 
 impl<E: Entity> EntityCreatedEvent<E> {
@@ -625,6 +645,145 @@ mod tests {
             .unwrap();
         context.execute();
         assert_eq!(count.get(), 1);
+    }
+
+    #[test]
+    fn entity_created_subscription_cache_tracks_listener_lifecycle() {
+        let mut context = Context::new();
+        assert!(
+            !context
+                .entity_store
+                .new_entity_id::<InitializationPerson>()
+                .1
+        );
+
+        let first = context
+            .subscribe_to_event(|_context, _event: EntityCreatedEvent<InitializationPerson>| {});
+        assert!(
+            context
+                .entity_store
+                .new_entity_id::<InitializationPerson>()
+                .1
+        );
+
+        let second = context
+            .subscribe_to_event(|_context, _event: EntityCreatedEvent<InitializationPerson>| {});
+        assert!(context.unsubscribe_from_event(&first));
+        assert!(
+            context
+                .entity_store
+                .new_entity_id::<InitializationPerson>()
+                .1
+        );
+
+        assert!(context.unsubscribe_from_event(&second));
+        assert!(
+            !context
+                .entity_store
+                .new_entity_id::<InitializationPerson>()
+                .1
+        );
+    }
+
+    #[test]
+    fn entity_created_subscription_cache_ignores_failed_unsubscription() {
+        let mut context = Context::new();
+        let listener = context
+            .subscribe_to_event(|_context, _event: EntityCreatedEvent<InitializationPerson>| {});
+
+        assert!(context.unsubscribe_from_event(&listener));
+        assert!(!context.unsubscribe_from_event(&listener));
+        assert!(
+            !context
+                .entity_store
+                .new_entity_id::<InitializationPerson>()
+                .1
+        );
+    }
+
+    #[test]
+    fn entity_created_subscription_cache_is_scoped_to_entity_type() {
+        let mut context = Context::new();
+        context.subscribe_to_event(|_context, _event: EntityCreatedEvent<InitializationPerson>| {});
+
+        assert!(
+            context
+                .entity_store
+                .new_entity_id::<InitializationPerson>()
+                .1
+        );
+        assert!(
+            !context
+                .entity_store
+                .new_entity_id::<OtherInitializationPerson>()
+                .1
+        );
+    }
+
+    #[test]
+    fn entity_created_subscription_cache_ignores_unrelated_event() {
+        let mut context = Context::new();
+        context.subscribe_to_event(
+            |_context, _event: PropertyInitializedEvent<InitializationPerson, InitConstant>| {},
+        );
+
+        assert!(
+            !context
+                .entity_store
+                .new_entity_id::<InitializationPerson>()
+                .1
+        );
+    }
+
+    #[test]
+    fn entity_created_subscription_cache_controls_delivery() {
+        let mut context = Context::new();
+        let count = Rc::new(Cell::new(0));
+        let count_clone = count.clone();
+        let listener = context.subscribe_to_event(
+            move |_context, _event: EntityCreatedEvent<InitializationPerson>| {
+                count_clone.set(count_clone.get() + 1);
+            },
+        );
+
+        context
+            .add_entity(with!(InitializationPerson, InitRequired(1)))
+            .unwrap();
+        context.execute();
+        assert_eq!(count.get(), 1);
+
+        assert!(context.unsubscribe_from_event(&listener));
+        context
+            .add_entity(with!(InitializationPerson, InitRequired(2)))
+            .unwrap();
+        context.execute();
+        assert_eq!(count.get(), 1);
+    }
+
+    #[test]
+    fn entity_created_subscription_cache_preserves_listener_order() {
+        let mut context = Context::new();
+        let order = Rc::new(RefCell::new(Vec::new()));
+
+        let order_clone = order.clone();
+        context.subscribe_to_event(
+            move |_context, _event: EntityCreatedEvent<InitializationPerson>| {
+                order_clone.borrow_mut().push(1);
+            },
+        );
+        let order_clone = order.clone();
+        context.subscribe_to_event(
+            move |_context, _event: EntityCreatedEvent<InitializationPerson>| {
+                order_clone.borrow_mut().push(2);
+            },
+        );
+
+        context
+            .add_entity(with!(InitializationPerson, InitRequired(1)))
+            .unwrap();
+        context.execute();
+
+        assert_eq!(*order.borrow(), vec![1, 2]);
     }
 
     #[test]

--- a/src/entity/property_list.rs
+++ b/src/entity/property_list.rs
@@ -27,6 +27,7 @@ use super::entity::{Entity, EntityId};
 use super::events::PropertyInitializedEvent;
 use super::property::{Property, PropertyInitializationKind};
 use super::property_store::PropertyStore;
+use crate::data_structures::bit_set::BitSet;
 use crate::entity::ContextEntitiesExt;
 use crate::{Context, IxaError};
 
@@ -58,7 +59,7 @@ pub trait PropertyList<E: Entity>: Copy + 'static {
         &self,
         context: &mut Context,
         entity_id: EntityId<E>,
-        subscription_mask: u32,
+        subscriptions: &BitSet,
     );
 
     /// Gets the tuple of property values for the given entity.
@@ -89,7 +90,7 @@ impl<E: Entity> PropertyList<E> for () {
         &self,
         _context: &mut Context,
         _entity_id: EntityId<E>,
-        _subscription_mask: u32,
+        _subscriptions: &BitSet,
     ) {
     }
 
@@ -117,7 +118,7 @@ impl<E: Entity + Copy> PropertyList<E> for E {
         &self,
         _context: &mut Context,
         _entity_id: EntityId<E>,
-        _subscription_mask: u32,
+        _subscriptions: &BitSet,
     ) {
     }
 
@@ -186,9 +187,9 @@ impl<E: Entity, P: Property<E>> PropertyList<E> for (P,) {
         &self,
         context: &mut Context,
         entity_id: EntityId<E>,
-        subscription_mask: u32,
+        subscriptions: &BitSet,
     ) {
-        if subscription_mask & (1_u32 << P::id()) != 0 {
+        if subscriptions.get(P::id()) {
             emit_initialized_event(context, entity_id, self.0);
         }
     }
@@ -238,10 +239,10 @@ macro_rules! impl_property_list {
                     &self,
                     context: &mut Context,
                     entity_id: EntityId<E>,
-                    subscription_mask: u32,
+                    subscriptions: &BitSet,
                 ) {
                     #(
-                        if subscription_mask & (1_u32 << P~N::id()) != 0 {
+                        if subscriptions.get(P~N::id()) {
                             emit_initialized_event(context, entity_id, self.N);
                         }
                     )*

--- a/src/entity/property_list.rs
+++ b/src/entity/property_list.rs
@@ -54,7 +54,12 @@ pub trait PropertyList<E: Entity>: Copy + 'static {
 
     /// Emits initialization events for the explicitly supplied property values.
     #[doc(hidden)]
-    fn emit_initialized_events(&self, context: &mut Context, entity_id: EntityId<E>);
+    fn emit_initialized_events(
+        &self,
+        context: &mut Context,
+        entity_id: EntityId<E>,
+        subscription_mask: u32,
+    );
 
     /// Gets the tuple of property values for the given entity.
     #[must_use]
@@ -80,7 +85,13 @@ impl<E: Entity> PropertyList<E> for () {
         // No values to assign.
     }
 
-    fn emit_initialized_events(&self, _context: &mut Context, _entity_id: EntityId<E>) {}
+    fn emit_initialized_events(
+        &self,
+        _context: &mut Context,
+        _entity_id: EntityId<E>,
+        _subscription_mask: u32,
+    ) {
+    }
 
     fn get_values_for_entity(_context: &Context, _entity_id: EntityId<E>) -> Self {}
 }
@@ -102,7 +113,13 @@ impl<E: Entity + Copy> PropertyList<E> for E {
         // No values to assign.
     }
 
-    fn emit_initialized_events(&self, _context: &mut Context, _entity_id: EntityId<E>) {}
+    fn emit_initialized_events(
+        &self,
+        _context: &mut Context,
+        _entity_id: EntityId<E>,
+        _subscription_mask: u32,
+    ) {
+    }
 
     fn get_values_for_entity(_context: &Context, _entity_id: EntityId<E>) -> E {
         E::default()
@@ -165,8 +182,15 @@ impl<E: Entity, P: Property<E>> PropertyList<E> for (P,) {
         property_value_store.set(entity_id, self.0);
     }
 
-    fn emit_initialized_events(&self, context: &mut Context, entity_id: EntityId<E>) {
-        emit_initialized_event(context, entity_id, self.0);
+    fn emit_initialized_events(
+        &self,
+        context: &mut Context,
+        entity_id: EntityId<E>,
+        subscription_mask: u32,
+    ) {
+        if subscription_mask & (1_u32 << P::id()) != 0 {
+            emit_initialized_event(context, entity_id, self.0);
+        }
     }
 
     fn get_values_for_entity(context: &Context, entity_id: EntityId<E>) -> Self {
@@ -210,8 +234,17 @@ macro_rules! impl_property_list {
                     })*
                 }
 
-                fn emit_initialized_events(&self, context: &mut Context, entity_id: EntityId<E>) {
-                    #(emit_initialized_event(context, entity_id, self.N);)*
+                fn emit_initialized_events(
+                    &self,
+                    context: &mut Context,
+                    entity_id: EntityId<E>,
+                    subscription_mask: u32,
+                ) {
+                    #(
+                        if subscription_mask & (1_u32 << P~N::id()) != 0 {
+                            emit_initialized_event(context, entity_id, self.N);
+                        }
+                    )*
                 }
 
                 fn get_values_for_entity(context: &Context, entity_id: EntityId<E>) -> Self {

--- a/src/entity/property_list.rs
+++ b/src/entity/property_list.rs
@@ -24,7 +24,8 @@ use std::any::TypeId;
 use seq_macro::seq;
 
 use super::entity::{Entity, EntityId};
-use super::property::Property;
+use super::events::PropertyInitializedEvent;
+use super::property::{Property, PropertyInitializationKind};
 use super::property_store::PropertyStore;
 use crate::entity::ContextEntitiesExt;
 use crate::{Context, IxaError};
@@ -51,6 +52,10 @@ pub trait PropertyList<E: Entity>: Copy + 'static {
         property_store: &mut PropertyStore<E>,
     );
 
+    /// Emits initialization events for the explicitly supplied property values.
+    #[doc(hidden)]
+    fn emit_initialized_events(&self, context: &mut Context, entity_id: EntityId<E>);
+
     /// Gets the tuple of property values for the given entity.
     #[must_use]
     fn get_values_for_entity(context: &Context, entity_id: EntityId<E>) -> Self;
@@ -75,6 +80,8 @@ impl<E: Entity> PropertyList<E> for () {
         // No values to assign.
     }
 
+    fn emit_initialized_events(&self, _context: &mut Context, _entity_id: EntityId<E>) {}
+
     fn get_values_for_entity(_context: &Context, _entity_id: EntityId<E>) -> Self {}
 }
 
@@ -95,12 +102,31 @@ impl<E: Entity + Copy> PropertyList<E> for E {
         // No values to assign.
     }
 
+    fn emit_initialized_events(&self, _context: &mut Context, _entity_id: EntityId<E>) {}
+
     fn get_values_for_entity(_context: &Context, _entity_id: EntityId<E>) -> E {
         E::default()
     }
 }
 
 impl<E: Entity + Copy> PropertyInitializationList<E> for E {}
+
+fn emit_initialized_event<E, P>(context: &mut Context, entity_id: EntityId<E>, value: P)
+where
+    E: Entity,
+    P: Property<E>,
+{
+    match P::initialization_kind() {
+        PropertyInitializationKind::Derived => {}
+        PropertyInitializationKind::Explicit => {
+            context.emit_event(PropertyInitializedEvent::new(entity_id, value));
+        }
+        PropertyInitializationKind::Constant if value != P::default_const() => {
+            context.emit_event(PropertyInitializedEvent::new(entity_id, value));
+        }
+        PropertyInitializationKind::Constant => {}
+    }
+}
 
 // ToDo(RobertJacobsonCDC): The following is a fundamental limitation in Rust. If downstream code *can* implement a
 //     trait impl that will cause conflicting implementations with some blanket impl, it disallows it, regardless of
@@ -137,6 +163,10 @@ impl<E: Entity, P: Property<E>> PropertyList<E> for (P,) {
     ) {
         let property_value_store = property_store.get_mut::<P>();
         property_value_store.set(entity_id, self.0);
+    }
+
+    fn emit_initialized_events(&self, context: &mut Context, entity_id: EntityId<E>) {
+        emit_initialized_event(context, entity_id, self.0);
     }
 
     fn get_values_for_entity(context: &Context, entity_id: EntityId<E>) -> Self {
@@ -178,6 +208,10 @@ macro_rules! impl_property_list {
                         let property_value_store = property_store.get_mut::<P~N>();
                         property_value_store.set(entity_id, self.N);
                     })*
+                }
+
+                fn emit_initialized_events(&self, context: &mut Context, entity_id: EntityId<E>) {
+                    #(emit_initialized_event(context, entity_id, self.N);)*
                 }
 
                 fn get_values_for_entity(context: &Context, entity_id: EntityId<E>) -> Self {

--- a/src/entity/property_store.rs
+++ b/src/entity/property_store.rs
@@ -75,6 +75,11 @@ where
 static NEXT_PROPERTY_ID: LazyLock<Mutex<HashMap<usize, usize>>> =
     LazyLock::new(|| Mutex::new(HashMap::default()));
 
+/// This hard cap exists only to allow us to cache the existence of subscribers to property
+/// initialized events in `PropertyStore`. We can always increase this to 64 or 128 if there is a
+/// use case, or we can find an alternative implementation that removes the cap.
+const MAX_PROPERTIES_PER_ENTITY: usize = u32::BITS as usize;
+
 /// A container struct to hold the (global) metadata for a single property.
 ///
 /// At program startup (before `main()`, using ctors) we compute metadata for all properties
@@ -203,6 +208,18 @@ pub fn initialize_property_id<E: Entity>(property_id: &AtomicUsize) -> usize {
     let mut guard = NEXT_PROPERTY_ID.lock().unwrap();
     let candidate = guard.entry(E::id()).or_insert_with(|| 0);
 
+    // The property may have been initialized while this call waited for the lock.
+    let existing = property_id.load(Ordering::Acquire);
+    if existing != usize::MAX {
+        return existing;
+    }
+
+    assert!(
+        *candidate < MAX_PROPERTIES_PER_ENTITY,
+        "Cannot register more than {MAX_PROPERTIES_PER_ENTITY} properties for entity `{}`",
+        E::name(),
+    );
+
     // Try to claim the candidate index. Here we guard against the potential race condition that
     // another instance of this plugin in another thread just initialized the index prior to us
     // obtaining the lock. If the index has been initialized beneath us, we do not update
@@ -228,6 +245,13 @@ pub fn initialize_property_id<E: Entity>(property_id: &AtomicUsize) -> usize {
 pub struct PropertyStore<E: Entity> {
     /// A vector of `Box<PropertyValueStoreCore<E, P>>`, type-erased to `Box<dyn PropertyValueStore<E>>`
     items: Vec<Box<dyn PropertyValueStore<E>>>,
+
+    /// Bitmask of properties that currently have `PropertyInitializedEvent` subscribers.
+    ///
+    /// `PropertyList::emit_initialized_events` reads this in the hot path to skip
+    /// per-property initialization-event work unless a handler is registered as a performance
+    /// optimization.
+    pub(in crate::entity) property_initialized_event_subscriptions: u32,
 
     /// One entry for every property whose `PropertyValueStoreCore` currently has an index.
     /// The property ID supports removal without relying on deduplicable function addresses.
@@ -269,6 +293,7 @@ impl<E: Entity> PropertyStore<E> {
 
         Self {
             items,
+            property_initialized_event_subscriptions: 0,
             index_new_entity_fns: Vec::new(),
         }
     }

--- a/src/entity/property_store.rs
+++ b/src/entity/property_store.rs
@@ -33,6 +33,7 @@ use std::collections::HashMap;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::{LazyLock, Mutex, OnceLock};
 
+use crate::data_structures::bit_set::BitSet;
 use crate::entity::entity::Entity;
 use crate::entity::entity_store::register_property_with_entity;
 use crate::entity::events::PartialPropertyChangeEventBox;
@@ -74,11 +75,6 @@ where
 /// dependency of some other property.
 static NEXT_PROPERTY_ID: LazyLock<Mutex<HashMap<usize, usize>>> =
     LazyLock::new(|| Mutex::new(HashMap::default()));
-
-/// This hard cap exists only to allow us to cache the existence of subscribers to property
-/// initialized events in `PropertyStore`. We can always increase this to 64 or 128 if there is a
-/// use case, or we can find an alternative implementation that removes the cap.
-const MAX_PROPERTIES_PER_ENTITY: usize = u32::BITS as usize;
 
 /// A container struct to hold the (global) metadata for a single property.
 ///
@@ -214,12 +210,6 @@ pub fn initialize_property_id<E: Entity>(property_id: &AtomicUsize) -> usize {
         return existing;
     }
 
-    assert!(
-        *candidate < MAX_PROPERTIES_PER_ENTITY,
-        "Cannot register more than {MAX_PROPERTIES_PER_ENTITY} properties for entity `{}`",
-        E::name(),
-    );
-
     // Try to claim the candidate index. Here we guard against the potential race condition that
     // another instance of this plugin in another thread just initialized the index prior to us
     // obtaining the lock. If the index has been initialized beneath us, we do not update
@@ -246,12 +236,12 @@ pub struct PropertyStore<E: Entity> {
     /// A vector of `Box<PropertyValueStoreCore<E, P>>`, type-erased to `Box<dyn PropertyValueStore<E>>`
     items: Vec<Box<dyn PropertyValueStore<E>>>,
 
-    /// Bitmask of properties that currently have `PropertyInitializedEvent` subscribers.
+    /// Set of properties that currently have `PropertyInitializedEvent` subscribers.
     ///
     /// `PropertyList::emit_initialized_events` reads this in the hot path to skip
     /// per-property initialization-event work unless a handler is registered as a performance
     /// optimization.
-    pub(in crate::entity) property_initialized_event_subscriptions: u32,
+    pub(in crate::entity) property_initialized_event_subscriptions: BitSet,
 
     /// One entry for every property whose `PropertyValueStoreCore` currently has an index.
     /// The property ID supports removal without relying on deduplicable function addresses.
@@ -293,7 +283,7 @@ impl<E: Entity> PropertyStore<E> {
 
         Self {
             items,
-            property_initialized_event_subscriptions: 0,
+            property_initialized_event_subscriptions: BitSet::new(num_items),
             index_new_entity_fns: Vec::new(),
         }
     }

--- a/src/entity/query/mod.rs
+++ b/src/entity/query/mod.rs
@@ -128,8 +128,14 @@ impl<E: Entity, T: PropertyList<E>> PropertyList<E> for EntityPropertyTuple<E, T
             .set_values_for_new_entity(entity_id, property_store)
     }
 
-    fn emit_initialized_events(&self, context: &mut Context, entity_id: EntityId<E>) {
-        self.inner.emit_initialized_events(context, entity_id);
+    fn emit_initialized_events(
+        &self,
+        context: &mut Context,
+        entity_id: EntityId<E>,
+        subscription_mask: u32,
+    ) {
+        self.inner
+            .emit_initialized_events(context, entity_id, subscription_mask);
     }
 
     fn get_values_for_entity(context: &Context, entity_id: EntityId<E>) -> Self {

--- a/src/entity/query/mod.rs
+++ b/src/entity/query/mod.rs
@@ -4,6 +4,7 @@ use std::any::TypeId;
 use std::marker::PhantomData;
 use std::sync::{Mutex, OnceLock};
 
+use crate::data_structures::bit_set::BitSet;
 use crate::entity::entity_set::{EntitySet, EntitySetIterator};
 use crate::entity::multi_property::type_ids_to_multi_property_id;
 use crate::entity::property_list::{PropertyInitializationList, PropertyList};
@@ -132,10 +133,10 @@ impl<E: Entity, T: PropertyList<E>> PropertyList<E> for EntityPropertyTuple<E, T
         &self,
         context: &mut Context,
         entity_id: EntityId<E>,
-        subscription_mask: u32,
+        subscriptions: &BitSet,
     ) {
         self.inner
-            .emit_initialized_events(context, entity_id, subscription_mask);
+            .emit_initialized_events(context, entity_id, subscriptions);
     }
 
     fn get_values_for_entity(context: &Context, entity_id: EntityId<E>) -> Self {

--- a/src/entity/query/mod.rs
+++ b/src/entity/query/mod.rs
@@ -128,6 +128,10 @@ impl<E: Entity, T: PropertyList<E>> PropertyList<E> for EntityPropertyTuple<E, T
             .set_values_for_new_entity(entity_id, property_store)
     }
 
+    fn emit_initialized_events(&self, context: &mut Context, entity_id: EntityId<E>) {
+        self.inner.emit_initialized_events(context, entity_id);
+    }
+
     fn get_values_for_entity(context: &Context, entity_id: EntityId<E>) -> Self {
         EntityPropertyTuple::new(T::get_values_for_entity(context, entity_id))
     }

--- a/src/macros/property_impl.rs
+++ b/src/macros/property_impl.rs
@@ -8,9 +8,6 @@ For the most common cases, use the [`define_property!`][macro@crate::define_prop
 with the standard derives required by the [`Property`][crate::entity::property::Property] trait and implements [`Property`][crate::entity::property::Property] (via
 [`impl_property!`][macro@crate::impl_property]) for you.
 
-An entity may have at most 32 registered properties, including explicit, constant, derived, and
-multi-properties. If there is a use-case for more properties, we can increase this cap.
-
 ```rust,ignore
 define_property!(struct Age(u8), Person);
 define_property!(struct Location(City, State), Person);
@@ -197,8 +194,6 @@ impl_property!(
 /// ### Notes
 ///
 /// - By default, the generated type derives `Debug`, `PartialEq`, `Eq`, `Hash`, `Clone`, and `Copy`.
-/// - An entity may have at most 32 registered properties, including explicit, constant, derived,
-///   and multi-properties.
 /// - Use the optional `default_const = <default_value>` argument to define a compile-time constant
 ///   default for the property.
 /// - Use `impl_eq_hash = Eq`, `Hash`, `both`, or `neither` as the first optional argument to suppress the default

--- a/src/macros/property_impl.rs
+++ b/src/macros/property_impl.rs
@@ -8,6 +8,9 @@ For the most common cases, use the [`define_property!`][macro@crate::define_prop
 with the standard derives required by the [`Property`][crate::entity::property::Property] trait and implements [`Property`][crate::entity::property::Property] (via
 [`impl_property!`][macro@crate::impl_property]) for you.
 
+An entity may have at most 32 registered properties, including explicit, constant, derived, and
+multi-properties. If there is a use-case for more properties, we can increase this cap.
+
 ```rust,ignore
 define_property!(struct Age(u8), Person);
 define_property!(struct Location(City, State), Person);
@@ -194,6 +197,8 @@ impl_property!(
 /// ### Notes
 ///
 /// - By default, the generated type derives `Debug`, `PartialEq`, `Eq`, `Hash`, `Clone`, and `Copy`.
+/// - An entity may have at most 32 registered properties, including explicit, constant, derived,
+///   and multi-properties.
 /// - Use the optional `default_const = <default_value>` argument to define a compile-time constant
 ///   default for the property.
 /// - Use `impl_eq_hash = Eq`, `Hash`, `both`, or `neither` as the first optional argument to suppress the default

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -1,5 +1,7 @@
 pub use crate::context::{Context, EventListenerId};
-pub use crate::entity::events::{EntityCreatedEvent, PropertyChangeEvent};
+pub use crate::entity::events::{
+    EntityCreatedEvent, PropertyChangeEvent, PropertyInitializedEvent,
+};
 pub use crate::entity::property::{IndexableProperty, Property};
 pub use crate::entity::{ContextEntitiesExt, Entity, EntityId};
 pub use crate::error::IxaError;


### PR DESCRIPTION
Implements `PropertyInitializedEvent<E, P>` (#1000). 

To make the implementation zero cost, we cache the fact that a property has `PropertyInitializedEvent` subscribers in a bit mask owned by `PropertyStore<E>`. This puts a hard cap on the number of properties an entity can have of 32. If we ever encounter a use case for more than 32 properties, we can increase this cap to 64 or 128, or we can find an alternative that eliminates the cap—but I figure we can cross that road if and when we come to it. (See also #1023.)

While I was at it, I also added a flag to cache the fact that there exist `EntityCreatedEvent` subscribers, which speeds up `add_entity` by a handful of percentage points. It's not huge, but the implementation is also pretty simple, so I figure it pays for itself.