### PR TITLE
fix: `PropertyValueCountTrigger` now observes `PropertyInitializedEvent`

### DIFF
--- a/src/entity/context_extension.rs
+++ b/src/entity/context_extension.rs
@@ -340,6 +340,8 @@ impl ContextEntitiesExt for Context {
             dispatch(self, new_entity_id);
         }
 
+        property_list.emit_initialized_events(self, new_entity_id);
+
         // Emit an `EntityCreatedEvent<Entity>`.
         self.emit_event(EntityCreatedEvent::<E>::new(new_entity_id));
 

--- a/src/entity/context_extension.rs
+++ b/src/entity/context_extension.rs
@@ -322,11 +322,16 @@ impl ContextEntitiesExt for Context {
 
         // All explicit values are now available, so derived and multi-property dispatchers see
         // the entity's complete initialized state.
-        let index_count = self
-            .entity_store
-            .get_property_store::<E>()
-            .index_new_entity_fns
-            .len();
+
+        // We simultaneously fetch the index count and bit mask of property initialized event
+        // subscriptions from the entity store without retaining a borrow of the store.
+        let (index_count, property_initialized_event_subscriptions) = {
+            let property_store = self.entity_store.get_property_store::<E>();
+            (
+                property_store.index_new_entity_fns.len(),
+                property_store.property_initialized_event_subscriptions,
+            )
+        };
 
         for index in 0..index_count {
             let dispatch = self
@@ -340,7 +345,13 @@ impl ContextEntitiesExt for Context {
             dispatch(self, new_entity_id);
         }
 
-        property_list.emit_initialized_events(self, new_entity_id);
+        if property_initialized_event_subscriptions != 0 {
+            property_list.emit_initialized_events(
+                self,
+                new_entity_id,
+                property_initialized_event_subscriptions,
+            );
+        }
 
         // Emit an `EntityCreatedEvent<Entity>`.
         self.emit_event(EntityCreatedEvent::<E>::new(new_entity_id));

--- a/src/entity/context_extension.rs
+++ b/src/entity/context_extension.rs
@@ -311,7 +311,8 @@ impl ContextEntitiesExt for Context {
         }
 
         // Now that we know we will succeed, we create the entity.
-        let new_entity_id = self.entity_store.new_entity_id::<E>();
+        let (new_entity_id, entity_created_event_subscribed) =
+            self.entity_store.new_entity_id::<E>();
 
         // Assign the properties in the list to the new entity.
         // This does not generate a property change event.
@@ -353,8 +354,9 @@ impl ContextEntitiesExt for Context {
             );
         }
 
-        // Emit an `EntityCreatedEvent<Entity>`.
-        self.emit_event(EntityCreatedEvent::<E>::new(new_entity_id));
+        if entity_created_event_subscribed {
+            self.emit_event(EntityCreatedEvent::<E>::new(new_entity_id));
+        }
 
         Ok(new_entity_id)
     }

--- a/src/entity/entity_store.rs
+++ b/src/entity/entity_store.rs
@@ -153,6 +153,9 @@ pub fn initialize_entity_index(plugin_index: &AtomicUsize) -> usize {
 pub struct EntityRecord {
     /// The total count of all entities of this type (i.e., the next index to assign).
     pub(crate) entity_count: usize,
+    /// Whether `EntityCreatedEvent` has any subscribers for this entity type. This is a performance
+    /// optimization for `add_entity`.
+    pub(in crate::entity) entity_created_event_subscribed: bool,
     /// Lazily initialized `Entity` instance.
     pub(crate) entity: OnceCell<Box<dyn Any>>,
     /// A type-erased `Box<PropertyStore<E>>`, lazily initialized.
@@ -163,6 +166,7 @@ impl EntityRecord {
     pub(crate) fn new() -> Self {
         Self {
             entity_count: 0,
+            entity_created_event_subscribed: false,
             entity: OnceCell::new(),
             property_store: OnceCell::new(),
         }
@@ -171,7 +175,7 @@ impl EntityRecord {
 
 /// A wrapper around a vector of entities.
 pub struct EntityStore {
-    items: Vec<EntityRecord>,
+    pub(in crate::entity) items: Vec<EntityRecord>,
 }
 
 impl Default for EntityStore {
@@ -236,13 +240,14 @@ impl EntityStore {
     }
 
     /// Creates a new `EntityId` for the given `Entity` type `E`.
-    /// Increments the entity counter and returns the next valid ID.
-    pub(crate) fn new_entity_id<E: Entity>(&mut self) -> EntityId<E> {
+    /// Increments the entity counter and returns the next valid ID together with whether
+    /// `EntityCreatedEvent<E>` has subscribers.
+    pub(crate) fn new_entity_id<E: Entity>(&mut self) -> (EntityId<E>, bool) {
         let index = E::id();
         let record = &mut self.items[index];
         let id = record.entity_count;
         record.entity_count += 1;
-        EntityId::new(id)
+        (EntityId::new(id), record.entity_created_event_subscribed)
     }
 
     /// Returns a total count of all created entities of type `E`.

--- a/src/entity/events.rs
+++ b/src/entity/events.rs
@@ -1,7 +1,11 @@
 /*!
 
-`EntityCreatedEvent` and `EntityPropertyChangeEvent` types are emitted when an entity is created or an entity's
-property value is changed.
+Entity events report creation, explicitly supplied initial values, and later property changes:
+
+- [`EntityCreatedEvent`] is emitted when an entity has been created.
+- [`PropertyInitializedEvent`] is emitted for each non-default, non-derived property value
+  explicitly supplied during creation.
+- [`PropertyChangeEvent`] is emitted when a property is subsequently updated.
 
 Client code can subscribe to these events with the `Context::subscribe_to_event<IxaEvent>(handler)` method:
 
@@ -15,6 +19,13 @@ fn handle_infection_status_change(context: &mut Context, event: InfectionStatusE
 }
 // We do so by subscribing to this event.
 context.subscribe_to_event::<InfectionStatusEvent>(handle_infection_status_change);
+
+// Observe a non-default value explicitly supplied when a person is created.
+context.subscribe_to_event(
+    |_context, event: PropertyInitializedEvent<Person, InfectionStatus>| {
+        // ... use event.entity_id and event.value ...
+    },
+);
 ```
 
 
@@ -140,6 +151,22 @@ impl<E: Entity> EntityCreatedEvent<E> {
     }
 }
 
+/// Emitted for a non-default, non-derived property value supplied when an entity is created.
+#[derive(IxaEvent)]
+pub struct PropertyInitializedEvent<E: Entity, P: Property<E>> {
+    /// The newly created entity.
+    pub entity_id: EntityId<E>,
+    /// The initial property value supplied by the caller.
+    pub value: P,
+}
+
+impl<E: Entity, P: Property<E>> PropertyInitializedEvent<E, P> {
+    #[must_use]
+    pub fn new(entity_id: EntityId<E>, value: P) -> Self {
+        Self { entity_id, value }
+    }
+}
+
 /// Emitted when a property is updated.
 /// These should not be emitted outside this module.
 #[derive(IxaEvent)]
@@ -154,7 +181,7 @@ pub struct PropertyChangeEvent<E: Entity, P: Property<E>> {
 
 #[cfg(test)]
 mod tests {
-    use std::cell::RefCell;
+    use std::cell::{Cell, RefCell};
     use std::rc::Rc;
 
     use super::*;
@@ -196,6 +223,254 @@ mod tests {
     define_property!(struct IsRunner(bool), Person, default_const = IsRunner(false));
 
     define_property!(struct RunningShoes(u8), Person );
+
+    define_entity!(InitializationPerson);
+
+    define_property!(
+        struct InitConstant(u8),
+        InitializationPerson,
+        default_const = InitConstant(0)
+    );
+
+    define_property!(
+        struct InitSecond(u8),
+        InitializationPerson,
+        default_const = InitSecond(0)
+    );
+
+    define_property!(struct InitRequired(u8), InitializationPerson);
+
+    define_derived_property!(
+        struct InitDerived(u8),
+        InitializationPerson,
+        [InitConstant],
+        [],
+        |value| {
+            let value: InitConstant = value;
+            InitDerived(value.0 + 1)
+        }
+    );
+
+    #[test]
+    fn initialization_event_contains_nondefault_constant_value() {
+        let mut context = Context::new();
+        let received = Rc::new(RefCell::new(None));
+        let received_clone = received.clone();
+        context.subscribe_to_event(
+            move |context, event: PropertyInitializedEvent<InitializationPerson, InitConstant>| {
+                assert_eq!(
+                    context.get_property::<InitializationPerson, InitConstant>(event.entity_id),
+                    event.value
+                );
+                *received_clone.borrow_mut() = Some((event.entity_id, event.value));
+            },
+        );
+
+        let entity_id = context
+            .add_entity(with!(
+                InitializationPerson,
+                InitConstant(7),
+                InitRequired(11)
+            ))
+            .unwrap();
+        context.execute();
+
+        assert_eq!(*received.borrow(), Some((entity_id, InitConstant(7))));
+    }
+
+    #[test]
+    fn required_property_initialization_emits_without_default() {
+        let mut context = Context::new();
+        let received = Rc::new(RefCell::new(None));
+        let received_clone = received.clone();
+        context.subscribe_to_event(
+            move |_context, event: PropertyInitializedEvent<InitializationPerson, InitRequired>| {
+                *received_clone.borrow_mut() = Some(event.value);
+            },
+        );
+
+        context
+            .add_entity(with!(InitializationPerson, InitRequired(23)))
+            .unwrap();
+        context.execute();
+
+        assert_eq!(*received.borrow(), Some(InitRequired(23)));
+    }
+
+    #[test]
+    fn explicit_constant_default_does_not_emit_initialization_event() {
+        let mut context = Context::new();
+        context.subscribe_to_event(
+            |_context, _event: PropertyInitializedEvent<InitializationPerson, InitConstant>| {
+                panic!("the explicit default must not emit");
+            },
+        );
+
+        context
+            .add_entity(with!(
+                InitializationPerson,
+                InitConstant(0),
+                InitRequired(1)
+            ))
+            .unwrap();
+        context.execute();
+    }
+
+    #[test]
+    fn omitted_constant_default_does_not_emit_initialization_event() {
+        let mut context = Context::new();
+        context.subscribe_to_event(
+            |_context, _event: PropertyInitializedEvent<InitializationPerson, InitConstant>| {
+                panic!("an omitted property must not emit");
+            },
+        );
+
+        context
+            .add_entity(with!(InitializationPerson, InitRequired(1)))
+            .unwrap();
+        context.execute();
+    }
+
+    #[test]
+    fn derived_property_does_not_emit_initialization_event() {
+        let mut context = Context::new();
+        context.subscribe_to_event(
+            |_context, _event: PropertyInitializedEvent<InitializationPerson, InitDerived>| {
+                panic!("a dependent derived property must not emit");
+            },
+        );
+
+        context
+            .add_entity(with!(
+                InitializationPerson,
+                InitConstant(9),
+                InitRequired(1)
+            ))
+            .unwrap();
+        context.execute();
+    }
+
+    #[test]
+    fn initialization_events_are_queued_in_property_order_before_creation() {
+        let mut context = Context::new();
+        context.index_property::<InitializationPerson, InitConstant>();
+        context.index_property_counts::<InitializationPerson, InitSecond>();
+
+        let order = Rc::new(RefCell::new(Vec::new()));
+        let order_clone = order.clone();
+        context.subscribe_to_event(
+            move |context, event: PropertyInitializedEvent<InitializationPerson, InitConstant>| {
+                assert_eq!(
+                    context.query_entity_count(with!(InitializationPerson, event.value)),
+                    1
+                );
+                assert_eq!(
+                    context.query_entity_count(with!(InitializationPerson, InitSecond(4))),
+                    1
+                );
+                order_clone.borrow_mut().push("constant");
+            },
+        );
+
+        let order_clone = order.clone();
+        context.subscribe_to_event(
+            move |_context, _event: PropertyInitializedEvent<InitializationPerson, InitSecond>| {
+                order_clone.borrow_mut().push("second");
+            },
+        );
+
+        let order_clone = order.clone();
+        context.subscribe_to_event(
+            move |_context,
+                  _event: PropertyInitializedEvent<InitializationPerson, InitRequired>| {
+                order_clone.borrow_mut().push("required");
+            },
+        );
+
+        let order_clone = order.clone();
+        context.subscribe_to_event(
+            move |_context, _event: EntityCreatedEvent<InitializationPerson>| {
+                order_clone.borrow_mut().push("created");
+            },
+        );
+
+        context
+            .add_entity(with!(
+                InitializationPerson,
+                InitConstant(3),
+                InitSecond(4),
+                InitRequired(5)
+            ))
+            .unwrap();
+        assert!(order.borrow().is_empty());
+
+        context.execute();
+        assert_eq!(
+            *order.borrow(),
+            vec!["constant", "second", "required", "created"]
+        );
+    }
+
+    #[test]
+    fn initialization_event_runs_once_per_subscriber() {
+        let mut context = Context::new();
+        let count = Rc::new(Cell::new(0));
+        for _ in 0..2 {
+            let count_clone = count.clone();
+            context.subscribe_to_event(
+                move |_context,
+                      _event: PropertyInitializedEvent<InitializationPerson, InitConstant>| {
+                    count_clone.set(count_clone.get() + 1);
+                },
+            );
+        }
+
+        context
+            .add_entity(with!(
+                InitializationPerson,
+                InitConstant(2),
+                InitRequired(1)
+            ))
+            .unwrap();
+        context.execute();
+
+        assert_eq!(count.get(), 2);
+    }
+
+    #[test]
+    fn repeated_creation_emits_matching_entity_ids_and_values() {
+        let mut context = Context::new();
+        let received = Rc::new(RefCell::new(Vec::new()));
+        let received_clone = received.clone();
+        context.subscribe_to_event(
+            move |_context, event: PropertyInitializedEvent<InitializationPerson, InitConstant>| {
+                received_clone
+                    .borrow_mut()
+                    .push((event.entity_id, event.value));
+            },
+        );
+
+        let first = context
+            .add_entity(with!(
+                InitializationPerson,
+                InitConstant(5),
+                InitRequired(1)
+            ))
+            .unwrap();
+        let second = context
+            .add_entity(with!(
+                InitializationPerson,
+                InitConstant(8),
+                InitRequired(2)
+            ))
+            .unwrap();
+        context.execute();
+
+        assert_eq!(
+            *received.borrow(),
+            vec![(first, InitConstant(5)), (second, InitConstant(8))]
+        );
+    }
 
     #[test]
     fn observe_entity_addition() {

--- a/src/entity/events.rs
+++ b/src/entity/events.rs
@@ -40,7 +40,7 @@ because a non-derived p
 use smallbox::space::S4;
 use smallbox::SmallBox;
 
-use crate::entity::property::Property;
+use crate::entity::property::{Property, PropertyInitializationKind};
 use crate::entity::{ContextEntitiesExt, Entity, EntityId};
 use crate::{Context, IxaEvent};
 
@@ -152,12 +152,50 @@ impl<E: Entity> EntityCreatedEvent<E> {
 }
 
 /// Emitted for a non-default, non-derived property value supplied when an entity is created.
-#[derive(IxaEvent)]
 pub struct PropertyInitializedEvent<E: Entity, P: Property<E>> {
     /// The newly created entity.
     pub entity_id: EntityId<E>,
     /// The initial property value supplied by the caller.
     pub value: P,
+}
+
+// Implemented manually to maintain the subscription mask through the event hooks.
+impl<E: Entity, P: Property<E>> Clone for PropertyInitializedEvent<E, P> {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
+
+impl<E: Entity, P: Property<E>> Copy for PropertyInitializedEvent<E, P> {}
+
+impl<E: Entity, P: Property<E>> IxaEvent for PropertyInitializedEvent<E, P> {
+    fn on_subscribe(context: &mut Context) {
+        match P::initialization_kind() {
+            PropertyInitializationKind::Explicit | PropertyInitializationKind::Constant => {
+                context
+                    .entity_store
+                    .get_property_store_mut::<E>()
+                    .property_initialized_event_subscriptions |= 1_u32 << P::id();
+            }
+            PropertyInitializationKind::Derived => {}
+        }
+    }
+
+    fn on_unsubscribe(context: &mut Context) {
+        match P::initialization_kind() {
+            PropertyInitializationKind::Explicit | PropertyInitializationKind::Constant
+                if !context.has_event_handlers::<Self>() =>
+            {
+                context
+                    .entity_store
+                    .get_property_store_mut::<E>()
+                    .property_initialized_event_subscriptions &= !(1_u32 << P::id());
+            }
+            PropertyInitializationKind::Explicit
+            | PropertyInitializationKind::Constant
+            | PropertyInitializationKind::Derived => {}
+        }
+    }
 }
 
 impl<E: Entity, P: Property<E>> PropertyInitializedEvent<E, P> {
@@ -239,6 +277,13 @@ mod tests {
     );
 
     define_property!(struct InitRequired(u8), InitializationPerson);
+
+    define_entity!(OtherInitializationPerson);
+    crate::impl_property!(
+        InitConstant,
+        OtherInitializationPerson,
+        default_const = InitConstant(0)
+    );
 
     define_derived_property!(
         struct InitDerived(u8),
@@ -351,7 +396,7 @@ mod tests {
     }
 
     #[test]
-    fn initialization_events_are_queued_in_property_order_before_creation() {
+    fn initialization_events_are_queued_before_creation() {
         let mut context = Context::new();
         context.index_property::<InitializationPerson, InitConstant>();
         context.index_property_counts::<InitializationPerson, InitSecond>();
@@ -405,10 +450,181 @@ mod tests {
         assert!(order.borrow().is_empty());
 
         context.execute();
-        assert_eq!(
-            *order.borrow(),
-            vec!["constant", "second", "required", "created"]
+        let order = order.borrow();
+        assert_eq!(order.len(), 4);
+        assert_eq!(order[3], "created");
+        assert!(order[..3].contains(&"constant"));
+        assert!(order[..3].contains(&"second"));
+        assert!(order[..3].contains(&"required"));
+    }
+
+    #[test]
+    fn property_initialized_subscription_cache_tracks_listener_lifecycle() {
+        let mut context = Context::new();
+        let bit = 1_u32 << <InitConstant as Property<InitializationPerson>>::id();
+
+        let first = context.subscribe_to_event(
+            |_context, _event: PropertyInitializedEvent<InitializationPerson, InitConstant>| {},
         );
+        assert_eq!(
+            context
+                .entity_store
+                .get_property_store::<InitializationPerson>()
+                .property_initialized_event_subscriptions
+                & bit,
+            bit
+        );
+
+        let second = context.subscribe_to_event(
+            |_context, _event: PropertyInitializedEvent<InitializationPerson, InitConstant>| {},
+        );
+        assert!(context.unsubscribe_from_event(&first));
+        assert_eq!(
+            context
+                .entity_store
+                .get_property_store::<InitializationPerson>()
+                .property_initialized_event_subscriptions
+                & bit,
+            bit
+        );
+
+        assert!(context.unsubscribe_from_event(&second));
+        assert_eq!(
+            context
+                .entity_store
+                .get_property_store::<InitializationPerson>()
+                .property_initialized_event_subscriptions
+                & bit,
+            0
+        );
+    }
+
+    #[test]
+    fn property_initialized_subscription_cache_ignores_failed_unsubscription() {
+        let mut context = Context::new();
+        let listener = context.subscribe_to_event(
+            |_context, _event: PropertyInitializedEvent<InitializationPerson, InitConstant>| {},
+        );
+        let bit = 1_u32 << <InitConstant as Property<InitializationPerson>>::id();
+
+        assert!(context.unsubscribe_from_event(&listener));
+        assert!(!context.unsubscribe_from_event(&listener));
+        assert_eq!(
+            context
+                .entity_store
+                .get_property_store::<InitializationPerson>()
+                .property_initialized_event_subscriptions
+                & bit,
+            0
+        );
+    }
+
+    #[test]
+    fn property_initialized_subscription_cache_ignores_derived_property() {
+        let mut context = Context::new();
+        context.subscribe_to_event(
+            |_context, _event: PropertyInitializedEvent<InitializationPerson, InitDerived>| {},
+        );
+
+        assert_eq!(
+            context
+                .entity_store
+                .get_property_store::<InitializationPerson>()
+                .property_initialized_event_subscriptions,
+            0
+        );
+    }
+
+    #[test]
+    fn property_initialized_subscription_cache_tracks_distinct_properties() {
+        let mut context = Context::new();
+        context.subscribe_to_event(
+            |_context, _event: PropertyInitializedEvent<InitializationPerson, InitConstant>| {},
+        );
+        context.subscribe_to_event(
+            |_context, _event: PropertyInitializedEvent<InitializationPerson, InitRequired>| {},
+        );
+
+        let expected = (1_u32 << <InitConstant as Property<InitializationPerson>>::id())
+            | (1_u32 << InitRequired::id());
+        assert_eq!(
+            context
+                .entity_store
+                .get_property_store::<InitializationPerson>()
+                .property_initialized_event_subscriptions,
+            expected
+        );
+    }
+
+    #[test]
+    fn property_initialized_subscription_cache_is_scoped_to_entity_type() {
+        let mut context = Context::new();
+        context.subscribe_to_event(
+            |_context, _event: PropertyInitializedEvent<InitializationPerson, InitConstant>| {},
+        );
+
+        assert_ne!(
+            context
+                .entity_store
+                .get_property_store::<InitializationPerson>()
+                .property_initialized_event_subscriptions,
+            0
+        );
+        assert_eq!(
+            context
+                .entity_store
+                .get_property_store::<OtherInitializationPerson>()
+                .property_initialized_event_subscriptions,
+            0
+        );
+    }
+
+    #[test]
+    fn property_initialized_subscription_cache_ignores_unrelated_event() {
+        let mut context = Context::new();
+        context.subscribe_to_event(|_context, _event: EntityCreatedEvent<InitializationPerson>| {});
+
+        assert_eq!(
+            context
+                .entity_store
+                .get_property_store::<InitializationPerson>()
+                .property_initialized_event_subscriptions,
+            0
+        );
+    }
+
+    #[test]
+    fn property_initialized_subscription_cache_controls_delivery() {
+        let mut context = Context::new();
+        let count = Rc::new(Cell::new(0));
+        let count_clone = count.clone();
+        let listener = context.subscribe_to_event(
+            move |_context,
+                  _event: PropertyInitializedEvent<InitializationPerson, InitRequired>| {
+                count_clone.set(count_clone.get() + 1);
+            },
+        );
+
+        context
+            .add_entity(with!(
+                InitializationPerson,
+                InitConstant(1),
+                InitRequired(1)
+            ))
+            .unwrap();
+        context.execute();
+        assert_eq!(count.get(), 1);
+
+        assert!(context.unsubscribe_from_event(&listener));
+        context
+            .add_entity(with!(
+                InitializationPerson,
+                InitConstant(2),
+                InitRequired(2)
+            ))
+            .unwrap();
+        context.execute();
+        assert_eq!(count.get(), 1);
     }
 
     #[test]

--- a/src/entity/events.rs
+++ b/src/entity/events.rs
@@ -138,10 +138,30 @@ impl<E: Entity, P: Property<E>> PartialPropertyChangeEventCore<E, P> {
 
 /// Emitted when a new entity is created.
 /// These should not be emitted outside this module.
-#[derive(IxaEvent)]
 pub struct EntityCreatedEvent<E: Entity> {
     /// The [`EntityId<E>`] of the new entity.
     pub entity_id: EntityId<E>,
+}
+
+// Implemented manually to maintain the subscription flag through the event hooks.
+impl<E: Entity> Clone for EntityCreatedEvent<E> {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
+
+impl<E: Entity> Copy for EntityCreatedEvent<E> {}
+
+impl<E: Entity> IxaEvent for EntityCreatedEvent<E> {
+    fn on_subscribe(context: &mut Context) {
+        context.entity_store.items[E::id()].entity_created_event_subscribed = true;
+    }
+
+    fn on_unsubscribe(context: &mut Context) {
+        if !context.has_event_handlers::<Self>() {
+            context.entity_store.items[E::id()].entity_created_event_subscribed = false;
+        }
+    }
 }
 
 impl<E: Entity> EntityCreatedEvent<E> {
@@ -625,6 +645,145 @@ mod tests {
             .unwrap();
         context.execute();
         assert_eq!(count.get(), 1);
+    }
+
+    #[test]
+    fn entity_created_subscription_cache_tracks_listener_lifecycle() {
+        let mut context = Context::new();
+        assert!(
+            !context
+                .entity_store
+                .new_entity_id::<InitializationPerson>()
+                .1
+        );
+
+        let first = context
+            .subscribe_to_event(|_context, _event: EntityCreatedEvent<InitializationPerson>| {});
+        assert!(
+            context
+                .entity_store
+                .new_entity_id::<InitializationPerson>()
+                .1
+        );
+
+        let second = context
+            .subscribe_to_event(|_context, _event: EntityCreatedEvent<InitializationPerson>| {});
+        assert!(context.unsubscribe_from_event(&first));
+        assert!(
+            context
+                .entity_store
+                .new_entity_id::<InitializationPerson>()
+                .1
+        );
+
+        assert!(context.unsubscribe_from_event(&second));
+        assert!(
+            !context
+                .entity_store
+                .new_entity_id::<InitializationPerson>()
+                .1
+        );
+    }
+
+    #[test]
+    fn entity_created_subscription_cache_ignores_failed_unsubscription() {
+        let mut context = Context::new();
+        let listener = context
+            .subscribe_to_event(|_context, _event: EntityCreatedEvent<InitializationPerson>| {});
+
+        assert!(context.unsubscribe_from_event(&listener));
+        assert!(!context.unsubscribe_from_event(&listener));
+        assert!(
+            !context
+                .entity_store
+                .new_entity_id::<InitializationPerson>()
+                .1
+        );
+    }
+
+    #[test]
+    fn entity_created_subscription_cache_is_scoped_to_entity_type() {
+        let mut context = Context::new();
+        context.subscribe_to_event(|_context, _event: EntityCreatedEvent<InitializationPerson>| {});
+
+        assert!(
+            context
+                .entity_store
+                .new_entity_id::<InitializationPerson>()
+                .1
+        );
+        assert!(
+            !context
+                .entity_store
+                .new_entity_id::<OtherInitializationPerson>()
+                .1
+        );
+    }
+
+    #[test]
+    fn entity_created_subscription_cache_ignores_unrelated_event() {
+        let mut context = Context::new();
+        context.subscribe_to_event(
+            |_context, _event: PropertyInitializedEvent<InitializationPerson, InitConstant>| {},
+        );
+
+        assert!(
+            !context
+                .entity_store
+                .new_entity_id::<InitializationPerson>()
+                .1
+        );
+    }
+
+    #[test]
+    fn entity_created_subscription_cache_controls_delivery() {
+        let mut context = Context::new();
+        let count = Rc::new(Cell::new(0));
+        let count_clone = count.clone();
+        let listener = context.subscribe_to_event(
+            move |_context, _event: EntityCreatedEvent<InitializationPerson>| {
+                count_clone.set(count_clone.get() + 1);
+            },
+        );
+
+        context
+            .add_entity(with!(InitializationPerson, InitRequired(1)))
+            .unwrap();
+        context.execute();
+        assert_eq!(count.get(), 1);
+
+        assert!(context.unsubscribe_from_event(&listener));
+        context
+            .add_entity(with!(InitializationPerson, InitRequired(2)))
+            .unwrap();
+        context.execute();
+        assert_eq!(count.get(), 1);
+    }
+
+    #[test]
+    fn entity_created_subscription_cache_preserves_listener_order() {
+        let mut context = Context::new();
+        let order = Rc::new(RefCell::new(Vec::new()));
+
+        let order_clone = order.clone();
+        context.subscribe_to_event(
+            move |_context, _event: EntityCreatedEvent<InitializationPerson>| {
+                order_clone.borrow_mut().push(1);
+            },
+        );
+        let order_clone = order.clone();
+        context.subscribe_to_event(
+            move |_context, _event: EntityCreatedEvent<InitializationPerson>| {
+                order_clone.borrow_mut().push(2);
+            },
+        );
+
+        context
+            .add_entity(with!(InitializationPerson, InitRequired(1)))
+            .unwrap();
+        context.execute();
+
+        assert_eq!(*order.borrow(), vec![1, 2]);
     }
 
     #[test]

--- a/src/entity/property_list.rs
+++ b/src/entity/property_list.rs
@@ -54,7 +54,12 @@ pub trait PropertyList<E: Entity>: Copy + 'static {
 
     /// Emits initialization events for the explicitly supplied property values.
     #[doc(hidden)]
-    fn emit_initialized_events(&self, context: &mut Context, entity_id: EntityId<E>);
+    fn emit_initialized_events(
+        &self,
+        context: &mut Context,
+        entity_id: EntityId<E>,
+        subscription_mask: u32,
+    );
 
     /// Gets the tuple of property values for the given entity.
     #[must_use]
@@ -80,7 +85,13 @@ impl<E: Entity> PropertyList<E> for () {
         // No values to assign.
     }
 
-    fn emit_initialized_events(&self, _context: &mut Context, _entity_id: EntityId<E>) {}
+    fn emit_initialized_events(
+        &self,
+        _context: &mut Context,
+        _entity_id: EntityId<E>,
+        _subscription_mask: u32,
+    ) {
+    }
 
     fn get_values_for_entity(_context: &Context, _entity_id: EntityId<E>) -> Self {}
 }
@@ -102,7 +113,13 @@ impl<E: Entity + Copy> PropertyList<E> for E {
         // No values to assign.
     }
 
-    fn emit_initialized_events(&self, _context: &mut Context, _entity_id: EntityId<E>) {}
+    fn emit_initialized_events(
+        &self,
+        _context: &mut Context,
+        _entity_id: EntityId<E>,
+        _subscription_mask: u32,
+    ) {
+    }
 
     fn get_values_for_entity(_context: &Context, _entity_id: EntityId<E>) -> E {
         E::default()
@@ -165,8 +182,15 @@ impl<E: Entity, P: Property<E>> PropertyList<E> for (P,) {
         property_value_store.set(entity_id, self.0);
     }
 
-    fn emit_initialized_events(&self, context: &mut Context, entity_id: EntityId<E>) {
-        emit_initialized_event(context, entity_id, self.0);
+    fn emit_initialized_events(
+        &self,
+        context: &mut Context,
+        entity_id: EntityId<E>,
+        subscription_mask: u32,
+    ) {
+        if subscription_mask & (1_u32 << P::id()) != 0 {
+            emit_initialized_event(context, entity_id, self.0);
+        }
     }
 
     fn get_values_for_entity(context: &Context, entity_id: EntityId<E>) -> Self {
@@ -210,8 +234,17 @@ macro_rules! impl_property_list {
                     })*
                 }
 
-                fn emit_initialized_events(&self, context: &mut Context, entity_id: EntityId<E>) {
-                    #(emit_initialized_event(context, entity_id, self.N);)*
+                fn emit_initialized_events(
+                    &self,
+                    context: &mut Context,
+                    entity_id: EntityId<E>,
+                    subscription_mask: u32,
+                ) {
+                    #(
+                        if subscription_mask & (1_u32 << P~N::id()) != 0 {
+                            emit_initialized_event(context, entity_id, self.N);
+                        }
+                    )*
                 }
 
                 fn get_values_for_entity(context: &Context, entity_id: EntityId<E>) -> Self {

--- a/src/entity/property_list.rs
+++ b/src/entity/property_list.rs
@@ -24,7 +24,8 @@ use std::any::TypeId;
 use seq_macro::seq;
 
 use super::entity::{Entity, EntityId};
-use super::property::Property;
+use super::events::PropertyInitializedEvent;
+use super::property::{Property, PropertyInitializationKind};
 use super::property_store::PropertyStore;
 use crate::entity::ContextEntitiesExt;
 use crate::{Context, IxaError};
@@ -51,6 +52,10 @@ pub trait PropertyList<E: Entity>: Copy + 'static {
         property_store: &mut PropertyStore<E>,
     );
 
+    /// Emits initialization events for the explicitly supplied property values.
+    #[doc(hidden)]
+    fn emit_initialized_events(&self, context: &mut Context, entity_id: EntityId<E>);
+
     /// Gets the tuple of property values for the given entity.
     #[must_use]
     fn get_values_for_entity(context: &Context, entity_id: EntityId<E>) -> Self;
@@ -75,6 +80,8 @@ impl<E: Entity> PropertyList<E> for () {
         // No values to assign.
     }
 
+    fn emit_initialized_events(&self, _context: &mut Context, _entity_id: EntityId<E>) {}
+
     fn get_values_for_entity(_context: &Context, _entity_id: EntityId<E>) -> Self {}
 }
 
@@ -95,12 +102,31 @@ impl<E: Entity + Copy> PropertyList<E> for E {
         // No values to assign.
     }
 
+    fn emit_initialized_events(&self, _context: &mut Context, _entity_id: EntityId<E>) {}
+
     fn get_values_for_entity(_context: &Context, _entity_id: EntityId<E>) -> E {
         E::default()
     }
 }
 
 impl<E: Entity + Copy> PropertyInitializationList<E> for E {}
+
+fn emit_initialized_event<E, P>(context: &mut Context, entity_id: EntityId<E>, value: P)
+where
+    E: Entity,
+    P: Property<E>,
+{
+    match P::initialization_kind() {
+        PropertyInitializationKind::Derived => {}
+        PropertyInitializationKind::Explicit => {
+            context.emit_event(PropertyInitializedEvent::new(entity_id, value));
+        }
+        PropertyInitializationKind::Constant if value != P::default_const() => {
+            context.emit_event(PropertyInitializedEvent::new(entity_id, value));
+        }
+        PropertyInitializationKind::Constant => {}
+    }
+}
 
 // ToDo(RobertJacobsonCDC): The following is a fundamental limitation in Rust. If downstream code *can* implement a
 //     trait impl that will cause conflicting implementations with some blanket impl, it disallows it, regardless of
@@ -137,6 +163,10 @@ impl<E: Entity, P: Property<E>> PropertyList<E> for (P,) {
     ) {
         let property_value_store = property_store.get_mut::<P>();
         property_value_store.set(entity_id, self.0);
+    }
+
+    fn emit_initialized_events(&self, context: &mut Context, entity_id: EntityId<E>) {
+        emit_initialized_event(context, entity_id, self.0);
     }
 
     fn get_values_for_entity(context: &Context, entity_id: EntityId<E>) -> Self {
@@ -178,6 +208,10 @@ macro_rules! impl_property_list {
                         let property_value_store = property_store.get_mut::<P~N>();
                         property_value_store.set(entity_id, self.N);
                     })*
+                }
+
+                fn emit_initialized_events(&self, context: &mut Context, entity_id: EntityId<E>) {
+                    #(emit_initialized_event(context, entity_id, self.N);)*
                 }
 
                 fn get_values_for_entity(context: &Context, entity_id: EntityId<E>) -> Self {

--- a/src/entity/property_store.rs
+++ b/src/entity/property_store.rs
@@ -75,6 +75,11 @@ where
 static NEXT_PROPERTY_ID: LazyLock<Mutex<HashMap<usize, usize>>> =
     LazyLock::new(|| Mutex::new(HashMap::default()));
 
+/// This hard cap exists only to allow us to cache the existence of subscribers to property
+/// initialized events in `PropertyStore`. We can always increase this to 64 or 128 if there is a
+/// use case, or we can find an alternative implementation that removes the cap.
+const MAX_PROPERTIES_PER_ENTITY: usize = u32::BITS as usize;
+
 /// A container struct to hold the (global) metadata for a single property.
 ///
 /// At program startup (before `main()`, using ctors) we compute metadata for all properties
@@ -203,6 +208,18 @@ pub fn initialize_property_id<E: Entity>(property_id: &AtomicUsize) -> usize {
     let mut guard = NEXT_PROPERTY_ID.lock().unwrap();
     let candidate = guard.entry(E::id()).or_insert_with(|| 0);
 
+    // The property may have been initialized while this call waited for the lock.
+    let existing = property_id.load(Ordering::Acquire);
+    if existing != usize::MAX {
+        return existing;
+    }
+
+    assert!(
+        *candidate < MAX_PROPERTIES_PER_ENTITY,
+        "Cannot register more than {MAX_PROPERTIES_PER_ENTITY} properties for entity `{}`",
+        E::name(),
+    );
+
     // Try to claim the candidate index. Here we guard against the potential race condition that
     // another instance of this plugin in another thread just initialized the index prior to us
     // obtaining the lock. If the index has been initialized beneath us, we do not update
@@ -228,6 +245,13 @@ pub fn initialize_property_id<E: Entity>(property_id: &AtomicUsize) -> usize {
 pub struct PropertyStore<E: Entity> {
     /// A vector of `Box<PropertyValueStoreCore<E, P>>`, type-erased to `Box<dyn PropertyValueStore<E>>`
     items: Vec<Box<dyn PropertyValueStore<E>>>,
+
+    /// Bitmask of properties that currently have `PropertyInitializedEvent` subscribers.
+    ///
+    /// `PropertyList::emit_initialized_events` reads this in the hot path to skip
+    /// per-property initialization-event work unless a handler is registered as a performance
+    /// optimization.
+    pub(in crate::entity) property_initialized_event_subscriptions: u32,
 
     /// One entry for every property whose `PropertyValueStoreCore` currently has an index.
     /// The property ID supports removal without relying on deduplicable function addresses.
@@ -269,6 +293,7 @@ impl<E: Entity> PropertyStore<E> {
 
         Self {
             items,
+            property_initialized_event_subscriptions: 0,
             index_new_entity_fns: Vec::new(),
         }
     }

--- a/src/entity/query/mod.rs
+++ b/src/entity/query/mod.rs
@@ -128,8 +128,14 @@ impl<E: Entity, T: PropertyList<E>> PropertyList<E> for EntityPropertyTuple<E, T
             .set_values_for_new_entity(entity_id, property_store)
     }
 
-    fn emit_initialized_events(&self, context: &mut Context, entity_id: EntityId<E>) {
-        self.inner.emit_initialized_events(context, entity_id);
+    fn emit_initialized_events(
+        &self,
+        context: &mut Context,
+        entity_id: EntityId<E>,
+        subscription_mask: u32,
+    ) {
+        self.inner
+            .emit_initialized_events(context, entity_id, subscription_mask);
     }
 
     fn get_values_for_entity(context: &Context, entity_id: EntityId<E>) -> Self {

--- a/src/entity/query/mod.rs
+++ b/src/entity/query/mod.rs
@@ -128,6 +128,10 @@ impl<E: Entity, T: PropertyList<E>> PropertyList<E> for EntityPropertyTuple<E, T
             .set_values_for_new_entity(entity_id, property_store)
     }
 
+    fn emit_initialized_events(&self, context: &mut Context, entity_id: EntityId<E>) {
+        self.inner.emit_initialized_events(context, entity_id);
+    }
+
     fn get_values_for_entity(context: &Context, entity_id: EntityId<E>) -> Self {
         EntityPropertyTuple::new(T::get_values_for_entity(context, entity_id))
     }

--- a/src/macros/property_impl.rs
+++ b/src/macros/property_impl.rs
@@ -8,6 +8,9 @@ For the most common cases, use the [`define_property!`][macro@crate::define_prop
 with the standard derives required by the [`Property`][crate::entity::property::Property] trait and implements [`Property`][crate::entity::property::Property] (via
 [`impl_property!`][macro@crate::impl_property]) for you.
 
+An entity may have at most 32 registered properties, including explicit, constant, derived, and
+multi-properties. If there is a use-case for more properties, we can increase this cap.
+
 ```rust,ignore
 define_property!(struct Age(u8), Person);
 define_property!(struct Location(City, State), Person);
@@ -194,6 +197,8 @@ impl_property!(
 /// ### Notes
 ///
 /// - By default, the generated type derives `Debug`, `PartialEq`, `Eq`, `Hash`, `Clone`, and `Copy`.
+/// - An entity may have at most 32 registered properties, including explicit, constant, derived,
+///   and multi-properties.
 /// - Use the optional `default_const = <default_value>` argument to define a compile-time constant
 ///   default for the property.
 /// - Use `impl_eq_hash = Eq`, `Hash`, `both`, or `neither` as the first optional argument to suppress the default

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -1,5 +1,7 @@
 pub use crate::context::{Context, EventListenerId};
-pub use crate::entity::events::{EntityCreatedEvent, PropertyChangeEvent};
+pub use crate::entity::events::{
+    EntityCreatedEvent, PropertyChangeEvent, PropertyInitializedEvent,
+};
 pub use crate::entity::property::{IndexableProperty, Property};
 pub use crate::entity::{ContextEntitiesExt, Entity, EntityId};
 pub use crate::error::IxaError;

--- a/src/triggers/mod.rs
+++ b/src/triggers/mod.rs
@@ -807,6 +807,83 @@ mod tests {
     }
 
     #[test]
+    fn property_value_count_tracks_created_value_before_same_tick_change() {
+        let mut context = Context::new();
+        let observed = Rc::new(RefCell::new(Vec::new()));
+        let observed_clone = Rc::clone(&observed);
+
+        #[derive(IxaEvent)]
+        struct InfectiousThresholdReached {
+            count: usize,
+            direction: Direction,
+        }
+
+        context.register_trigger(
+            PropertyValueCountTrigger::<Person, InfectionStatus>::decreases_to(
+                InfectionStatus::Infectious,
+                0,
+            )
+            .repeating()
+            .emit_with(|event| InfectiousThresholdReached {
+                count: event.count,
+                direction: event.direction,
+            }),
+        );
+        context.subscribe_to_event(move |_context, event: InfectiousThresholdReached| {
+            observed_clone
+                .borrow_mut()
+                .push((event.count, event.direction));
+        });
+
+        let person = context
+            .add_entity(with!(Person, InfectionStatus::Infectious))
+            .unwrap();
+        context.set_property(person, InfectionStatus::Susceptible);
+        context.execute();
+
+        assert_eq!(*observed.borrow(), vec![(0, Direction::Decreasing)]);
+    }
+
+    #[test]
+    fn property_value_count_does_not_double_count_same_tick_change_to_tracked() {
+        let mut context = Context::new();
+        let observed = Rc::new(RefCell::new(Vec::new()));
+        let observed_clone = Rc::clone(&observed);
+
+        #[derive(IxaEvent)]
+        struct InfectiousThresholdReached {
+            count: usize,
+            direction: Direction,
+        }
+
+        context.register_trigger(
+            PropertyValueCountTrigger::<Person, InfectionStatus>::changes_to(
+                InfectionStatus::Infectious,
+                0,
+            )
+            .repeating()
+            .emit_with(|event| InfectiousThresholdReached {
+                count: event.count,
+                direction: event.direction,
+            }),
+        );
+        context.subscribe_to_event(move |_context, event: InfectiousThresholdReached| {
+            observed_clone
+                .borrow_mut()
+                .push((event.count, event.direction));
+        });
+
+        let person = context.add_entity(Person).unwrap();
+        context.set_property(person, InfectionStatus::Infectious);
+        context.execute();
+
+        context.set_property(person, InfectionStatus::Susceptible);
+        context.execute();
+
+        assert_eq!(*observed.borrow(), vec![(0, Direction::Decreasing)]);
+    }
+
+    #[test]
     #[should_panic(expected = "period must be greater than 0")]
     fn periodic_time_trigger_zero_period_panics() {
         let _ = PeriodicTimeTrigger::every(0.0);

--- a/src/triggers/property_value_count.rs
+++ b/src/triggers/property_value_count.rs
@@ -3,7 +3,7 @@ use std::marker::PhantomData;
 use std::rc::Rc;
 
 use super::{Direction, TriggerCriterion, TriggerMode};
-use crate::entity::events::{EntityCreatedEvent, PropertyChangeEvent};
+use crate::entity::events::{PropertyChangeEvent, PropertyInitializedEvent};
 use crate::entity::property::Property;
 use crate::entity::{ContextEntitiesExt, Entity, EntityId};
 use crate::{Context, EntityPropertyTuple};
@@ -11,7 +11,7 @@ use crate::{Context, EntityPropertyTuple};
 /// Trigger criterion for the count of entities with a particular property value.
 ///
 /// [`PropertyValueCountTrigger`] observes
-/// [`EntityCreatedEvent`](crate::entity::events::EntityCreatedEvent) and
+/// [`PropertyInitializedEvent`](crate::entity::events::PropertyInitializedEvent) and
 /// [`PropertyChangeEvent`](crate::entity::events::PropertyChangeEvent) for a specific
 /// entity/property pair and emits when the count of entities with a configured property value
 /// crosses a configured threshold.
@@ -30,8 +30,8 @@ use crate::{Context, EntityPropertyTuple};
 ///
 /// The observation data passed to
 /// [`TriggerCriterion::emit_with`](super::TriggerCriterion::emit_with) is
-/// [`PropertyValueCountTriggerEvent`]. It contains the entity ID whose creation or property write
-/// caused the crossing, the tracked property value, the new count, the observed
+/// [`PropertyValueCountTriggerEvent`]. It contains the entity ID whose property initialization or
+/// write caused the crossing, the tracked property value, the new count, the observed
 /// [`Direction`](super::Direction), the configured direction filter as `Option<Direction>`, and the
 /// selected [`TriggerMode`](super::TriggerMode):
 ///
@@ -65,10 +65,11 @@ use crate::{Context, EntityPropertyTuple};
 /// [`PropertyValueCountTrigger::once`] to emit only for the first crossing, or
 /// [`PropertyValueCountTrigger::repeating`] to return to the default repeating behavior.
 ///
-/// Entity creation can cause a crossing if the new entity has the tracked value. Property writes
-/// can cause a crossing when they move an entity into or out of the tracked value. A no-op write
-/// where `previous == current` still emits a property-change event at the entity layer, but it does
-/// not change this trigger's tracked count and therefore cannot by itself cross the threshold.
+/// Property initialization from entity creation can cause a crossing if the initialized property
+/// has the tracked value. Property writes can cause a crossing when they move an entity into or out
+/// of the tracked value. A no-op write where `previous == current` still emits a property-change
+/// event at the entity layer, but it does not change this trigger's tracked count and therefore
+/// cannot by itself cross the threshold.
 ///
 /// ## Example
 ///
@@ -213,9 +214,8 @@ where
                 context.subscribe_to_event({
                     let state = Rc::clone(&state);
                     let on_match = Rc::clone(&on_match);
-                    move |context, event: EntityCreatedEvent<E>| {
-                        let current = context.get_property::<E, P>(event.entity_id);
-                        if current == self.value {
+                    move |context, event: PropertyInitializedEvent<E, P>| {
+                        if event.value == self.value {
                             let mut state_value = state.get();
                             if !state_value.active {
                                 return;
@@ -304,9 +304,8 @@ where
                 context.subscribe_to_event({
                     let count = Rc::clone(&count);
                     let on_match = Rc::clone(&on_match);
-                    move |context, event: EntityCreatedEvent<E>| {
-                        let current = context.get_property::<E, P>(event.entity_id);
-                        if current == self.value {
+                    move |context, event: PropertyInitializedEvent<E, P>| {
+                        if event.value == self.value {
                             let previous_count = count.get();
                             let current_count = previous_count + 1;
                             count.set(current_count);


### PR DESCRIPTION
Fixes #922, a possible underflow in `PropertyValueCountTrigger`.

This PR is stacked on #1025.