### PR TITLE
feat: Add query profiling feature

### DIFF
--- a/docs/book/src/topics/profiling-module.md
+++ b/docs/book/src/topics/profiling-module.md
@@ -118,6 +118,27 @@ See `examples/profiling` in the repository for a more complete example,
 including configuring `report_options()` to control the output directory, file
 prefix, and overwrite behavior.
 
+## Query timings
+
+When the `profiling` feature is enabled, context query APIs automatically
+aggregate query execution times by query shape. A query shape consists of the
+entity type and its unordered property names; property values do not affect the
+identity. For example, queries for `Age(10), Alive(true)` and
+`Alive(false), Age(20)` share one timing row.
+
+The `Count` column reports consumed query executions. Each eager query method or
+`EntitySet` terminal operation counts once. An iterator counts once when it
+performs query work, whether it is consumed through `next`, `count`, `for_each`,
+or `fold`. Creating and dropping an unused iterator does not increment the
+count. For partially consumed iterators, only work completed before the iterator
+is dropped contributes to the recorded execution time. User callback time in
+`for_each` and `fold` is excluded.
+
+Set algebra retains a query profile when all profiled operands have the same
+query identity, including when a profiled set is combined with an unprofiled
+set. Combining sets with different query identities clears the profile from the
+result so the composed work is not attributed to an arbitrary query.
+
 ## Writing JSON output
 
 `ProfilingContextExt::write_profiling_data()` writes a pretty JSON file to:
@@ -131,6 +152,8 @@ prefix, overwrite). The JSON includes:
 - `execution_statistics`
 - `named_counts`
 - `named_spans`
+- `query_timings`, with query label, observation count, total duration,
+  minimum duration, and maximum duration
 - `computed_statistics`
 
 Example:

--- a/integration-tests/ixa-profiling-tests/Cargo.toml
+++ b/integration-tests/ixa-profiling-tests/Cargo.toml
@@ -11,6 +11,7 @@ authors.workspace = true
 
 [dependencies]
 ixa = { path = "../../", features = ["profiling"] }
+serde.workspace = true
 
 [dev-dependencies]
 assert_cmd.workspace = true

--- a/integration-tests/ixa-profiling-tests/bin/runner_test_profiling.rs
+++ b/integration-tests/ixa-profiling-tests/bin/runner_test_profiling.rs
@@ -4,10 +4,58 @@ use ixa::profiling::{
     add_computed_statistic, increment_named_count, open_span, ProfilingContextExt,
 };
 use ixa::runner::run_with_args;
+use ixa::{define_entity, define_property, with, ContextEntitiesExt};
+
+define_entity!(ProfilingPerson);
+define_property!(struct ProfilingAge(u8), ProfilingPerson);
+define_property!(struct ProfilingCounty(u8), ProfilingPerson);
 
 fn main() {
     let mut context = run_with_args(|context, _args, _| {
         context.add_plan(0.0, |context| {
+            context
+                .add_entity(with!(ProfilingPerson, ProfilingAge(42), ProfilingCounty(1)))
+                .unwrap();
+            context
+                .add_entity(with!(ProfilingPerson, ProfilingAge(7), ProfilingCounty(2)))
+                .unwrap();
+            assert_eq!(
+                context
+                    .query_result_iterator(with!(ProfilingPerson, ProfilingAge(42)))
+                    .count(),
+                1
+            );
+            assert_eq!(
+                context
+                    .query_result_iterator(with!(
+                        ProfilingPerson,
+                        ProfilingAge(42),
+                        ProfilingCounty(1)
+                    ))
+                    .count(),
+                1
+            );
+            assert_eq!(
+                context
+                    .query_result_iterator(with!(
+                        ProfilingPerson,
+                        ProfilingCounty(1),
+                        ProfilingAge(42)
+                    ))
+                    .count(),
+                1
+            );
+            assert_eq!(
+                context
+                    .query_result_iterator(with!(
+                        ProfilingPerson,
+                        ProfilingAge(7),
+                        ProfilingCounty(2)
+                    ))
+                    .count(),
+                1
+            );
+
             increment_named_count("it_prof_event");
             increment_named_count("it_prof_event");
             increment_named_count("it_prof_event");

--- a/integration-tests/ixa-profiling-tests/tests/profiling.rs
+++ b/integration-tests/ixa-profiling-tests/tests/profiling.rs
@@ -31,6 +31,7 @@ mod tests {
         assert!(json["execution_statistics"].is_object());
         assert!(json["named_counts"].is_array());
         assert!(json["named_spans"].is_array());
+        assert!(json["query_timings"].is_array());
         assert!(json["computed_statistics"].is_object());
 
         let counts = json["named_counts"].as_array().unwrap();
@@ -49,6 +50,25 @@ mod tests {
             it_prof_span["count"].as_u64().unwrap_or(0) >= 1,
             "expected it_prof_span to be recorded at least once"
         );
+
+        let query_timings = json["query_timings"].as_array().unwrap();
+        let profiling_age_query = query_timings
+            .iter()
+            .find(|q| q["query"] == "ProfilingPerson: (ProfilingAge)")
+            .expect("ProfilingPerson age query not found in query_timings");
+        assert_eq!(profiling_age_query["count"], 1);
+        assert!(profiling_age_query["total"].as_f64().is_some());
+        assert!(profiling_age_query["min"].as_f64().is_some());
+        assert!(profiling_age_query["max"].as_f64().is_some());
+
+        let profiling_age_county_query = query_timings
+            .iter()
+            .find(|q| q["query"] == "ProfilingPerson: (ProfilingAge, ProfilingCounty)")
+            .expect("ProfilingPerson age/county query not found in query_timings");
+        assert_eq!(profiling_age_county_query["count"], 3);
+        assert!(profiling_age_county_query["total"].as_f64().is_some());
+        assert!(profiling_age_county_query["min"].as_f64().is_some());
+        assert!(profiling_age_county_query["max"].as_f64().is_some());
 
         let computed = &json["computed_statistics"];
         assert_eq!(computed["it_prof_stat"]["description"], "Total test events");

--- a/src/context.rs
+++ b/src/context.rs
@@ -23,12 +23,11 @@ use crate::execution_stats::{
 };
 use crate::global_properties::get_global_property_count;
 use crate::plan_queue::{PlanId, PlanQueue};
-use crate::{get_data_plugin_count, trace, warn, HashMap, HashMapExt};
-
 #[cfg(feature = "profiling")]
 use crate::profiling::{
     print_profiling_data, print_query_timings, QueryProfileHandle, QueryProfilingData,
 };
+use crate::{get_data_plugin_count, trace, warn, HashMap, HashMapExt};
 
 /// The common callback used by multiple [`Context`] methods for future events
 type Callback = dyn FnOnce(&mut Context);
@@ -212,6 +211,7 @@ impl Context {
             .query_profiling_data(identity)
     }
 
+    #[inline]
     pub(crate) fn get_property_value_store<E: Entity, P: Property<E>>(
         &self,
     ) -> &PropertyValueStoreCore<E, P> {

--- a/src/context.rs
+++ b/src/context.rs
@@ -4,6 +4,8 @@
 //! for storing and manipulating the state of a given simulation.
 use std::any::{Any, TypeId};
 use std::cell::OnceCell;
+#[cfg(feature = "profiling")]
+use std::cell::RefCell;
 use std::collections::VecDeque;
 use std::fmt::{Display, Formatter};
 use std::marker::PhantomData;
@@ -152,6 +154,8 @@ pub struct Context {
     start_time: Option<f64>,
     shutdown_status: ShutdownStatus,
     execution_profiler: ExecutionProfilingCollector,
+    #[cfg(feature = "profiling")]
+    query_profiler: RefCell<crate::profiling::QueryProfiler>,
     pub(crate) print_execution_statistics: bool,
 }
 
@@ -181,8 +185,28 @@ impl Context {
             start_time: None,
             shutdown_status: ShutdownStatus::None,
             execution_profiler: ExecutionProfilingCollector::new(),
+            #[cfg(feature = "profiling")]
+            query_profiler: RefCell::new(crate::profiling::QueryProfiler::default()),
             print_execution_statistics: false,
         }
+    }
+
+    #[cfg(feature = "profiling")]
+    pub(crate) fn query_profile_handle(
+        &self,
+        query: &'static str,
+    ) -> crate::profiling::QueryProfileHandle<'_> {
+        crate::profiling::QueryProfileHandle::new(&self.query_profiler, query)
+    }
+
+    #[cfg(feature = "profiling")]
+    pub(crate) fn query_timings_table(&self) -> Vec<crate::profiling::QueryTimingRow> {
+        self.query_profiler.borrow().query_timings_table()
+    }
+
+    #[cfg(all(test, feature = "profiling"))]
+    pub(crate) fn query_timing(&self, query: &str) -> Option<crate::profiling::QueryTiming> {
+        self.query_profiler.borrow().query_timing(query).cloned()
     }
 
     pub(crate) fn get_property_value_store<E: Entity, P: Property<E>>(
@@ -702,7 +726,10 @@ impl Context {
         if self.print_execution_statistics {
             print_execution_statistics(&stats);
             #[cfg(feature = "profiling")]
-            crate::profiling::print_profiling_data();
+            {
+                crate::profiling::print_profiling_data();
+                crate::profiling::print_query_timings(&self.query_timings_table());
+            }
         } else {
             log_execution_statistics(&stats);
         }

--- a/src/context.rs
+++ b/src/context.rs
@@ -12,6 +12,8 @@ use std::rc::Rc;
 use crate::data_plugin::DataPlugin;
 use crate::entity::entity_store::EntityStore;
 use crate::entity::multi_property::emit_pre_main_diagnostics;
+#[cfg(feature = "profiling")]
+use crate::entity::multi_property::QueryIdentityId;
 use crate::entity::property::Property;
 use crate::entity::property_value_store_core::PropertyValueStoreCore;
 use crate::entity::Entity;
@@ -22,6 +24,11 @@ use crate::execution_stats::{
 use crate::global_properties::get_global_property_count;
 use crate::plan_queue::{PlanId, PlanQueue};
 use crate::{get_data_plugin_count, trace, warn, HashMap, HashMapExt};
+
+#[cfg(feature = "profiling")]
+use crate::profiling::{
+    print_profiling_data, print_query_timings, QueryProfileHandle, QueryProfilingData,
+};
 
 /// The common callback used by multiple [`Context`] methods for future events
 type Callback = dyn FnOnce(&mut Context);
@@ -186,28 +193,23 @@ impl Context {
     }
 
     #[cfg(feature = "profiling")]
-    pub(crate) fn query_profile_handle(
-        &self,
-        query: &'static str,
-    ) -> crate::profiling::QueryProfileHandle<'_> {
-        crate::profiling::QueryProfileHandle::new(&self.execution_profiler.query_profiler, query)
+    pub(crate) fn query_profile_handle(&self, identity: QueryIdentityId) -> QueryProfileHandle<'_> {
+        QueryProfileHandle::new(&self.execution_profiler.query_profiler, identity)
     }
 
     #[cfg(feature = "profiling")]
-    pub(crate) fn query_profiling_snapshot(
-        &self,
-    ) -> Vec<(&'static str, crate::profiling::QueryProfilingData)> {
+    pub(crate) fn query_profiling_snapshot(&self) -> Vec<(&'static str, QueryProfilingData)> {
         self.execution_profiler.query_profiler.snapshot()
     }
 
     #[cfg(all(test, feature = "profiling"))]
     pub(crate) fn query_profiling_data(
         &self,
-        query: &str,
-    ) -> Option<crate::profiling::QueryProfilingData> {
+        identity: QueryIdentityId,
+    ) -> Option<QueryProfilingData> {
         self.execution_profiler
             .query_profiler
-            .query_profiling_data(query)
+            .query_profiling_data(identity)
     }
 
     pub(crate) fn get_property_value_store<E: Entity, P: Property<E>>(
@@ -728,8 +730,8 @@ impl Context {
             print_execution_statistics(&stats);
             #[cfg(feature = "profiling")]
             {
-                crate::profiling::print_profiling_data();
-                crate::profiling::print_query_timings(&self.query_profiling_snapshot());
+                print_profiling_data();
+                print_query_timings(&self.query_profiling_snapshot());
             }
         } else {
             log_execution_statistics(&stats);

--- a/src/context.rs
+++ b/src/context.rs
@@ -4,8 +4,6 @@
 //! for storing and manipulating the state of a given simulation.
 use std::any::{Any, TypeId};
 use std::cell::OnceCell;
-#[cfg(feature = "profiling")]
-use std::cell::RefCell;
 use std::collections::VecDeque;
 use std::fmt::{Display, Formatter};
 use std::marker::PhantomData;
@@ -154,8 +152,6 @@ pub struct Context {
     start_time: Option<f64>,
     shutdown_status: ShutdownStatus,
     execution_profiler: ExecutionProfilingCollector,
-    #[cfg(feature = "profiling")]
-    query_profiler: RefCell<crate::profiling::QueryProfiler>,
     pub(crate) print_execution_statistics: bool,
 }
 
@@ -185,8 +181,6 @@ impl Context {
             start_time: None,
             shutdown_status: ShutdownStatus::None,
             execution_profiler: ExecutionProfilingCollector::new(),
-            #[cfg(feature = "profiling")]
-            query_profiler: RefCell::new(crate::profiling::QueryProfiler::default()),
             print_execution_statistics: false,
         }
     }
@@ -196,17 +190,24 @@ impl Context {
         &self,
         query: &'static str,
     ) -> crate::profiling::QueryProfileHandle<'_> {
-        crate::profiling::QueryProfileHandle::new(&self.query_profiler, query)
+        crate::profiling::QueryProfileHandle::new(&self.execution_profiler.query_profiler, query)
     }
 
     #[cfg(feature = "profiling")]
-    pub(crate) fn query_timings_table(&self) -> Vec<crate::profiling::QueryTimingRow> {
-        self.query_profiler.borrow().query_timings_table()
+    pub(crate) fn query_profiling_snapshot(
+        &self,
+    ) -> Vec<(&'static str, crate::profiling::QueryProfilingData)> {
+        self.execution_profiler.query_profiler.snapshot()
     }
 
     #[cfg(all(test, feature = "profiling"))]
-    pub(crate) fn query_timing(&self, query: &str) -> Option<crate::profiling::QueryTiming> {
-        self.query_profiler.borrow().query_timing(query).cloned()
+    pub(crate) fn query_profiling_data(
+        &self,
+        query: &str,
+    ) -> Option<crate::profiling::QueryProfilingData> {
+        self.execution_profiler
+            .query_profiler
+            .query_profiling_data(query)
     }
 
     pub(crate) fn get_property_value_store<E: Entity, P: Property<E>>(
@@ -728,7 +729,7 @@ impl Context {
             #[cfg(feature = "profiling")]
             {
                 crate::profiling::print_profiling_data();
-                crate::profiling::print_query_timings(&self.query_timings_table());
+                crate::profiling::print_query_timings(&self.query_profiling_snapshot());
             }
         } else {
             log_execution_statistics(&stats);

--- a/src/entity/context_extension.rs
+++ b/src/entity/context_extension.rs
@@ -1813,12 +1813,16 @@ mod tests {
 
     #[cfg(feature = "profiling")]
     fn query_count(context: &Context, query: &str) -> Option<usize> {
-        context.query_timing(query).map(|timing| timing.count)
+        context
+            .query_profiling_data(query)
+            .map(|profiling_data| profiling_data.count)
     }
 
     #[cfg(feature = "profiling")]
     fn query_total(context: &Context, query: &str) -> Option<Duration> {
-        context.query_timing(query).map(|timing| timing.total)
+        context
+            .query_profiling_data(query)
+            .map(|profiling_data| profiling_data.total)
     }
 
     #[cfg(feature = "profiling")]
@@ -1871,9 +1875,9 @@ mod tests {
             1
         );
         assert_eq!(query_count(&context, label), Some(1));
-        let timing = context.query_timing(label).unwrap();
-        assert_eq!(timing.min, timing.total);
-        assert_eq!(timing.max, timing.total);
+        let profiling_data = context.query_profiling_data(label).unwrap();
+        assert_eq!(profiling_data.min, profiling_data.total);
+        assert_eq!(profiling_data.max, profiling_data.total);
 
         let mut iter =
             context.query_result_iterator(with!(ProfilingBoundaryPerson, ProfilingBoundaryAge(42)));
@@ -1904,7 +1908,24 @@ mod tests {
 
     #[cfg(feature = "profiling")]
     #[test]
-    fn unused_query_result_iterator_does_not_record_query_timing() {
+    fn count_commits_work_from_a_partially_consumed_iterator_once() {
+        let mut context = Context::new();
+        let person = context
+            .add_entity(with!(ProfilingBoundaryPerson, ProfilingBoundaryAge(42)))
+            .unwrap();
+
+        let label = "ProfilingBoundaryPerson: (ProfilingBoundaryAge)";
+        let mut iter =
+            context.query_result_iterator(with!(ProfilingBoundaryPerson, ProfilingBoundaryAge(42)));
+        assert_eq!(iter.next(), Some(person));
+        assert_eq!(iter.count(), 0);
+
+        assert_eq!(query_count(&context, label), Some(1));
+    }
+
+    #[cfg(feature = "profiling")]
+    #[test]
+    fn unused_query_result_iterator_does_not_record_profiling_data() {
         let mut context = Context::new();
         context
             .add_entity(with!(
@@ -2020,6 +2041,26 @@ mod tests {
         );
 
         assert_eq!(query_count(&context, label), Some(4));
+    }
+
+    #[cfg(feature = "profiling")]
+    #[test]
+    fn to_owned_vec_records_one_execution_without_nested_iterator_timing() {
+        let mut context = Context::new();
+        let person = context
+            .add_entity(with!(ProfilingCallbackPerson, ProfilingCallbackAge(42)))
+            .unwrap();
+        context
+            .add_entity(with!(ProfilingCallbackPerson, ProfilingCallbackAge(7)))
+            .unwrap();
+
+        let label = "ProfilingCallbackPerson: (ProfilingCallbackAge)";
+        let people = context
+            .query(with!(ProfilingCallbackPerson, ProfilingCallbackAge(42)))
+            .to_owned_vec();
+
+        assert_eq!(people, vec![person]);
+        assert_eq!(query_count(&context, label), Some(1));
     }
 
     #[cfg(feature = "profiling")]

--- a/src/entity/context_extension.rs
+++ b/src/entity/context_extension.rs
@@ -15,11 +15,6 @@ use crate::rand::Rng;
 use crate::random::sample_multiple_from_known_length;
 use crate::{warn, Context, ContextRandomExt, ExecutionPhase, IxaError, RngId};
 
-#[cfg(feature = "profiling")]
-fn query_profile_label<E: Entity, Q: Query<E>>(query: &Q) -> &'static str {
-    <Q as crate::entity::QueryInternal<E>>::query_profile_label(query)
-}
-
 fn create_property_index<E, P>(context: &mut Context, requested: PropertyIndexType)
 where
     E: Entity,
@@ -497,14 +492,15 @@ impl ContextEntitiesExt for Context {
         query: Q,
         callback: &mut dyn FnMut(EntitySet<'a, E>),
     ) {
+        let resolved = query.resolved_query();
         #[cfg(feature = "profiling")]
-        let profile = self.query_profile_handle(query_profile_label::<E, Q>(&query));
+        let profile = self.query_profile_handle(resolved.identity);
 
         // The fast path for indexed queries.
         //
         // This mirrors the indexed case in `SourceSet<'a, E>::new()` and
         // `QueryInternal::new_query_result`. The difference is, we access the index set if we find it.
-        if let Some(multi_property_id) = query.multi_property_id() {
+        if let Some(multi_property_id) = resolved.index_property_id {
             let property_store = self.entity_store.get_property_store::<E>();
             let query_parts = query.query_parts();
             let lookup_result = property_store
@@ -550,15 +546,14 @@ impl ContextEntitiesExt for Context {
     }
 
     fn query_entity_count<E: Entity, Q: Query<E>>(&self, query: Q) -> usize {
+        let resolved = query.resolved_query();
         #[cfg(feature = "profiling")]
-        let _query_profile_scope = self
-            .query_profile_handle(query_profile_label::<E, Q>(&query))
-            .scope();
+        let _query_profile_scope = self.query_profile_handle(resolved.identity).scope();
 
         // The fast path for indexed queries.
         //
         // This mirrors the indexed case in `SourceSet<'a, E>::new()` and `QueryInternal::new_query_result`.
-        if let Some(multi_property_id) = query.multi_property_id() {
+        if let Some(multi_property_id) = resolved.index_property_id {
             let property_store = self.entity_store.get_property_store::<E>();
             let query_parts = query.query_parts();
             let lookup_result = property_store
@@ -582,7 +577,7 @@ impl ContextEntitiesExt for Context {
     {
         #[cfg(feature = "profiling")]
         let _query_profile_scope = self
-            .query_profile_handle(query_profile_label::<E, Q>(&query))
+            .query_profile_handle(query.resolved_query().identity)
             .scope();
 
         if query.is_empty_query() {
@@ -614,7 +609,7 @@ impl ContextEntitiesExt for Context {
     {
         #[cfg(feature = "profiling")]
         let _query_profile_scope = self
-            .query_profile_handle(query_profile_label::<E, Q>(&query))
+            .query_profile_handle(query.resolved_query().identity)
             .scope();
 
         if query.is_empty_query() {
@@ -645,7 +640,7 @@ impl ContextEntitiesExt for Context {
     {
         #[cfg(feature = "profiling")]
         let _query_profile_scope = self
-            .query_profile_handle(query_profile_label::<E, Q>(&query))
+            .query_profile_handle(query.resolved_query().identity)
             .scope();
 
         if query.is_empty_query() {
@@ -676,7 +671,7 @@ impl ContextEntitiesExt for Context {
 
     fn query<E: Entity, Q: Query<E>>(&self, query: Q) -> EntitySet<E> {
         #[cfg(feature = "profiling")]
-        let profile = self.query_profile_handle(query_profile_label::<E, Q>(&query));
+        let profile = self.query_profile_handle(query.resolved_query().identity);
         let result = query.new_query_result(self);
         #[cfg(feature = "profiling")]
         let result = result.with_query_profile(profile);
@@ -685,7 +680,7 @@ impl ContextEntitiesExt for Context {
 
     fn query_result_iterator<E: Entity, Q: Query<E>>(&self, query: Q) -> EntitySetIterator<E> {
         #[cfg(feature = "profiling")]
-        let profile = self.query_profile_handle(query_profile_label::<E, Q>(&query));
+        let profile = self.query_profile_handle(query.resolved_query().identity);
         let result = query.new_query_result_iterator(self);
         #[cfg(feature = "profiling")]
         let result = result.with_query_profile(profile);
@@ -695,7 +690,7 @@ impl ContextEntitiesExt for Context {
     fn match_entity<E: Entity, Q: Query<E>>(&self, entity_id: EntityId<E>, query: Q) -> bool {
         #[cfg(feature = "profiling")]
         let _query_profile_scope = self
-            .query_profile_handle(query_profile_label::<E, Q>(&query))
+            .query_profile_handle(query.resolved_query().identity)
             .scope();
         query.match_entity(entity_id, self)
     }
@@ -703,7 +698,7 @@ impl ContextEntitiesExt for Context {
     fn filter_entities<E: Entity, Q: Query<E>>(&self, entities: &mut Vec<EntityId<E>>, query: Q) {
         #[cfg(feature = "profiling")]
         let _query_profile_scope = self
-            .query_profile_handle(query_profile_label::<E, Q>(&query))
+            .query_profile_handle(query.resolved_query().identity)
             .scope();
         query.filter_entities(entities, self);
     }
@@ -714,9 +709,13 @@ mod tests {
     use std::cell::RefCell;
     use std::rc::Rc;
     #[cfg(feature = "profiling")]
+    use std::thread;
+    #[cfg(feature = "profiling")]
     use std::time::Duration;
 
     use super::*;
+    #[cfg(feature = "profiling")]
+    use crate::entity::multi_property::QueryIdentityId;
     use crate::entity::query::QueryInternal;
     use crate::hashing::IndexSet;
     use crate::prelude::PropertyChangeEvent;
@@ -1812,16 +1811,16 @@ mod tests {
     }
 
     #[cfg(feature = "profiling")]
-    fn query_count(context: &Context, query: &str) -> Option<usize> {
+    fn query_count(context: &Context, identity: QueryIdentityId) -> Option<usize> {
         context
-            .query_profiling_data(query)
+            .query_profiling_data(identity)
             .map(|profiling_data| profiling_data.count)
     }
 
     #[cfg(feature = "profiling")]
-    fn query_total(context: &Context, query: &str) -> Option<Duration> {
+    fn query_total(context: &Context, identity: QueryIdentityId) -> Option<Duration> {
         context
-            .query_profiling_data(query)
+            .query_profiling_data(identity)
             .map(|profiling_data| profiling_data.total)
     }
 
@@ -1836,7 +1835,9 @@ mod tests {
             .add_entity(with!(ProfilingPerson, ProfilingAge(7), ProfilingCounty(2)))
             .unwrap();
 
-        let label = "ProfilingPerson: (ProfilingAge, ProfilingCounty)";
+        let identity = with!(ProfilingPerson, ProfilingAge(0), ProfilingCounty(0))
+            .resolved_query()
+            .identity;
         assert_eq!(
             context
                 .query_result_iterator(with!(ProfilingPerson, ProfilingAge(42), ProfilingCounty(1)))
@@ -1856,7 +1857,7 @@ mod tests {
             1
         );
 
-        assert_eq!(query_count(&context, label), Some(3));
+        assert_eq!(query_count(&context, identity), Some(3));
     }
 
     #[cfg(feature = "profiling")]
@@ -1867,26 +1868,28 @@ mod tests {
             .add_entity(with!(ProfilingBoundaryPerson, ProfilingBoundaryAge(42)))
             .unwrap();
 
-        let label = "ProfilingBoundaryPerson: (ProfilingBoundaryAge)";
+        let identity = with!(ProfilingBoundaryPerson, ProfilingBoundaryAge(0))
+            .resolved_query()
+            .identity;
         assert_eq!(
             context
                 .query_result_iterator(with!(ProfilingBoundaryPerson, ProfilingBoundaryAge(42)))
                 .count(),
             1
         );
-        assert_eq!(query_count(&context, label), Some(1));
-        let profiling_data = context.query_profiling_data(label).unwrap();
+        assert_eq!(query_count(&context, identity), Some(1));
+        let profiling_data = context.query_profiling_data(identity).unwrap();
         assert_eq!(profiling_data.min, profiling_data.total);
         assert_eq!(profiling_data.max, profiling_data.total);
 
         let mut iter =
             context.query_result_iterator(with!(ProfilingBoundaryPerson, ProfilingBoundaryAge(42)));
         assert_eq!(iter.next(), Some(person));
-        assert_eq!(query_count(&context, label), Some(1));
+        assert_eq!(query_count(&context, identity), Some(1));
         assert_eq!(iter.next(), None);
-        assert_eq!(query_count(&context, label), Some(2));
+        assert_eq!(query_count(&context, identity), Some(2));
         assert_eq!(iter.next(), None);
-        assert_eq!(query_count(&context, label), Some(2));
+        assert_eq!(query_count(&context, identity), Some(2));
     }
 
     #[cfg(feature = "profiling")]
@@ -1897,13 +1900,15 @@ mod tests {
             .add_entity(with!(ProfilingBoundaryPerson, ProfilingBoundaryAge(42)))
             .unwrap();
 
-        let label = "ProfilingBoundaryPerson: (ProfilingBoundaryAge)";
+        let identity = with!(ProfilingBoundaryPerson, ProfilingBoundaryAge(0))
+            .resolved_query()
+            .identity;
         let mut iter =
             context.query_result_iterator(with!(ProfilingBoundaryPerson, ProfilingBoundaryAge(42)));
         assert_eq!(iter.next(), Some(person));
-        assert_eq!(query_count(&context, label), None);
+        assert_eq!(query_count(&context, identity), None);
         drop(iter);
-        assert_eq!(query_count(&context, label), Some(1));
+        assert_eq!(query_count(&context, identity), Some(1));
     }
 
     #[cfg(feature = "profiling")]
@@ -1914,13 +1919,15 @@ mod tests {
             .add_entity(with!(ProfilingBoundaryPerson, ProfilingBoundaryAge(42)))
             .unwrap();
 
-        let label = "ProfilingBoundaryPerson: (ProfilingBoundaryAge)";
+        let identity = with!(ProfilingBoundaryPerson, ProfilingBoundaryAge(0))
+            .resolved_query()
+            .identity;
         let mut iter =
             context.query_result_iterator(with!(ProfilingBoundaryPerson, ProfilingBoundaryAge(42)));
         assert_eq!(iter.next(), Some(person));
         assert_eq!(iter.count(), 0);
 
-        assert_eq!(query_count(&context, label), Some(1));
+        assert_eq!(query_count(&context, identity), Some(1));
     }
 
     #[cfg(feature = "profiling")]
@@ -1934,14 +1941,16 @@ mod tests {
             ))
             .unwrap();
 
-        let label = "ProfilingUnusedIteratorPerson: (ProfilingUnusedIteratorAge)";
+        let identity = with!(ProfilingUnusedIteratorPerson, ProfilingUnusedIteratorAge(0))
+            .resolved_query()
+            .identity;
         let iter = context.query_result_iterator(with!(
             ProfilingUnusedIteratorPerson,
             ProfilingUnusedIteratorAge(42)
         ));
         drop(iter);
 
-        assert_eq!(query_count(&context, label), None);
+        assert_eq!(query_count(&context, identity), None);
     }
 
     #[cfg(feature = "profiling")]
@@ -1954,7 +1963,9 @@ mod tests {
                 .unwrap();
         }
 
-        let label = "ProfilingIdlePerson: (ProfilingIdleAge)";
+        let identity = with!(ProfilingIdlePerson, ProfilingIdleAge(0))
+            .resolved_query()
+            .identity;
         assert_eq!(
             context
                 .query_result_iterator(with!(ProfilingIdlePerson, ProfilingIdleAge(1)))
@@ -1973,7 +1984,7 @@ mod tests {
             .fold(0usize, |count, _| count + 1);
         assert_eq!(folded, 1);
 
-        assert_eq!(query_count(&context, label), Some(4));
+        assert_eq!(query_count(&context, identity), Some(4));
     }
 
     #[cfg(feature = "profiling")]
@@ -1986,22 +1997,24 @@ mod tests {
                 .unwrap();
         }
 
-        let label = "ProfilingIdlePerson: (ProfilingIdleAge)";
+        let identity = with!(ProfilingIdlePerson, ProfilingIdleAge(0))
+            .resolved_query()
+            .identity;
         context
             .query_result_iterator(with!(ProfilingIdlePerson, ProfilingIdleAge(10)))
-            .for_each(|_| std::thread::sleep(Duration::from_millis(50)));
+            .for_each(|_| thread::sleep(Duration::from_millis(50)));
 
         let folded = context
             .query_result_iterator(with!(ProfilingIdlePerson, ProfilingIdleAge(11)))
             .fold(0usize, |count, _| {
-                std::thread::sleep(Duration::from_millis(50));
+                thread::sleep(Duration::from_millis(50));
                 count + 1
             });
 
         assert_eq!(folded, 1);
-        assert_eq!(query_count(&context, label), Some(2));
+        assert_eq!(query_count(&context, identity), Some(2));
         assert!(
-            query_total(&context, label).unwrap() < Duration::from_millis(50),
+            query_total(&context, identity).unwrap() < Duration::from_millis(50),
             "query timing should exclude callback work"
         );
     }
@@ -2020,14 +2033,16 @@ mod tests {
             .add_entity(with!(ProfilingCallbackPerson, ProfilingCallbackAge(7)))
             .unwrap();
 
-        let label = "ProfilingCallbackPerson: (ProfilingCallbackAge)";
+        let identity = with!(ProfilingCallbackPerson, ProfilingCallbackAge(0))
+            .resolved_query()
+            .identity;
         context.with_query_results(
             with!(ProfilingCallbackPerson, ProfilingCallbackAge(42)),
             &mut |_people| {
-                std::thread::sleep(Duration::from_millis(10));
+                thread::sleep(Duration::from_millis(10));
             },
         );
-        assert_eq!(query_count(&context, label), None);
+        assert_eq!(query_count(&context, identity), None);
 
         context.with_query_results(
             with!(ProfilingCallbackPerson, ProfilingCallbackAge(42)),
@@ -2040,7 +2055,7 @@ mod tests {
             },
         );
 
-        assert_eq!(query_count(&context, label), Some(4));
+        assert_eq!(query_count(&context, identity), Some(4));
     }
 
     #[cfg(feature = "profiling")]
@@ -2054,13 +2069,15 @@ mod tests {
             .add_entity(with!(ProfilingCallbackPerson, ProfilingCallbackAge(7)))
             .unwrap();
 
-        let label = "ProfilingCallbackPerson: (ProfilingCallbackAge)";
+        let identity = with!(ProfilingCallbackPerson, ProfilingCallbackAge(0))
+            .resolved_query()
+            .identity;
         let people = context
             .query(with!(ProfilingCallbackPerson, ProfilingCallbackAge(42)))
             .to_owned_vec();
 
         assert_eq!(people, vec![person]);
-        assert_eq!(query_count(&context, label), Some(1));
+        assert_eq!(query_count(&context, identity), Some(1));
     }
 
     #[cfg(feature = "profiling")]
@@ -2074,7 +2091,9 @@ mod tests {
             .add_entity(with!(ProfilingContainsPerson, ProfilingContainsAge(7)))
             .unwrap();
 
-        let label = "ProfilingContainsPerson: (ProfilingContainsAge)";
+        let identity = with!(ProfilingContainsPerson, ProfilingContainsAge(0))
+            .resolved_query()
+            .identity;
         assert_eq!(
             context.query_entity_count(with!(ProfilingContainsPerson, ProfilingContainsAge(42))),
             1
@@ -2090,7 +2109,7 @@ mod tests {
         );
         assert_eq!(people, vec![person]);
 
-        assert_eq!(query_count(&context, label), Some(3));
+        assert_eq!(query_count(&context, identity), Some(3));
     }
 
     #[cfg(feature = "profiling")]
@@ -2119,6 +2138,9 @@ mod tests {
             ))
             .unwrap();
 
+        let identity = with!(ProfilingComposedPerson, ProfilingComposedAge(0))
+            .resolved_query()
+            .identity;
         let exclusions = EntitySet::from_source(SourceSet::singleton(excluded));
         let count = context
             .query(with!(ProfilingComposedPerson, ProfilingComposedAge(42)))
@@ -2127,10 +2149,7 @@ mod tests {
             .count();
 
         assert_eq!(count, 1);
-        assert_eq!(
-            query_count(&context, "ProfilingComposedPerson: (ProfilingComposedAge)"),
-            Some(1)
-        );
+        assert_eq!(query_count(&context, identity), Some(1));
         assert!(context
             .query(with!(ProfilingComposedPerson, ProfilingComposedAge(42)))
             .difference(EntitySet::from_source(SourceSet::singleton(excluded)))
@@ -2156,6 +2175,9 @@ mod tests {
             ))
             .unwrap();
 
+        let identity = with!(ProfilingComposedPerson, ProfilingComposedAge(0))
+            .resolved_query()
+            .identity;
         let count = context
             .query(with!(ProfilingComposedPerson, ProfilingComposedAge(42)))
             .union(context.query(with!(ProfilingComposedPerson, ProfilingComposedAge(7))))
@@ -2163,10 +2185,7 @@ mod tests {
             .count();
 
         assert_eq!(count, 2);
-        assert_eq!(
-            query_count(&context, "ProfilingComposedPerson: (ProfilingComposedAge)"),
-            Some(1)
-        );
+        assert_eq!(query_count(&context, identity), Some(1));
     }
 
     #[cfg(feature = "profiling")]
@@ -2181,6 +2200,12 @@ mod tests {
             ))
             .unwrap();
 
+        let age_identity = with!(ProfilingComposedPerson, ProfilingComposedAge(0))
+            .resolved_query()
+            .identity;
+        let county_identity = with!(ProfilingComposedPerson, ProfilingComposedCounty(0))
+            .resolved_query()
+            .identity;
         let count = context
             .query(with!(ProfilingComposedPerson, ProfilingComposedAge(42)))
             .intersection(context.query(with!(ProfilingComposedPerson, ProfilingComposedCounty(1))))
@@ -2188,16 +2213,7 @@ mod tests {
             .count();
 
         assert_eq!(count, 1);
-        assert_eq!(
-            query_count(&context, "ProfilingComposedPerson: (ProfilingComposedAge)"),
-            None
-        );
-        assert_eq!(
-            query_count(
-                &context,
-                "ProfilingComposedPerson: (ProfilingComposedCounty)"
-            ),
-            None
-        );
+        assert_eq!(query_count(&context, age_identity), None);
+        assert_eq!(query_count(&context, county_identity), None);
     }
 }

--- a/src/entity/context_extension.rs
+++ b/src/entity/context_extension.rs
@@ -15,6 +15,11 @@ use crate::rand::Rng;
 use crate::random::sample_multiple_from_known_length;
 use crate::{warn, Context, ContextRandomExt, ExecutionPhase, IxaError, RngId};
 
+#[cfg(feature = "profiling")]
+fn query_profile_label<E: Entity, Q: Query<E>>(query: &Q) -> &'static str {
+    <Q as crate::entity::QueryInternal<E>>::query_profile_label(query)
+}
+
 fn create_property_index<E, P>(context: &mut Context, requested: PropertyIndexType)
 where
     E: Entity,
@@ -492,10 +497,13 @@ impl ContextEntitiesExt for Context {
         query: Q,
         callback: &mut dyn FnMut(EntitySet<'a, E>),
     ) {
-        // The fast path for indexed queries.
+        #[cfg(feature = "profiling")]
+        let profile = self.query_profile_handle(query_profile_label::<E, Q>(&query));
 
-        // This mirrors the indexed case in `SourceSet<'a, E>::new()` and `QueryInternal::new_query_result`.
-        // The difference is, we access the index set if we find it.
+        // The fast path for indexed queries.
+        //
+        // This mirrors the indexed case in `SourceSet<'a, E>::new()` and
+        // `QueryInternal::new_query_result`. The difference is, we access the index set if we find it.
         if let Some(multi_property_id) = query.multi_property_id() {
             let property_store = self.entity_store.get_property_store::<E>();
             let query_parts = query.query_parts();
@@ -503,11 +511,17 @@ impl ContextEntitiesExt for Context {
                 .get_index_set_for_query_parts(multi_property_id, query_parts.as_ref());
             match lookup_result {
                 IndexSetResult::Set(people_set) => {
-                    callback(EntitySet::from_source(SourceSet::IndexSet(people_set)));
+                    let result = EntitySet::from_source(SourceSet::IndexSet(people_set));
+                    #[cfg(feature = "profiling")]
+                    let result = result.with_query_profile(profile);
+                    callback(result);
                     return;
                 }
                 IndexSetResult::Empty => {
-                    callback(EntitySet::empty());
+                    let result = EntitySet::empty();
+                    #[cfg(feature = "profiling")]
+                    let result = result.with_query_profile(profile);
+                    callback(result);
                     return;
                 }
                 IndexSetResult::Unsupported => {}
@@ -518,20 +532,29 @@ impl ContextEntitiesExt for Context {
         // Special case a whole-population query.
         if query.is_empty_query() {
             warn!("Called Context::with_query_results() with an empty query. Prefer Context::get_entity_iterator::<E>() for working with the entire population.");
-            callback(EntitySet::from_source(SourceSet::PopulationRange(
-                0..self.get_entity_count::<E>(),
-            )));
+            let result =
+                EntitySet::from_source(SourceSet::PopulationRange(0..self.get_entity_count::<E>()));
+            #[cfg(feature = "profiling")]
+            let result = result.with_query_profile(profile);
+            callback(result);
             return;
         }
 
         // The slow path of computing the full query set.
         warn!("Called Context::with_query_results() with an unindexed query. It's almost always better to use Context::query_result_iterator() for unindexed queries.");
 
-        // Fall back to the query's `EntitySet`.
-        callback(self.query(query));
+        let result = query.new_query_result(self);
+        #[cfg(feature = "profiling")]
+        let result = result.with_query_profile(profile);
+        callback(result);
     }
 
     fn query_entity_count<E: Entity, Q: Query<E>>(&self, query: Q) -> usize {
+        #[cfg(feature = "profiling")]
+        let _query_profile_scope = self
+            .query_profile_handle(query_profile_label::<E, Q>(&query))
+            .scope();
+
         // The fast path for indexed queries.
         //
         // This mirrors the indexed case in `SourceSet<'a, E>::new()` and `QueryInternal::new_query_result`.
@@ -547,8 +570,9 @@ impl ContextEntitiesExt for Context {
             // If the property is not indexed, we fall through.
         }
 
-        self.query_result_iterator(query).count()
+        query.new_query_result_iterator(self).count()
     }
+
     fn sample_entity<E, Q, R>(&self, rng_id: R, query: Q) -> Option<EntityId<E>>
     where
         E: Entity,
@@ -556,6 +580,11 @@ impl ContextEntitiesExt for Context {
         R: RngId + 'static,
         R::RngType: Rng,
     {
+        #[cfg(feature = "profiling")]
+        let _query_profile_scope = self
+            .query_profile_handle(query_profile_label::<E, Q>(&query))
+            .scope();
+
         if query.is_empty_query() {
             let population = self.get_entity_count::<E>();
             return self.sample(rng_id, move |rng| {
@@ -572,7 +601,7 @@ impl ContextEntitiesExt for Context {
             });
         }
 
-        let query_result = self.query(query);
+        let query_result = query.new_query_result(self);
         self.sample(rng_id, move |rng| query_result.sample_entity(rng))
     }
 
@@ -583,6 +612,11 @@ impl ContextEntitiesExt for Context {
         R: RngId + 'static,
         R::RngType: Rng,
     {
+        #[cfg(feature = "profiling")]
+        let _query_profile_scope = self
+            .query_profile_handle(query_profile_label::<E, Q>(&query))
+            .scope();
+
         if query.is_empty_query() {
             let population = self.get_entity_count::<E>();
             return self.sample(rng_id, move |rng| {
@@ -598,7 +632,7 @@ impl ContextEntitiesExt for Context {
             });
         }
 
-        let query_result = self.query(query);
+        let query_result = query.new_query_result(self);
         self.sample(rng_id, move |rng| query_result.count_and_sample_entity(rng))
     }
 
@@ -609,6 +643,11 @@ impl ContextEntitiesExt for Context {
         R: RngId + 'static,
         R::RngType: Rng,
     {
+        #[cfg(feature = "profiling")]
+        let _query_profile_scope = self
+            .query_profile_handle(query_profile_label::<E, Q>(&query))
+            .scope();
+
         if query.is_empty_query() {
             let population = self.get_entity_count::<E>();
             return self.sample(rng_id, move |rng| {
@@ -623,7 +662,7 @@ impl ContextEntitiesExt for Context {
             });
         }
 
-        let query_result = self.query(query);
+        let query_result = query.new_query_result(self);
         self.sample(rng_id, move |rng| query_result.sample_entities(rng, n))
     }
 
@@ -636,18 +675,36 @@ impl ContextEntitiesExt for Context {
     }
 
     fn query<E: Entity, Q: Query<E>>(&self, query: Q) -> EntitySet<E> {
-        query.new_query_result(self)
+        #[cfg(feature = "profiling")]
+        let profile = self.query_profile_handle(query_profile_label::<E, Q>(&query));
+        let result = query.new_query_result(self);
+        #[cfg(feature = "profiling")]
+        let result = result.with_query_profile(profile);
+        result
     }
 
     fn query_result_iterator<E: Entity, Q: Query<E>>(&self, query: Q) -> EntitySetIterator<E> {
-        query.new_query_result_iterator(self)
+        #[cfg(feature = "profiling")]
+        let profile = self.query_profile_handle(query_profile_label::<E, Q>(&query));
+        let result = query.new_query_result_iterator(self);
+        #[cfg(feature = "profiling")]
+        let result = result.with_query_profile(profile);
+        result
     }
 
     fn match_entity<E: Entity, Q: Query<E>>(&self, entity_id: EntityId<E>, query: Q) -> bool {
+        #[cfg(feature = "profiling")]
+        let _query_profile_scope = self
+            .query_profile_handle(query_profile_label::<E, Q>(&query))
+            .scope();
         query.match_entity(entity_id, self)
     }
 
     fn filter_entities<E: Entity, Q: Query<E>>(&self, entities: &mut Vec<EntityId<E>>, query: Q) {
+        #[cfg(feature = "profiling")]
+        let _query_profile_scope = self
+            .query_profile_handle(query_profile_label::<E, Q>(&query))
+            .scope();
         query.filter_entities(entities, self);
     }
 }
@@ -656,6 +713,8 @@ impl ContextEntitiesExt for Context {
 mod tests {
     use std::cell::RefCell;
     use std::rc::Rc;
+    #[cfg(feature = "profiling")]
+    use std::time::Duration;
 
     use super::*;
     use crate::entity::query::QueryInternal;
@@ -673,6 +732,108 @@ mod tests {
     define_entity!(Person);
 
     define_property!(struct Age(u8), Person);
+
+    #[cfg(feature = "profiling")]
+    define_entity!(ProfilingPerson);
+    #[cfg(feature = "profiling")]
+    define_property!(struct ProfilingAge(u8), ProfilingPerson);
+    #[cfg(feature = "profiling")]
+    define_property!(struct ProfilingCounty(u8), ProfilingPerson);
+    #[cfg(feature = "profiling")]
+    define_entity!(ProfilingBoundaryPerson);
+    #[cfg(feature = "profiling")]
+    define_property!(struct ProfilingBoundaryAge(u8), ProfilingBoundaryPerson);
+    #[cfg(feature = "profiling")]
+    define_entity!(ProfilingCallbackPerson);
+    #[cfg(feature = "profiling")]
+    define_property!(struct ProfilingCallbackAge(u8), ProfilingCallbackPerson);
+    #[cfg(feature = "profiling")]
+    define_entity!(ProfilingIdlePerson);
+    #[cfg(feature = "profiling")]
+    define_property!(struct ProfilingIdleAge(u8), ProfilingIdlePerson);
+    #[cfg(feature = "profiling")]
+    define_entity!(ProfilingUnusedIteratorPerson);
+    #[cfg(feature = "profiling")]
+    define_property!(struct ProfilingUnusedIteratorAge(u8), ProfilingUnusedIteratorPerson);
+    #[cfg(feature = "profiling")]
+    define_entity!(ProfilingContainsPerson);
+    #[cfg(feature = "profiling")]
+    define_property!(struct ProfilingContainsAge(u8), ProfilingContainsPerson);
+    #[cfg(feature = "profiling")]
+    define_entity!(ProfilingIndexedCountPerson);
+    #[cfg(feature = "profiling")]
+    define_property!(struct ProfilingIndexedCountAge(u8), ProfilingIndexedCountPerson);
+    #[cfg(feature = "profiling")]
+    define_entity!(ProfilingUnindexedCountPerson);
+    #[cfg(feature = "profiling")]
+    define_property!(
+        struct ProfilingUnindexedCountAge(u8),
+        ProfilingUnindexedCountPerson
+    );
+    #[cfg(feature = "profiling")]
+    define_entity!(ProfilingIndexedIteratorPerson);
+    #[cfg(feature = "profiling")]
+    define_property!(
+        struct ProfilingIndexedIteratorAge(u8),
+        ProfilingIndexedIteratorPerson
+    );
+    #[cfg(feature = "profiling")]
+    define_entity!(ProfilingUnindexedIteratorPerson);
+    #[cfg(feature = "profiling")]
+    define_property!(
+        struct ProfilingUnindexedIteratorAge(u8),
+        ProfilingUnindexedIteratorPerson
+    );
+    #[cfg(feature = "profiling")]
+    define_entity!(ProfilingIndexedWithResultsPerson);
+    #[cfg(feature = "profiling")]
+    define_property!(
+        struct ProfilingIndexedWithResultsAge(u8),
+        ProfilingIndexedWithResultsPerson
+    );
+    #[cfg(feature = "profiling")]
+    define_entity!(ProfilingIndexedMatchPerson);
+    #[cfg(feature = "profiling")]
+    define_property!(
+        struct ProfilingIndexedMatchAge(u8),
+        ProfilingIndexedMatchPerson
+    );
+    #[cfg(feature = "profiling")]
+    define_entity!(ProfilingIndexedFilterPerson);
+    #[cfg(feature = "profiling")]
+    define_property!(
+        struct ProfilingIndexedFilterAge(u8),
+        ProfilingIndexedFilterPerson
+    );
+    #[cfg(feature = "profiling")]
+    define_property!(
+        struct ProfilingIndexedFilterCounty(u8),
+        ProfilingIndexedFilterPerson
+    );
+    #[cfg(feature = "profiling")]
+    define_multi_property!(
+        ProfilingIndexedFilterPerson,
+        (ProfilingIndexedFilterAge, ProfilingIndexedFilterCounty)
+    );
+    #[cfg(feature = "profiling")]
+    define_entity!(ProfilingSingleFilterPerson);
+    #[cfg(feature = "profiling")]
+    define_property!(
+        struct ProfilingSingleFilterAge(u8),
+        ProfilingSingleFilterPerson
+    );
+    #[cfg(feature = "profiling")]
+    define_entity!(ProfilingComposedPerson);
+    #[cfg(feature = "profiling")]
+    define_property!(
+        struct ProfilingComposedAge(u8),
+        ProfilingComposedPerson
+    );
+    #[cfg(feature = "profiling")]
+    define_property!(
+        struct ProfilingComposedCounty(u8),
+        ProfilingComposedPerson
+    );
 
     #[derive(Debug, PartialEq, Eq, Hash, Clone, Copy)]
     struct CounterValue(u8);
@@ -1648,5 +1809,354 @@ mod tests {
 
         assert_eq!(*observed_times.borrow(), vec![-2.0, -1.0, 0.0]);
         assert_eq!(*observed_counts.borrow(), vec![1, 0, 0]);
+    }
+
+    #[cfg(feature = "profiling")]
+    fn query_count(context: &Context, query: &str) -> Option<usize> {
+        context.query_timing(query).map(|timing| timing.count)
+    }
+
+    #[cfg(feature = "profiling")]
+    fn query_total(context: &Context, query: &str) -> Option<Duration> {
+        context.query_timing(query).map(|timing| timing.total)
+    }
+
+    #[cfg(feature = "profiling")]
+    #[test]
+    fn query_identity_aggregates_unordered_properties_and_ignores_values() {
+        let mut context = Context::new();
+        context
+            .add_entity(with!(ProfilingPerson, ProfilingAge(42), ProfilingCounty(1)))
+            .unwrap();
+        context
+            .add_entity(with!(ProfilingPerson, ProfilingAge(7), ProfilingCounty(2)))
+            .unwrap();
+
+        let label = "ProfilingPerson: (ProfilingAge, ProfilingCounty)";
+        assert_eq!(
+            context
+                .query_result_iterator(with!(ProfilingPerson, ProfilingAge(42), ProfilingCounty(1)))
+                .count(),
+            1
+        );
+        assert_eq!(
+            context
+                .query_result_iterator(with!(ProfilingPerson, ProfilingCounty(1), ProfilingAge(42)))
+                .count(),
+            1
+        );
+        assert_eq!(
+            context
+                .query_result_iterator(with!(ProfilingPerson, ProfilingAge(7), ProfilingCounty(2)))
+                .count(),
+            1
+        );
+
+        assert_eq!(query_count(&context, label), Some(3));
+    }
+
+    #[cfg(feature = "profiling")]
+    #[test]
+    fn iterator_consumption_styles_each_record_one_execution() {
+        let mut context = Context::new();
+        let person = context
+            .add_entity(with!(ProfilingBoundaryPerson, ProfilingBoundaryAge(42)))
+            .unwrap();
+
+        let label = "ProfilingBoundaryPerson: (ProfilingBoundaryAge)";
+        assert_eq!(
+            context
+                .query_result_iterator(with!(ProfilingBoundaryPerson, ProfilingBoundaryAge(42)))
+                .count(),
+            1
+        );
+        assert_eq!(query_count(&context, label), Some(1));
+        let timing = context.query_timing(label).unwrap();
+        assert_eq!(timing.min, timing.total);
+        assert_eq!(timing.max, timing.total);
+
+        let mut iter =
+            context.query_result_iterator(with!(ProfilingBoundaryPerson, ProfilingBoundaryAge(42)));
+        assert_eq!(iter.next(), Some(person));
+        assert_eq!(query_count(&context, label), Some(1));
+        assert_eq!(iter.next(), None);
+        assert_eq!(query_count(&context, label), Some(2));
+        assert_eq!(iter.next(), None);
+        assert_eq!(query_count(&context, label), Some(2));
+    }
+
+    #[cfg(feature = "profiling")]
+    #[test]
+    fn partially_consumed_iterator_records_one_execution_when_dropped() {
+        let mut context = Context::new();
+        let person = context
+            .add_entity(with!(ProfilingBoundaryPerson, ProfilingBoundaryAge(42)))
+            .unwrap();
+
+        let label = "ProfilingBoundaryPerson: (ProfilingBoundaryAge)";
+        let mut iter =
+            context.query_result_iterator(with!(ProfilingBoundaryPerson, ProfilingBoundaryAge(42)));
+        assert_eq!(iter.next(), Some(person));
+        assert_eq!(query_count(&context, label), None);
+        drop(iter);
+        assert_eq!(query_count(&context, label), Some(1));
+    }
+
+    #[cfg(feature = "profiling")]
+    #[test]
+    fn unused_query_result_iterator_does_not_record_query_timing() {
+        let mut context = Context::new();
+        context
+            .add_entity(with!(
+                ProfilingUnusedIteratorPerson,
+                ProfilingUnusedIteratorAge(42)
+            ))
+            .unwrap();
+
+        let label = "ProfilingUnusedIteratorPerson: (ProfilingUnusedIteratorAge)";
+        let iter = context.query_result_iterator(with!(
+            ProfilingUnusedIteratorPerson,
+            ProfilingUnusedIteratorAge(42)
+        ));
+        drop(iter);
+
+        assert_eq!(query_count(&context, label), None);
+    }
+
+    #[cfg(feature = "profiling")]
+    #[test]
+    fn iterator_adaptor_methods_record_once_per_direct_call() {
+        let mut context = Context::new();
+        for age in [1, 2, 2, 3] {
+            context
+                .add_entity(with!(ProfilingIdlePerson, ProfilingIdleAge(age)))
+                .unwrap();
+        }
+
+        let label = "ProfilingIdlePerson: (ProfilingIdleAge)";
+        assert_eq!(
+            context
+                .query_result_iterator(with!(ProfilingIdlePerson, ProfilingIdleAge(1)))
+                .count(),
+            1
+        );
+        assert!(context
+            .query_result_iterator(with!(ProfilingIdlePerson, ProfilingIdleAge(2)))
+            .nth(1)
+            .is_some());
+        context
+            .query_result_iterator(with!(ProfilingIdlePerson, ProfilingIdleAge(3)))
+            .for_each(|_| {});
+        let folded = context
+            .query_result_iterator(with!(ProfilingIdlePerson, ProfilingIdleAge(1)))
+            .fold(0usize, |count, _| count + 1);
+        assert_eq!(folded, 1);
+
+        assert_eq!(query_count(&context, label), Some(4));
+    }
+
+    #[cfg(feature = "profiling")]
+    #[test]
+    fn iterator_adaptor_methods_do_not_record_callback_work() {
+        let mut context = Context::new();
+        for age in [10, 11] {
+            context
+                .add_entity(with!(ProfilingIdlePerson, ProfilingIdleAge(age)))
+                .unwrap();
+        }
+
+        let label = "ProfilingIdlePerson: (ProfilingIdleAge)";
+        context
+            .query_result_iterator(with!(ProfilingIdlePerson, ProfilingIdleAge(10)))
+            .for_each(|_| std::thread::sleep(Duration::from_millis(50)));
+
+        let folded = context
+            .query_result_iterator(with!(ProfilingIdlePerson, ProfilingIdleAge(11)))
+            .fold(0usize, |count, _| {
+                std::thread::sleep(Duration::from_millis(50));
+                count + 1
+            });
+
+        assert_eq!(folded, 1);
+        assert_eq!(query_count(&context, label), Some(2));
+        assert!(
+            query_total(&context, label).unwrap() < Duration::from_millis(50),
+            "query timing should exclude callback work"
+        );
+    }
+
+    #[cfg(feature = "profiling")]
+    #[test]
+    fn entity_set_operations_record_once_without_counting_callback_work() {
+        use rand::rngs::StdRng;
+        use rand::SeedableRng;
+
+        let mut context = Context::new();
+        let person = context
+            .add_entity(with!(ProfilingCallbackPerson, ProfilingCallbackAge(42)))
+            .unwrap();
+        context
+            .add_entity(with!(ProfilingCallbackPerson, ProfilingCallbackAge(7)))
+            .unwrap();
+
+        let label = "ProfilingCallbackPerson: (ProfilingCallbackAge)";
+        context.with_query_results(
+            with!(ProfilingCallbackPerson, ProfilingCallbackAge(42)),
+            &mut |_people| {
+                std::thread::sleep(Duration::from_millis(10));
+            },
+        );
+        assert_eq!(query_count(&context, label), None);
+
+        context.with_query_results(
+            with!(ProfilingCallbackPerson, ProfilingCallbackAge(42)),
+            &mut |people| {
+                let mut rng = StdRng::seed_from_u64(1);
+                assert!(people.contains(person));
+                assert!(people.sample_entity(&mut rng).is_some());
+                assert_eq!(people.count_and_sample_entity(&mut rng).0, 1);
+                assert_eq!(people.sample_entities(&mut rng, 1).len(), 1);
+            },
+        );
+
+        assert_eq!(query_count(&context, label), Some(4));
+    }
+
+    #[cfg(feature = "profiling")]
+    #[test]
+    fn eager_public_query_methods_record_once_per_call() {
+        let mut context = Context::new();
+        let person = context
+            .add_entity(with!(ProfilingContainsPerson, ProfilingContainsAge(42)))
+            .unwrap();
+        let other = context
+            .add_entity(with!(ProfilingContainsPerson, ProfilingContainsAge(7)))
+            .unwrap();
+
+        let label = "ProfilingContainsPerson: (ProfilingContainsAge)";
+        assert_eq!(
+            context.query_entity_count(with!(ProfilingContainsPerson, ProfilingContainsAge(42))),
+            1
+        );
+        assert!(context.match_entity(
+            person,
+            with!(ProfilingContainsPerson, ProfilingContainsAge(42))
+        ));
+        let mut people = vec![person, other];
+        context.filter_entities(
+            &mut people,
+            with!(ProfilingContainsPerson, ProfilingContainsAge(42)),
+        );
+        assert_eq!(people, vec![person]);
+
+        assert_eq!(query_count(&context, label), Some(3));
+    }
+
+    #[cfg(feature = "profiling")]
+    #[test]
+    fn composed_entity_set_operation_preserves_single_query_profile() {
+        let mut context = Context::new();
+        let included = context
+            .add_entity(with!(
+                ProfilingComposedPerson,
+                ProfilingComposedAge(42),
+                ProfilingComposedCounty(1)
+            ))
+            .unwrap();
+        let excluded = context
+            .add_entity(with!(
+                ProfilingComposedPerson,
+                ProfilingComposedAge(42),
+                ProfilingComposedCounty(2)
+            ))
+            .unwrap();
+        context
+            .add_entity(with!(
+                ProfilingComposedPerson,
+                ProfilingComposedAge(7),
+                ProfilingComposedCounty(3)
+            ))
+            .unwrap();
+
+        let exclusions = EntitySet::from_source(SourceSet::singleton(excluded));
+        let count = context
+            .query(with!(ProfilingComposedPerson, ProfilingComposedAge(42)))
+            .difference(exclusions)
+            .into_iter()
+            .count();
+
+        assert_eq!(count, 1);
+        assert_eq!(
+            query_count(&context, "ProfilingComposedPerson: (ProfilingComposedAge)"),
+            Some(1)
+        );
+        assert!(context
+            .query(with!(ProfilingComposedPerson, ProfilingComposedAge(42)))
+            .difference(EntitySet::from_source(SourceSet::singleton(excluded)))
+            .contains(included));
+    }
+
+    #[cfg(feature = "profiling")]
+    #[test]
+    fn set_algebra_preserves_a_shared_query_profile() {
+        let mut context = Context::new();
+        context
+            .add_entity(with!(
+                ProfilingComposedPerson,
+                ProfilingComposedAge(42),
+                ProfilingComposedCounty(1)
+            ))
+            .unwrap();
+        context
+            .add_entity(with!(
+                ProfilingComposedPerson,
+                ProfilingComposedAge(7),
+                ProfilingComposedCounty(2)
+            ))
+            .unwrap();
+
+        let count = context
+            .query(with!(ProfilingComposedPerson, ProfilingComposedAge(42)))
+            .union(context.query(with!(ProfilingComposedPerson, ProfilingComposedAge(7))))
+            .into_iter()
+            .count();
+
+        assert_eq!(count, 2);
+        assert_eq!(
+            query_count(&context, "ProfilingComposedPerson: (ProfilingComposedAge)"),
+            Some(1)
+        );
+    }
+
+    #[cfg(feature = "profiling")]
+    #[test]
+    fn set_algebra_clears_distinct_query_profiles() {
+        let mut context = Context::new();
+        context
+            .add_entity(with!(
+                ProfilingComposedPerson,
+                ProfilingComposedAge(42),
+                ProfilingComposedCounty(1)
+            ))
+            .unwrap();
+
+        let count = context
+            .query(with!(ProfilingComposedPerson, ProfilingComposedAge(42)))
+            .intersection(context.query(with!(ProfilingComposedPerson, ProfilingComposedCounty(1))))
+            .into_iter()
+            .count();
+
+        assert_eq!(count, 1);
+        assert_eq!(
+            query_count(&context, "ProfilingComposedPerson: (ProfilingComposedAge)"),
+            None
+        );
+        assert_eq!(
+            query_count(
+                &context,
+                "ProfilingComposedPerson: (ProfilingComposedCounty)"
+            ),
+            None
+        );
     }
 }

--- a/src/entity/context_extension.rs
+++ b/src/entity/context_extension.rs
@@ -568,6 +568,7 @@ impl ContextEntitiesExt for Context {
         query.new_query_result_iterator(self).count()
     }
 
+    #[inline]
     fn sample_entity<E, Q, R>(&self, rng_id: R, query: Q) -> Option<EntityId<E>>
     where
         E: Entity,

--- a/src/entity/entity.rs
+++ b/src/entity/entity.rs
@@ -115,6 +115,15 @@ pub trait Entity: Any + Default {
     #[must_use]
     fn id() -> usize;
 
+    /// Returns the process-local profiling identity for this entity's whole-population query.
+    ///
+    /// This is macro support and is not a stable identifier. Entity implementations generated
+    /// by Ixa macros override it with a per-concrete-type cache.
+    #[doc(hidden)]
+    fn all_query_identity() -> usize {
+        panic!("Entity implementations must be created with define_entity! or impl_entity!")
+    }
+
     /// Creates a new boxed instance of the item.
     #[must_use]
     fn new_boxed() -> Box<Self> {

--- a/src/entity/entity_set/entity_set.rs
+++ b/src/entity/entity_set/entity_set.rs
@@ -24,7 +24,11 @@ use crate::random::{
 };
 
 /// Opaque public wrapper around the internal set-expression tree.
-pub struct EntitySet<'a, E: Entity>(EntitySetInner<'a, E>);
+pub struct EntitySet<'a, E: Entity> {
+    pub(super) inner: EntitySetInner<'a, E>,
+    #[cfg(feature = "profiling")]
+    pub(in crate::entity) query_profile: Option<crate::profiling::QueryProfileHandle<'a>>,
+}
 
 /// Internal set-expression tree used to represent composed query sources.
 pub(super) enum EntitySetInner<'a, E: Entity> {
@@ -36,7 +40,11 @@ pub(super) enum EntitySetInner<'a, E: Entity> {
 
 impl<'a, E: Entity> Clone for EntitySet<'a, E> {
     fn clone(&self) -> Self {
-        Self(self.0.clone())
+        Self {
+            inner: self.inner.clone(),
+            #[cfg(feature = "profiling")]
+            query_profile: self.query_profile,
+        }
     }
 }
 
@@ -58,16 +66,40 @@ impl<'a, E: Entity> Default for EntitySet<'a, E> {
 }
 
 impl<'a, E: Entity> EntitySet<'a, E> {
-    pub(super) fn into_inner(self) -> EntitySetInner<'a, E> {
-        self.0
+    fn new(inner: EntitySetInner<'a, E>) -> Self {
+        Self {
+            inner,
+            #[cfg(feature = "profiling")]
+            query_profile: None,
+        }
+    }
+
+    /// Set algebra retains profiling only when all profiled operands have the
+    /// same query identity. This avoids charging a composed operation to an
+    /// arbitrary query while preserving a single identifiable query origin.
+    #[cfg(feature = "profiling")]
+    fn unique_query_profile(
+        left: &Self,
+        right: &Self,
+    ) -> Option<crate::profiling::QueryProfileHandle<'a>> {
+        match (left.query_profile, right.query_profile) {
+            (Some(left_profile), Some(right_profile))
+                if left_profile.same_query_as(right_profile) =>
+            {
+                Some(left_profile)
+            }
+            (Some(_), Some(_)) => None,
+            (profile @ Some(_), None) | (None, profile @ Some(_)) => profile,
+            (None, None) => None,
+        }
     }
 
     pub(super) fn is_source_leaf(&self) -> bool {
-        matches!(self.0, EntitySetInner::Source(_))
+        matches!(self.inner, EntitySetInner::Source(_))
     }
 
     pub(super) fn into_source_leaf(self) -> Option<SourceSet<'a, E>> {
-        match self.0 {
+        match self.inner {
             EntitySetInner::Source(source) => Some(source),
             _ => None,
         }
@@ -76,12 +108,12 @@ impl<'a, E: Entity> EntitySet<'a, E> {
     /// Create an empty entity set.
     #[must_use]
     pub fn empty() -> Self {
-        EntitySet(EntitySetInner::Source(SourceSet::empty()))
+        Self::new(EntitySetInner::Source(SourceSet::empty()))
     }
 
     /// Create an entity set from a single source set.
     pub(crate) fn from_source(source: SourceSet<'a, E>) -> Self {
-        EntitySet(EntitySetInner::Source(source))
+        Self::new(EntitySetInner::Source(source))
     }
 
     pub(crate) fn from_intersection_sources(mut sources: Vec<SourceSet<'a, E>>) -> Self {
@@ -97,126 +129,212 @@ impl<'a, E: Entity> EntitySet<'a, E> {
 
         let sets = sources.into_iter().map(Self::from_source).collect();
 
-        EntitySet(EntitySetInner::Intersection(sets))
+        Self::new(EntitySetInner::Intersection(sets))
+    }
+
+    #[cfg(feature = "profiling")]
+    #[inline]
+    pub(in crate::entity) fn with_query_profile(
+        mut self,
+        profile: crate::profiling::QueryProfileHandle<'a>,
+    ) -> Self {
+        self.query_profile = Some(profile);
+        self
     }
 
     #[must_use]
     pub fn union(self, other: Self) -> Self {
-        // Idempotence: A ∪ A = A  (same structure over same sources)
-        if self.structurally_eq(&other) {
-            return self;
-        }
-
-        // Adjacent or overlapping intervals
-        if let (Some(a), Some(b)) = (self.as_range(), other.as_range()) {
-            if a.start <= b.end && b.start <= a.end {
-                return Self::from_source(SourceSet::population_range(
-                    a.start.min(b.start)..a.end.max(b.end),
-                ));
-            }
-        }
-
-        // Union with empty set is identity: A ∪ ∅ = ∅ ∪ A = A
-        match (self.is_empty(), other.is_empty()) {
-            (true, _) => return other,
-            (_, true) => return self,
-            _ => { /* pass */ }
-        }
-
-        // Larger set on LHS: more likely to short-circuit `||`.
-        let (left, right) = if self.sort_key() >= other.sort_key() {
-            (self, other)
-        } else {
-            (other, self)
+        let left = self;
+        let right = other;
+        #[cfg(feature = "profiling")]
+        let (left, right, query_profile) = {
+            let query_profile = Self::unique_query_profile(&left, &right);
+            let mut left = left;
+            let mut right = right;
+            left.query_profile = None;
+            right.query_profile = None;
+            (left, right, query_profile)
         };
-        EntitySet(EntitySetInner::Union(Box::new(left), Box::new(right)))
+
+        let result = 'result: {
+            // Idempotence: A ∪ A = A  (same structure over same sources)
+            if left.structurally_eq(&right) {
+                break 'result left;
+            }
+
+            // Adjacent or overlapping intervals
+            if let (Some(a), Some(b)) = (left.as_range(), right.as_range()) {
+                if a.start <= b.end && b.start <= a.end {
+                    break 'result Self::from_source(SourceSet::population_range(
+                        a.start.min(b.start)..a.end.max(b.end),
+                    ));
+                }
+            }
+
+            // Union with empty set is identity: A ∪ ∅ = ∅ ∪ A = A
+            match (left.is_empty(), right.is_empty()) {
+                (true, _) => break 'result right,
+                (_, true) => break 'result left,
+                _ => { /* pass */ }
+            }
+
+            // Larger set on LHS: more likely to short-circuit `||`.
+            let (left, right) = if left.sort_key() >= right.sort_key() {
+                (left, right)
+            } else {
+                (right, left)
+            };
+            break 'result Self::new(EntitySetInner::Union(Box::new(left), Box::new(right)));
+        };
+        #[cfg(feature = "profiling")]
+        let result = {
+            let mut result = result;
+            result.query_profile = query_profile;
+            result
+        };
+        result
     }
 
     #[must_use]
     pub fn intersection(self, other: Self) -> Self {
-        // Idempotence: A ∩ A = A
-        if self.structurally_eq(&other) {
-            return self;
-        }
-
-        // Intersection of overlapping intervals
-        if let (Some(a), Some(b)) = (self.as_range(), other.as_range()) {
-            let overlap = a.start.max(b.start)..a.end.min(b.end);
-            return if overlap.is_empty() {
-                Self::empty()
-            } else {
-                Self::from_source(SourceSet::population_range(overlap))
-            };
-        }
-
-        // Intersection an empty set is empty: A ∩ ∅ = ∅ ∩ A = ∅
-        match (self.is_empty(), other.is_empty()) {
-            (true, _) => return self,
-            (_, true) => return other,
-            _ => { /* pass */ }
-        }
-
-        let mut sets = match self {
-            EntitySet(EntitySetInner::Intersection(sets)) => sets,
-            _ => vec![self],
+        let left = self;
+        let right = other;
+        #[cfg(feature = "profiling")]
+        let (left, right, query_profile) = {
+            let query_profile = Self::unique_query_profile(&left, &right);
+            let mut left = left;
+            let mut right = right;
+            left.query_profile = None;
+            right.query_profile = None;
+            (left, right, query_profile)
         };
 
-        sets.push(other);
-        // Keep intersections sorted smallest-to-largest so iterators can take the
-        // first source as the driver and membership checks short-circuit quickly.
-        sets.sort_unstable_by_key(EntitySet::sort_key);
-        EntitySet(EntitySetInner::Intersection(sets))
+        let result = 'result: {
+            // Idempotence: A ∩ A = A
+            if left.structurally_eq(&right) {
+                break 'result left;
+            }
+
+            // Intersection of overlapping intervals
+            if let (Some(a), Some(b)) = (left.as_range(), right.as_range()) {
+                let overlap = a.start.max(b.start)..a.end.min(b.end);
+                break 'result if overlap.is_empty() {
+                    Self::empty()
+                } else {
+                    Self::from_source(SourceSet::population_range(overlap))
+                };
+            }
+
+            // Intersection an empty set is empty: A ∩ ∅ = ∅ ∩ A = ∅
+            match (left.is_empty(), right.is_empty()) {
+                (true, _) => break 'result left,
+                (_, true) => break 'result right,
+                _ => { /* pass */ }
+            }
+
+            let mut sets = match left {
+                EntitySet {
+                    inner: EntitySetInner::Intersection(sets),
+                    ..
+                } => sets,
+                _ => vec![left],
+            };
+
+            sets.push(right);
+            // Keep intersections sorted smallest-to-largest so iterators can take the
+            // first source as the driver and membership checks short-circuit quickly.
+            sets.sort_unstable_by_key(EntitySet::sort_key);
+            break 'result Self::new(EntitySetInner::Intersection(sets));
+        };
+        #[cfg(feature = "profiling")]
+        let result = {
+            let mut result = result;
+            result.query_profile = query_profile;
+            result
+        };
+        result
     }
 
     #[must_use]
     pub fn difference(self, other: Self) -> Self {
-        // Self-subtraction: A \ A = ∅
-        if self.structurally_eq(&other) {
-            return Self::empty();
-        }
+        let left = self;
+        let right = other;
+        #[cfg(feature = "profiling")]
+        let (left, right, query_profile) = {
+            let query_profile = Self::unique_query_profile(&left, &right);
+            let mut left = left;
+            let mut right = right;
+            left.query_profile = None;
+            right.query_profile = None;
+            (left, right, query_profile)
+        };
 
-        if let (Some(a), Some(b)) = (self.as_range(), other.as_range()) {
-            let overlap = a.start.max(b.start)..a.end.min(b.end);
-            // Disjoint ranges leave the left operand unchanged.
-            if overlap.is_empty() {
-                return Self::from_source(SourceSet::population_range(a));
+        let result = 'result: {
+            // Self-subtraction: A \ A = ∅
+            if left.structurally_eq(&right) {
+                break 'result Self::empty();
             }
-            // A covering subtraction removes the entire left range.
-            if overlap.start == a.start && overlap.end == a.end {
-                return Self::empty();
-            }
-            // Trimming the left edge still leaves one contiguous suffix.
-            if overlap.start == a.start {
-                return Self::from_source(SourceSet::population_range(overlap.end..a.end));
-            }
-            // Trimming the right edge still leaves one contiguous prefix.
-            if overlap.end == a.end {
-                return Self::from_source(SourceSet::population_range(a.start..overlap.start));
-            }
-            // An interior subtraction would split the range, so keep the generic difference node.
-        }
 
-        // Subtraction involving an empty set is identity: A \ ∅ = A, ∅ \ A = ∅
-        if self.is_empty() || other.is_empty() {
-            return self;
-        }
+            if let (Some(a), Some(b)) = (left.as_range(), right.as_range()) {
+                let overlap = a.start.max(b.start)..a.end.min(b.end);
+                // Disjoint ranges leave the left operand unchanged.
+                if overlap.is_empty() {
+                    break 'result Self::from_source(SourceSet::population_range(a));
+                }
+                // A covering subtraction removes the entire left range.
+                if overlap.start == a.start && overlap.end == a.end {
+                    break 'result Self::empty();
+                }
+                // Trimming the left edge still leaves one contiguous suffix.
+                if overlap.start == a.start {
+                    break 'result Self::from_source(SourceSet::population_range(
+                        overlap.end..a.end,
+                    ));
+                }
+                // Trimming the right edge still leaves one contiguous prefix.
+                if overlap.end == a.end {
+                    break 'result Self::from_source(SourceSet::population_range(
+                        a.start..overlap.start,
+                    ));
+                }
+                // An interior subtraction would split the range, so keep the generic difference node.
+            }
 
-        EntitySet(EntitySetInner::Difference(Box::new(self), Box::new(other)))
+            // Subtraction involving an empty set is identity: A \ ∅ = A, ∅ \ A = ∅
+            if left.is_empty() || right.is_empty() {
+                break 'result left;
+            }
+
+            break 'result Self::new(EntitySetInner::Difference(Box::new(left), Box::new(right)));
+        };
+        #[cfg(feature = "profiling")]
+        let result = {
+            let mut result = result;
+            result.query_profile = query_profile;
+            result
+        };
+        result
     }
 
     /// Test whether `entity_id` is a member of this set.
     #[must_use]
     pub fn contains(&self, entity_id: EntityId<E>) -> bool {
-        match self {
-            EntitySet(EntitySetInner::Source(source)) => source.contains(entity_id),
-            EntitySet(EntitySetInner::Union(a, b)) => {
-                a.contains(entity_id) || b.contains(entity_id)
+        #[cfg(feature = "profiling")]
+        let _query_profile_scope = self
+            .query_profile
+            .map(crate::profiling::QueryProfileHandle::scope);
+        self.contains_impl(entity_id)
+    }
+
+    fn contains_impl(&self, entity_id: EntityId<E>) -> bool {
+        match &self.inner {
+            EntitySetInner::Source(source) => source.contains(entity_id),
+            EntitySetInner::Union(a, b) => a.contains_impl(entity_id) || b.contains_impl(entity_id),
+            EntitySetInner::Intersection(sets) => {
+                sets.iter().all(|set| set.contains_impl(entity_id))
             }
-            EntitySet(EntitySetInner::Intersection(sets)) => {
-                sets.iter().all(|set| set.contains(entity_id))
-            }
-            EntitySet(EntitySetInner::Difference(a, b)) => {
-                a.contains(entity_id) && !b.contains(entity_id)
+            EntitySetInner::Difference(a, b) => {
+                a.contains_impl(entity_id) && !b.contains_impl(entity_id)
             }
         }
     }
@@ -241,27 +359,41 @@ impl<'a, E: Entity> EntitySet<'a, E> {
         R: Rng,
         X: Borrow<EntityId<E>>,
     {
+        #[cfg(feature = "profiling")]
+        let _query_profile_scope = self
+            .query_profile
+            .map(crate::profiling::QueryProfileHandle::scope);
+
         let excluded = *excluded.borrow();
-        if let Some(n) = self.try_len() {
+        if let Some(n) = self.try_len_impl() {
             if n == 0 {
-                return None;
+                None
+            } else {
+                let p = rng.random_range(0..n as u32) as usize;
+                match self.try_nth(p) {
+                    Some(candidate) if candidate != excluded => Some(candidate),
+                    Some(_) if n == 1 => None,
+                    Some(_) => {
+                        // `excluded` is at position `p`. Resample from the n-1 remaining
+                        // positions: pick `k` uniform in `[0, n-1)`, then map it around
+                        // the hole at `p`.
+                        let k = rng.random_range(0..(n - 1) as u32) as usize;
+                        let target = if k < p { k } else { k + 1 };
+                        self.try_nth(target)
+                    }
+                    None => None,
+                }
             }
-            let p = rng.random_range(0..n as u32) as usize;
-            let candidate = self.try_nth(p)?;
-            if candidate != excluded {
-                return Some(candidate);
-            }
-            // `excluded` is at position `p`. Resample from the n-1 remaining
-            // positions: pick `k` uniform in `[0, n-1)`, then map it around
-            // the hole at `p`.
-            if n == 1 {
-                return None;
-            }
-            let k = rng.random_range(0..(n - 1) as u32) as usize;
-            let target = if k < p { k } else { k + 1 };
-            return self.try_nth(target);
+        } else {
+            let set = self.clone();
+            #[cfg(feature = "profiling")]
+            let set = {
+                let mut set = set;
+                set.query_profile = None;
+                set
+            };
+            sample_single_excluding_l_reservoir(rng, set, excluded)
         }
-        sample_single_excluding_l_reservoir(rng, self.clone(), excluded)
     }
 
     /// Sample a single entity uniformly from this set. Returns `None` if the
@@ -271,7 +403,12 @@ impl<'a, E: Entity> EntitySet<'a, E> {
     where
         R: Rng,
     {
-        if let Some(n) = self.try_len() {
+        #[cfg(feature = "profiling")]
+        let _query_profile_scope = self
+            .query_profile
+            .map(crate::profiling::QueryProfileHandle::scope);
+
+        if let Some(n) = self.try_len_impl() {
             if n == 0 {
                 warn!("Requested a sample entity from an empty population");
                 return None;
@@ -280,7 +417,14 @@ impl<'a, E: Entity> EntitySet<'a, E> {
             let index = rng.random_range(0..n as u32) as usize;
             return self.try_nth(index);
         }
-        sample_single_l_reservoir(rng, self.clone())
+        let set = self.clone();
+        #[cfg(feature = "profiling")]
+        let set = {
+            let mut set = set;
+            set.query_profile = None;
+            set
+        };
+        sample_single_l_reservoir(rng, set)
     }
 
     /// Count the entities in this set and sample one uniformly from them.
@@ -291,14 +435,26 @@ impl<'a, E: Entity> EntitySet<'a, E> {
     where
         R: Rng,
     {
-        if let Some(n) = self.try_len() {
+        #[cfg(feature = "profiling")]
+        let _query_profile_scope = self
+            .query_profile
+            .map(crate::profiling::QueryProfileHandle::scope);
+
+        if let Some(n) = self.try_len_impl() {
             if n == 0 {
                 return (0, None);
             }
             let index = rng.random_range(0..n as u32) as usize;
             return (n, self.try_nth(index));
         }
-        count_and_sample_single_l_reservoir(rng, self.clone())
+        let set = self.clone();
+        #[cfg(feature = "profiling")]
+        let set = {
+            let mut set = set;
+            set.query_profile = None;
+            set
+        };
+        count_and_sample_single_l_reservoir(rng, set)
     }
 
     /// Sample up to `requested` entities uniformly from this set. If the set
@@ -308,13 +464,36 @@ impl<'a, E: Entity> EntitySet<'a, E> {
     where
         R: Rng,
     {
-        match self.try_len() {
+        #[cfg(feature = "profiling")]
+        let _query_profile_scope = self
+            .query_profile
+            .map(crate::profiling::QueryProfileHandle::scope);
+
+        match self.try_len_impl() {
             Some(0) => {
                 warn!("Requested a sample of entities from an empty population");
                 vec![]
             }
-            Some(_) => sample_multiple_from_known_length(rng, self.clone(), requested),
-            None => sample_multiple_l_reservoir(rng, self.clone(), requested),
+            Some(_) => {
+                let set = self.clone();
+                #[cfg(feature = "profiling")]
+                let set = {
+                    let mut set = set;
+                    set.query_profile = None;
+                    set
+                };
+                sample_multiple_from_known_length(rng, set, requested)
+            }
+            None => {
+                let set = self.clone();
+                #[cfg(feature = "profiling")]
+                let set = {
+                    let mut set = set;
+                    set.query_profile = None;
+                    set
+                };
+                sample_multiple_l_reservoir(rng, set, requested)
+            }
         }
     }
 
@@ -324,42 +503,45 @@ impl<'a, E: Entity> EntitySet<'a, E> {
     /// Composite expressions return `None`.
     #[must_use]
     pub fn try_len(&self) -> Option<usize> {
-        match self {
-            EntitySet(EntitySetInner::Source(source)) => source.try_len(),
+        #[cfg(feature = "profiling")]
+        let _query_profile_scope = self
+            .query_profile
+            .map(crate::profiling::QueryProfileHandle::scope);
+        self.try_len_impl()
+    }
+
+    fn try_len_impl(&self) -> Option<usize> {
+        match &self.inner {
+            EntitySetInner::Source(source) => source.try_len(),
             _ => None,
         }
     }
 
-    /// Random-access lookup. Defined for the same variants as `try_len`.
     fn try_nth(&self, idx: usize) -> Option<EntityId<E>> {
-        match self {
-            EntitySet(EntitySetInner::Source(source)) => source.try_nth(idx),
+        match &self.inner {
+            EntitySetInner::Source(source) => source.try_nth(idx),
             _ => None,
         }
     }
 
     fn as_range(&self) -> Option<Range<usize>> {
-        match self {
-            EntitySet(EntitySetInner::Source(SourceSet::PopulationRange(range))) => {
-                Some(range.clone())
-            }
+        match &self.inner {
+            EntitySetInner::Source(SourceSet::PopulationRange(range)) => Some(range.clone()),
             _ => None,
         }
     }
 
     fn is_empty(&self) -> bool {
-        match self {
-            EntitySet(EntitySetInner::Source(SourceSet::PopulationRange(range))) => {
-                range.is_empty()
-            }
+        match &self.inner {
+            EntitySetInner::Source(SourceSet::PopulationRange(range)) => range.is_empty(),
             _ => false,
         }
     }
 
     fn sort_key(&self) -> (usize, u8) {
-        match self {
-            EntitySet(EntitySetInner::Source(source)) => source.sort_key(),
-            EntitySet(EntitySetInner::Union(left, right)) => {
+        match &self.inner {
+            EntitySetInner::Source(source) => source.sort_key(),
+            EntitySetInner::Union(left, right) => {
                 // Union upper bound is additive; cost hint tracks the cheaper side.
                 let (left_upper, left_hint) = left.sort_key();
                 let (right_upper, right_hint) = right.sort_key();
@@ -368,7 +550,7 @@ impl<'a, E: Entity> EntitySet<'a, E> {
                     left_hint.min(right_hint),
                 )
             }
-            EntitySet(EntitySetInner::Intersection(sets)) => {
+            EntitySetInner::Intersection(sets) => {
                 let mut upper = usize::MAX;
                 let mut hint = 0u8;
                 for set in sets {
@@ -381,7 +563,7 @@ impl<'a, E: Entity> EntitySet<'a, E> {
                 }
                 (upper, hint)
             }
-            EntitySet(EntitySetInner::Difference(left, right)) => {
+            EntitySetInner::Difference(left, right) => {
                 let (left_upper, left_hint) = left.sort_key();
                 let (_, right_hint) = right.sort_key();
                 (left_upper, left_hint.saturating_add(right_hint))
@@ -391,20 +573,13 @@ impl<'a, E: Entity> EntitySet<'a, E> {
 
     /// Structural equality check: same tree shape with same sources at leaves.
     fn structurally_eq(&self, other: &Self) -> bool {
-        match (self, other) {
-            (EntitySet(EntitySetInner::Source(a)), EntitySet(EntitySetInner::Source(b))) => a == b,
-            (
-                EntitySet(EntitySetInner::Union(a1, a2)),
-                EntitySet(EntitySetInner::Union(b1, b2)),
-            )
-            | (
-                EntitySet(EntitySetInner::Difference(a1, a2)),
-                EntitySet(EntitySetInner::Difference(b1, b2)),
-            ) => a1.structurally_eq(b1) && a2.structurally_eq(b2),
-            (
-                EntitySet(EntitySetInner::Intersection(a_sets)),
-                EntitySet(EntitySetInner::Intersection(b_sets)),
-            ) => {
+        match (&self.inner, &other.inner) {
+            (EntitySetInner::Source(a), EntitySetInner::Source(b)) => a == b,
+            (EntitySetInner::Union(a1, a2), EntitySetInner::Union(b1, b2))
+            | (EntitySetInner::Difference(a1, a2), EntitySetInner::Difference(b1, b2)) => {
+                a1.structurally_eq(b1) && a2.structurally_eq(b2)
+            }
+            (EntitySetInner::Intersection(a_sets), EntitySetInner::Intersection(b_sets)) => {
                 a_sets.len() == b_sets.len()
                     && a_sets
                         .iter()
@@ -509,7 +684,7 @@ mod tests {
         );
         assert!(matches!(
             adjacent,
-            EntitySet(EntitySetInner::Source(SourceSet::PopulationRange(ref range))) if range == &(0..6)
+            EntitySet { inner: EntitySetInner::Source(SourceSet::PopulationRange(ref range)), .. } if range == &(0..6)
         ));
 
         let overlapping = EntitySet::from_source(SourceSet::<Person>::population_range(2..6))
@@ -518,14 +693,20 @@ mod tests {
             ));
         assert!(matches!(
             overlapping,
-            EntitySet(EntitySetInner::Source(SourceSet::PopulationRange(ref range))) if range == &(2..8)
+            EntitySet { inner: EntitySetInner::Source(SourceSet::PopulationRange(ref range)), .. } if range == &(2..8)
         ));
 
         let disjoint = EntitySet::from_source(SourceSet::<Person>::singleton(EntityId::new(1)))
             .union(EntitySet::from_source(SourceSet::<Person>::singleton(
                 EntityId::new(4),
             )));
-        assert!(matches!(disjoint, EntitySet(EntitySetInner::Union(_, _))));
+        assert!(matches!(
+            disjoint,
+            EntitySet {
+                inner: EntitySetInner::Union(_, _),
+                ..
+            }
+        ));
     }
 
     #[test]
@@ -536,7 +717,7 @@ mod tests {
             ));
         assert!(matches!(
             overlap,
-            EntitySet(EntitySetInner::Source(SourceSet::PopulationRange(ref range))) if range == &(4..6)
+            EntitySet { inner: EntitySetInner::Source(SourceSet::PopulationRange(ref range)), .. } if range == &(4..6)
         ));
 
         let empty = EntitySet::from_source(SourceSet::<Person>::population_range(1..3))
@@ -545,7 +726,7 @@ mod tests {
             ));
         assert!(matches!(
             empty,
-            EntitySet(EntitySetInner::Source(SourceSet::PopulationRange(ref range))) if range == &(0..0)
+            EntitySet { inner: EntitySetInner::Source(SourceSet::PopulationRange(ref range)), .. } if range == &(0..0)
         ));
 
         let indexed_ids = finite_set(&[1, 2, 3]);
@@ -563,7 +744,7 @@ mod tests {
             ));
         assert!(matches!(
             unchanged,
-            EntitySet(EntitySetInner::Source(SourceSet::PopulationRange(ref range))) if range == &(2..6)
+            EntitySet { inner: EntitySetInner::Source(SourceSet::PopulationRange(ref range)), .. } if range == &(2..6)
         ));
 
         let empty = EntitySet::from_source(SourceSet::<Person>::population_range(2..6)).difference(
@@ -571,7 +752,7 @@ mod tests {
         );
         assert!(matches!(
             empty,
-            EntitySet(EntitySetInner::Source(SourceSet::PopulationRange(ref range))) if range == &(0..0)
+            EntitySet { inner: EntitySetInner::Source(SourceSet::PopulationRange(ref range)), .. } if range == &(0..0)
         ));
 
         let trim_left = EntitySet::from_source(SourceSet::<Person>::population_range(2..6))
@@ -580,7 +761,7 @@ mod tests {
             ));
         assert!(matches!(
             trim_left,
-            EntitySet(EntitySetInner::Source(SourceSet::PopulationRange(ref range))) if range == &(4..6)
+            EntitySet { inner: EntitySetInner::Source(SourceSet::PopulationRange(ref range)), .. } if range == &(4..6)
         ));
 
         let trim_right = EntitySet::from_source(SourceSet::<Person>::population_range(2..6))
@@ -589,13 +770,19 @@ mod tests {
             ));
         assert!(matches!(
             trim_right,
-            EntitySet(EntitySetInner::Source(SourceSet::PopulationRange(ref range))) if range == &(2..4)
+            EntitySet { inner: EntitySetInner::Source(SourceSet::PopulationRange(ref range)), .. } if range == &(2..4)
         ));
 
         let split = EntitySet::from_source(SourceSet::<Person>::population_range(2..8)).difference(
             EntitySet::from_source(SourceSet::<Person>::population_range(4..6)),
         );
-        assert!(matches!(split, EntitySet(EntitySetInner::Difference(_, _))));
+        assert!(matches!(
+            split,
+            EntitySet {
+                inner: EntitySetInner::Difference(_, _),
+                ..
+            }
+        ));
         assert!(split.contains(EntityId::<Person>::new(2)));
         assert!(split.contains(EntityId::<Person>::new(7)));
         assert!(!split.contains(EntityId::<Person>::new(4)));
@@ -783,7 +970,10 @@ mod tests {
 
         assert!(matches!(
             union,
-            EntitySet(EntitySetInner::Source(SourceSet::PropertySet(_)))
+            EntitySet {
+                inner: EntitySetInner::Source(SourceSet::PropertySet(_)),
+                ..
+            }
         ));
         assert_eq!(union.into_iter().collect::<Vec<_>>(), vec![p1, p2]);
     }
@@ -807,7 +997,10 @@ mod tests {
 
         assert!(matches!(
             union,
-            EntitySet(EntitySetInner::Source(SourceSet::PropertySet(_)))
+            EntitySet {
+                inner: EntitySetInner::Source(SourceSet::PropertySet(_)),
+                ..
+            }
         ));
         assert_eq!(union.into_iter().collect::<Vec<_>>(), vec![matching]);
     }

--- a/src/entity/entity_set/entity_set.rs
+++ b/src/entity/entity_set/entity_set.rs
@@ -144,19 +144,19 @@ impl<'a, E: Entity> EntitySet<'a, E> {
 
     #[must_use]
     pub fn union(self, other: Self) -> Self {
-        let left = self;
-        let right = other;
+        // Mutation only happens for profiling feature.
+        #![allow(unused_mut)]
+        let mut left = self;
+        let mut right = other;
         #[cfg(feature = "profiling")]
-        let (left, right, query_profile) = {
-            let query_profile = Self::unique_query_profile(&left, &right);
-            let mut left = left;
-            let mut right = right;
+        let query_profile = Self::unique_query_profile(&left, &right);
+        #[cfg(feature = "profiling")]
+        {
             left.query_profile = None;
             right.query_profile = None;
-            (left, right, query_profile)
-        };
+        }
 
-        let result = 'result: {
+        let mut result = 'result: {
             // Idempotence: A ∪ A = A  (same structure over same sources)
             if left.structurally_eq(&right) {
                 break 'result left;
@@ -187,29 +187,27 @@ impl<'a, E: Entity> EntitySet<'a, E> {
             break 'result Self::new(EntitySetInner::Union(Box::new(left), Box::new(right)));
         };
         #[cfg(feature = "profiling")]
-        let result = {
-            let mut result = result;
+        {
             result.query_profile = query_profile;
-            result
-        };
+        }
         result
     }
 
     #[must_use]
     pub fn intersection(self, other: Self) -> Self {
-        let left = self;
-        let right = other;
+        // Mutation only happens for profiling feature.
+        #![allow(unused_mut)]
+        let mut left = self;
+        let mut right = other;
         #[cfg(feature = "profiling")]
-        let (left, right, query_profile) = {
-            let query_profile = Self::unique_query_profile(&left, &right);
-            let mut left = left;
-            let mut right = right;
+        let query_profile = Self::unique_query_profile(&left, &right);
+        #[cfg(feature = "profiling")]
+        {
             left.query_profile = None;
             right.query_profile = None;
-            (left, right, query_profile)
-        };
+        }
 
-        let result = 'result: {
+        let mut result = 'result: {
             // Idempotence: A ∩ A = A
             if left.structurally_eq(&right) {
                 break 'result left;
@@ -247,29 +245,27 @@ impl<'a, E: Entity> EntitySet<'a, E> {
             break 'result Self::new(EntitySetInner::Intersection(sets));
         };
         #[cfg(feature = "profiling")]
-        let result = {
-            let mut result = result;
+        {
             result.query_profile = query_profile;
-            result
-        };
+        }
         result
     }
 
     #[must_use]
     pub fn difference(self, other: Self) -> Self {
-        let left = self;
-        let right = other;
+        // Mutation only happens for profiling feature.
+        #![allow(unused_mut)]
+        let mut left = self;
+        let mut right = other;
         #[cfg(feature = "profiling")]
-        let (left, right, query_profile) = {
-            let query_profile = Self::unique_query_profile(&left, &right);
-            let mut left = left;
-            let mut right = right;
+        let query_profile = Self::unique_query_profile(&left, &right);
+        #[cfg(feature = "profiling")]
+        {
             left.query_profile = None;
             right.query_profile = None;
-            (left, right, query_profile)
-        };
+        }
 
-        let result = 'result: {
+        let mut result = 'result: {
             // Self-subtraction: A \ A = ∅
             if left.structurally_eq(&right) {
                 break 'result Self::empty();
@@ -308,11 +304,9 @@ impl<'a, E: Entity> EntitySet<'a, E> {
             break 'result Self::new(EntitySetInner::Difference(Box::new(left), Box::new(right)));
         };
         #[cfg(feature = "profiling")]
-        let result = {
-            let mut result = result;
+        {
             result.query_profile = query_profile;
-            result
-        };
+        }
         result
     }
 
@@ -341,7 +335,14 @@ impl<'a, E: Entity> EntitySet<'a, E> {
 
     /// Collect this set's contents into an owned vector of `EntityId<E>`.
     #[must_use]
-    pub fn to_owned_vec(self) -> Vec<EntityId<E>> {
+    #[allow(unused_mut)]
+    pub fn to_owned_vec(mut self) -> Vec<EntityId<E>> {
+        #[cfg(feature = "profiling")]
+        let _query_profile_scope = self
+            .query_profile
+            .take()
+            .map(crate::profiling::QueryProfileHandle::scope);
+
         self.into_iter().collect()
     }
 
@@ -385,13 +386,12 @@ impl<'a, E: Entity> EntitySet<'a, E> {
                 }
             }
         } else {
-            let set = self.clone();
+            #[allow(unused_mut)]
+            let mut set = self.clone();
             #[cfg(feature = "profiling")]
-            let set = {
-                let mut set = set;
+            {
                 set.query_profile = None;
-                set
-            };
+            }
             sample_single_excluding_l_reservoir(rng, set, excluded)
         }
     }
@@ -417,13 +417,12 @@ impl<'a, E: Entity> EntitySet<'a, E> {
             let index = rng.random_range(0..n as u32) as usize;
             return self.try_nth(index);
         }
-        let set = self.clone();
+        #[allow(unused_mut)]
+        let mut set = self.clone();
         #[cfg(feature = "profiling")]
-        let set = {
-            let mut set = set;
+        {
             set.query_profile = None;
-            set
-        };
+        }
         sample_single_l_reservoir(rng, set)
     }
 
@@ -447,13 +446,12 @@ impl<'a, E: Entity> EntitySet<'a, E> {
             let index = rng.random_range(0..n as u32) as usize;
             return (n, self.try_nth(index));
         }
-        let set = self.clone();
+        #[allow(unused_mut)]
+        let mut set = self.clone();
         #[cfg(feature = "profiling")]
-        let set = {
-            let mut set = set;
+        {
             set.query_profile = None;
-            set
-        };
+        }
         count_and_sample_single_l_reservoir(rng, set)
     }
 
@@ -475,23 +473,21 @@ impl<'a, E: Entity> EntitySet<'a, E> {
                 vec![]
             }
             Some(_) => {
-                let set = self.clone();
+                #[allow(unused_mut)]
+                let mut set = self.clone();
                 #[cfg(feature = "profiling")]
-                let set = {
-                    let mut set = set;
+                {
                     set.query_profile = None;
-                    set
-                };
+                }
                 sample_multiple_from_known_length(rng, set, requested)
             }
             None => {
-                let set = self.clone();
+                #[allow(unused_mut)]
+                let mut set = self.clone();
                 #[cfg(feature = "profiling")]
-                let set = {
-                    let mut set = set;
+                {
                     set.query_profile = None;
-                    set
-                };
+                }
                 sample_multiple_l_reservoir(rng, set, requested)
             }
         }

--- a/src/entity/entity_set/entity_set.rs
+++ b/src/entity/entity_set/entity_set.rs
@@ -386,6 +386,7 @@ impl<'a, E: Entity> EntitySet<'a, E> {
     /// Sample a single entity uniformly from this set. Returns `None` if the
     /// set is empty.
     #[must_use]
+    #[inline]
     pub fn sample_entity<R>(&self, rng: &mut R) -> Option<EntityId<E>>
     where
         R: Rng,

--- a/src/entity/entity_set/entity_set.rs
+++ b/src/entity/entity_set/entity_set.rs
@@ -18,6 +18,8 @@ use rand::Rng;
 
 use super::{EntitySetIterator, SourceSet};
 use crate::entity::{Entity, EntityId};
+#[cfg(feature = "profiling")]
+use crate::profiling::QueryProfileHandle;
 use crate::random::{
     count_and_sample_single_l_reservoir, sample_multiple_from_known_length,
     sample_multiple_l_reservoir, sample_single_excluding_l_reservoir, sample_single_l_reservoir,
@@ -27,7 +29,7 @@ use crate::random::{
 pub struct EntitySet<'a, E: Entity> {
     pub(super) inner: EntitySetInner<'a, E>,
     #[cfg(feature = "profiling")]
-    pub(in crate::entity) query_profile: Option<crate::profiling::QueryProfileHandle<'a>>,
+    pub(in crate::entity) query_profile: Option<QueryProfileHandle<'a>>,
 }
 
 /// Internal set-expression tree used to represent composed query sources.
@@ -78,14 +80,9 @@ impl<'a, E: Entity> EntitySet<'a, E> {
     /// same query identity. This avoids charging a composed operation to an
     /// arbitrary query while preserving a single identifiable query origin.
     #[cfg(feature = "profiling")]
-    fn unique_query_profile(
-        left: &Self,
-        right: &Self,
-    ) -> Option<crate::profiling::QueryProfileHandle<'a>> {
+    fn unique_query_profile(left: &Self, right: &Self) -> Option<QueryProfileHandle<'a>> {
         match (left.query_profile, right.query_profile) {
-            (Some(left_profile), Some(right_profile))
-                if left_profile.same_query_as(right_profile) =>
-            {
+            (Some(left_profile), Some(right_profile)) if left_profile == right_profile => {
                 Some(left_profile)
             }
             (Some(_), Some(_)) => None,
@@ -134,10 +131,7 @@ impl<'a, E: Entity> EntitySet<'a, E> {
 
     #[cfg(feature = "profiling")]
     #[inline]
-    pub(in crate::entity) fn with_query_profile(
-        mut self,
-        profile: crate::profiling::QueryProfileHandle<'a>,
-    ) -> Self {
+    pub(in crate::entity) fn with_query_profile(mut self, profile: QueryProfileHandle<'a>) -> Self {
         self.query_profile = Some(profile);
         self
     }
@@ -314,9 +308,7 @@ impl<'a, E: Entity> EntitySet<'a, E> {
     #[must_use]
     pub fn contains(&self, entity_id: EntityId<E>) -> bool {
         #[cfg(feature = "profiling")]
-        let _query_profile_scope = self
-            .query_profile
-            .map(crate::profiling::QueryProfileHandle::scope);
+        let _query_profile_scope = self.query_profile.map(QueryProfileHandle::scope);
         self.contains_impl(entity_id)
     }
 
@@ -338,10 +330,7 @@ impl<'a, E: Entity> EntitySet<'a, E> {
     #[allow(unused_mut)]
     pub fn to_owned_vec(mut self) -> Vec<EntityId<E>> {
         #[cfg(feature = "profiling")]
-        let _query_profile_scope = self
-            .query_profile
-            .take()
-            .map(crate::profiling::QueryProfileHandle::scope);
+        let _query_profile_scope = self.query_profile.take().map(QueryProfileHandle::scope);
 
         self.into_iter().collect()
     }
@@ -361,9 +350,7 @@ impl<'a, E: Entity> EntitySet<'a, E> {
         X: Borrow<EntityId<E>>,
     {
         #[cfg(feature = "profiling")]
-        let _query_profile_scope = self
-            .query_profile
-            .map(crate::profiling::QueryProfileHandle::scope);
+        let _query_profile_scope = self.query_profile.map(QueryProfileHandle::scope);
 
         let excluded = *excluded.borrow();
         if let Some(n) = self.try_len_impl() {
@@ -404,9 +391,7 @@ impl<'a, E: Entity> EntitySet<'a, E> {
         R: Rng,
     {
         #[cfg(feature = "profiling")]
-        let _query_profile_scope = self
-            .query_profile
-            .map(crate::profiling::QueryProfileHandle::scope);
+        let _query_profile_scope = self.query_profile.map(QueryProfileHandle::scope);
 
         if let Some(n) = self.try_len_impl() {
             if n == 0 {
@@ -435,9 +420,7 @@ impl<'a, E: Entity> EntitySet<'a, E> {
         R: Rng,
     {
         #[cfg(feature = "profiling")]
-        let _query_profile_scope = self
-            .query_profile
-            .map(crate::profiling::QueryProfileHandle::scope);
+        let _query_profile_scope = self.query_profile.map(QueryProfileHandle::scope);
 
         if let Some(n) = self.try_len_impl() {
             if n == 0 {
@@ -463,9 +446,7 @@ impl<'a, E: Entity> EntitySet<'a, E> {
         R: Rng,
     {
         #[cfg(feature = "profiling")]
-        let _query_profile_scope = self
-            .query_profile
-            .map(crate::profiling::QueryProfileHandle::scope);
+        let _query_profile_scope = self.query_profile.map(QueryProfileHandle::scope);
 
         match self.try_len_impl() {
             Some(0) => {
@@ -500,9 +481,7 @@ impl<'a, E: Entity> EntitySet<'a, E> {
     #[must_use]
     pub fn try_len(&self) -> Option<usize> {
         #[cfg(feature = "profiling")]
-        let _query_profile_scope = self
-            .query_profile
-            .map(crate::profiling::QueryProfileHandle::scope);
+        let _query_profile_scope = self.query_profile.map(QueryProfileHandle::scope);
         self.try_len_impl()
     }
 

--- a/src/entity/entity_set/entity_set_iterator.rs
+++ b/src/entity/entity_set/entity_set_iterator.rs
@@ -52,7 +52,7 @@ impl<'a, E: Entity> EntitySetIteratorInner<'a, E> {
     }
 
     fn from_entity_set(set: EntitySet<'a, E>) -> Self {
-        match set.into_inner() {
+        match set.inner {
             EntitySetInner::Source(source) => {
                 if source.try_len() == Some(0) {
                     Self::empty_source()
@@ -210,26 +210,70 @@ impl<'a, E: Entity> EntitySetIteratorInner<'a, E> {
             }
         }
     }
+
+    fn count_inner(self) -> usize {
+        match self {
+            Self::Source(source) => source.count(),
+            Self::IntersectionSources {
+                mut driver,
+                filters,
+            } => driver
+                .by_ref()
+                .filter(|&entity_id| filters.iter().all(|filter| filter.contains(entity_id)))
+                .count(),
+            mut other => {
+                let mut count = 0usize;
+                while other.next_inner().is_some() {
+                    count += 1;
+                }
+                count
+            }
+        }
+    }
+
+    fn nth_inner(&mut self, n: usize) -> Option<EntityId<E>> {
+        match self {
+            Self::Source(source) => source.nth(n),
+            Self::IntersectionSources { driver, filters } => driver
+                .by_ref()
+                .filter(|&entity_id| filters.iter().all(|filter| filter.contains(entity_id)))
+                .nth(n),
+            _ => {
+                for _ in 0..n {
+                    self.next_inner()?;
+                }
+                self.next_inner()
+            }
+        }
+    }
 }
 
 /// An iterator over the IDs in an entity set, producing `EntityId<E>`s until exhausted.
 pub struct EntitySetIterator<'c, E: Entity> {
     inner: EntitySetIteratorInner<'c, E>,
+    #[cfg(feature = "profiling")]
+    pub(in crate::entity) query_profile: Option<crate::profiling::QueryExecutionProfile<'c>>,
 }
 
 impl<'c, E: Entity> EntitySetIterator<'c, E> {
-    pub(crate) fn empty() -> EntitySetIterator<'c, E> {
-        EntitySetIterator {
-            inner: EntitySetIteratorInner::empty_source(),
+    fn from_inner(inner: EntitySetIteratorInner<'c, E>) -> Self {
+        Self {
+            inner,
+            #[cfg(feature = "profiling")]
+            query_profile: None,
         }
     }
 
+    pub(crate) fn empty() -> EntitySetIterator<'c, E> {
+        Self::from_inner(EntitySetIteratorInner::empty_source())
+    }
+
     pub(crate) fn from_population_iterator(iter: PopulationIterator<E>) -> Self {
-        EntitySetIterator {
-            inner: EntitySetIteratorInner::Source(SourceIterator::PopulationRange(
-                PopulationRangeIterator::from_population_iterator(iter),
+        Self::from_inner(EntitySetIteratorInner::Source(
+            SourceIterator::PopulationRange(PopulationRangeIterator::from_population_iterator(
+                iter,
             )),
-        }
+        ))
     }
 
     pub(crate) fn from_sources(mut sources: Vec<SourceSet<'c, E>>) -> Self {
@@ -237,9 +281,9 @@ impl<'c, E: Entity> EntitySetIterator<'c, E> {
             return Self::empty();
         }
         if sources.len() == 1 {
-            return EntitySetIterator {
-                inner: EntitySetIteratorInner::Source(sources.pop().unwrap().into_iter()),
-            };
+            return Self::from_inner(EntitySetIteratorInner::Source(
+                sources.pop().unwrap().into_iter(),
+            ));
         }
 
         // This path constructs intersections from raw source vectors, so we sort here.
@@ -247,23 +291,42 @@ impl<'c, E: Entity> EntitySetIterator<'c, E> {
         sources.sort_unstable_by_key(SourceSet::sort_key);
         let mut source_iter = sources.into_iter();
         let driver = source_iter.next().unwrap().into_iter();
-        EntitySetIterator {
-            inner: EntitySetIteratorInner::IntersectionSources {
-                driver,
-                filters: source_iter.collect(),
-            },
-        }
+        Self::from_inner(EntitySetIteratorInner::IntersectionSources {
+            driver,
+            filters: source_iter.collect(),
+        })
     }
 
     pub(crate) fn from_index_set(set: &'c IndexSet<EntityId<E>>) -> EntitySetIterator<'c, E> {
-        EntitySetIterator {
-            inner: EntitySetIteratorInner::Source(SourceSet::IndexSet(set).into_iter()),
-        }
+        Self::from_inner(EntitySetIteratorInner::Source(
+            SourceSet::IndexSet(set).into_iter(),
+        ))
+    }
+
+    #[cfg(feature = "profiling")]
+    #[inline]
+    pub(in crate::entity) fn with_query_profile(
+        mut self,
+        profile: crate::profiling::QueryProfileHandle<'c>,
+    ) -> Self {
+        self.query_profile = Some(crate::profiling::QueryExecutionProfile::new(profile));
+        self
     }
 
     pub(super) fn new(set: EntitySet<'c, E>) -> Self {
-        EntitySetIterator {
+        #[cfg(feature = "profiling")]
+        let (set, query_profile) = {
+            let mut set = set;
+            let query_profile = set
+                .query_profile
+                .take()
+                .map(crate::profiling::QueryExecutionProfile::new);
+            (set, query_profile)
+        };
+        Self {
             inner: EntitySetIteratorInner::from_entity_set(set),
+            #[cfg(feature = "profiling")]
+            query_profile,
         }
     }
 }
@@ -273,6 +336,17 @@ impl<'a, E: Entity> Iterator for EntitySetIterator<'a, E> {
 
     #[inline]
     fn next(&mut self) -> Option<Self::Item> {
+        #[cfg(feature = "profiling")]
+        {
+            let inner = &mut self.inner;
+            if let Some(profile) = &mut self.query_profile {
+                let item = profile.measure(|| inner.next_inner());
+                if item.is_none() {
+                    profile.finish();
+                }
+                return item;
+            }
+        }
         self.inner.next_inner()
     }
 
@@ -282,54 +356,67 @@ impl<'a, E: Entity> Iterator for EntitySetIterator<'a, E> {
     }
 
     fn count(self) -> usize {
-        let EntitySetIterator { inner } = self;
-        match inner {
-            EntitySetIteratorInner::Source(source) => source.count(),
-            EntitySetIteratorInner::IntersectionSources {
-                mut driver,
-                filters,
-            } => driver
-                .by_ref()
-                .filter(|&entity_id| filters.iter().all(|filter| filter.contains(entity_id)))
-                .count(),
-            other => {
-                let mut it = EntitySetIterator { inner: other };
-                let mut n = 0usize;
-                while it.next().is_some() {
-                    n += 1;
-                }
-                n
+        #[cfg(feature = "profiling")]
+        {
+            let Self {
+                inner,
+                mut query_profile,
+            } = self;
+            match &mut query_profile {
+                Some(profile) => profile.measure(|| inner.count_inner()),
+                None => inner.count_inner(),
             }
+        }
+        #[cfg(not(feature = "profiling"))]
+        {
+            self.inner.count_inner()
         }
     }
 
     #[inline]
     fn nth(&mut self, n: usize) -> Option<Self::Item> {
-        match &mut self.inner {
-            EntitySetIteratorInner::Source(source) => source.nth(n),
-            EntitySetIteratorInner::IntersectionSources { driver, filters } => driver
-                .by_ref()
-                .filter(|&entity_id| filters.iter().all(|filter| filter.contains(entity_id)))
-                .nth(n),
-            _ => {
-                for _ in 0..n {
-                    self.next()?;
+        #[cfg(feature = "profiling")]
+        {
+            let inner = &mut self.inner;
+            if let Some(profile) = &mut self.query_profile {
+                let item = profile.measure(|| inner.nth_inner(n));
+                if item.is_none() {
+                    profile.finish();
                 }
-                self.next()
+                return item;
             }
         }
+        self.inner.nth_inner(n)
     }
 
     fn for_each<F>(self, mut f: F)
     where
         F: FnMut(Self::Item),
     {
-        let EntitySetIterator { inner } = self;
+        let EntitySetIterator {
+            inner,
+            #[cfg(feature = "profiling")]
+            query_profile,
+        } = self;
+        #[cfg(feature = "profiling")]
+        let mut inner = inner;
+        #[cfg(feature = "profiling")]
+        if let Some(mut query_profile) = query_profile {
+            loop {
+                let item = query_profile.measure(|| inner.next_inner());
+                let Some(item) = item else {
+                    query_profile.finish();
+                    break;
+                };
+                f(item);
+            }
+            return;
+        }
+
         match inner {
             EntitySetIteratorInner::Source(source) => source.for_each(f),
-            other => {
-                let it = EntitySetIterator { inner: other };
-                for item in it {
+            mut other => {
+                while let Some(item) = other.next_inner() {
                     f(item);
                 }
             }
@@ -340,13 +427,32 @@ impl<'a, E: Entity> Iterator for EntitySetIterator<'a, E> {
     where
         F: FnMut(B, Self::Item) -> B,
     {
-        let EntitySetIterator { inner } = self;
+        let EntitySetIterator {
+            inner,
+            #[cfg(feature = "profiling")]
+            query_profile,
+        } = self;
+        #[cfg(feature = "profiling")]
+        let mut inner = inner;
+        #[cfg(feature = "profiling")]
+        if let Some(mut query_profile) = query_profile {
+            let mut acc = init;
+            loop {
+                let item = query_profile.measure(|| inner.next_inner());
+                let Some(item) = item else {
+                    query_profile.finish();
+                    break;
+                };
+                acc = f(acc, item);
+            }
+            return acc;
+        }
+
         match inner {
             EntitySetIteratorInner::Source(source) => source.fold(init, f),
-            other => {
-                let it = EntitySetIterator { inner: other };
+            mut other => {
                 let mut acc = init;
-                for item in it {
+                while let Some(item) = other.next_inner() {
                     acc = f(acc, item);
                 }
                 acc

--- a/src/entity/entity_set/entity_set_iterator.rs
+++ b/src/entity/entity_set/entity_set_iterator.rs
@@ -210,42 +210,6 @@ impl<'a, E: Entity> EntitySetIteratorInner<'a, E> {
             }
         }
     }
-
-    fn count_inner(self) -> usize {
-        match self {
-            Self::Source(source) => source.count(),
-            Self::IntersectionSources {
-                mut driver,
-                filters,
-            } => driver
-                .by_ref()
-                .filter(|&entity_id| filters.iter().all(|filter| filter.contains(entity_id)))
-                .count(),
-            mut other => {
-                let mut count = 0usize;
-                while other.next_inner().is_some() {
-                    count += 1;
-                }
-                count
-            }
-        }
-    }
-
-    fn nth_inner(&mut self, n: usize) -> Option<EntityId<E>> {
-        match self {
-            Self::Source(source) => source.nth(n),
-            Self::IntersectionSources { driver, filters } => driver
-                .by_ref()
-                .filter(|&entity_id| filters.iter().all(|filter| filter.contains(entity_id)))
-                .nth(n),
-            _ => {
-                for _ in 0..n {
-                    self.next_inner()?;
-                }
-                self.next_inner()
-            }
-        }
-    }
 }
 
 /// An iterator over the IDs in an entity set, producing `EntityId<E>`s until exhausted.
@@ -309,20 +273,17 @@ impl<'c, E: Entity> EntitySetIterator<'c, E> {
         mut self,
         profile: crate::profiling::QueryProfileHandle<'c>,
     ) -> Self {
-        self.query_profile = Some(crate::profiling::QueryExecutionProfile::new(profile));
+        self.query_profile = Some(profile.execution());
         self
     }
 
-    pub(super) fn new(set: EntitySet<'c, E>) -> Self {
+    #[allow(unused_mut)]
+    pub(super) fn new(mut set: EntitySet<'c, E>) -> Self {
         #[cfg(feature = "profiling")]
-        let (set, query_profile) = {
-            let mut set = set;
-            let query_profile = set
-                .query_profile
-                .take()
-                .map(crate::profiling::QueryExecutionProfile::new);
-            (set, query_profile)
-        };
+        let query_profile = set
+            .query_profile
+            .take()
+            .map(crate::profiling::QueryProfileHandle::execution);
         Self {
             inner: EntitySetIteratorInner::from_entity_set(set),
             #[cfg(feature = "profiling")]
@@ -338,9 +299,15 @@ impl<'a, E: Entity> Iterator for EntitySetIterator<'a, E> {
     fn next(&mut self) -> Option<Self::Item> {
         #[cfg(feature = "profiling")]
         {
-            let inner = &mut self.inner;
-            if let Some(profile) = &mut self.query_profile {
-                let item = profile.measure(|| inner.next_inner());
+            let Self {
+                inner,
+                query_profile,
+            } = self;
+            if let Some(profile) = query_profile {
+                let item = {
+                    let _query_execution_scope = profile.scope();
+                    inner.next_inner()
+                };
                 if item.is_none() {
                     profile.finish();
                 }
@@ -356,54 +323,94 @@ impl<'a, E: Entity> Iterator for EntitySetIterator<'a, E> {
     }
 
     fn count(self) -> usize {
+        let Self {
+            inner,
+            #[cfg(feature = "profiling")]
+            mut query_profile,
+        } = self;
+
         #[cfg(feature = "profiling")]
-        {
-            let Self {
-                inner,
-                mut query_profile,
-            } = self;
-            match &mut query_profile {
-                Some(profile) => profile.measure(|| inner.count_inner()),
-                None => inner.count_inner(),
+        let _query_execution_scope = query_profile
+            .as_mut()
+            .and_then(crate::profiling::QueryExecutionProfile::scope);
+
+        match inner {
+            EntitySetIteratorInner::Source(source) => source.count(),
+            EntitySetIteratorInner::IntersectionSources {
+                mut driver,
+                filters,
+            } => driver
+                .by_ref()
+                .filter(|&entity_id| filters.iter().all(|filter| filter.contains(entity_id)))
+                .count(),
+            mut other => {
+                let mut count = 0usize;
+                while other.next_inner().is_some() {
+                    count += 1;
+                }
+                count
             }
-        }
-        #[cfg(not(feature = "profiling"))]
-        {
-            self.inner.count_inner()
         }
     }
 
     #[inline]
     fn nth(&mut self, n: usize) -> Option<Self::Item> {
-        #[cfg(feature = "profiling")]
-        {
-            let inner = &mut self.inner;
-            if let Some(profile) = &mut self.query_profile {
-                let item = profile.measure(|| inner.nth_inner(n));
-                if item.is_none() {
-                    profile.finish();
+        let Self {
+            inner,
+            #[cfg(feature = "profiling")]
+            query_profile,
+        } = self;
+
+        let item = {
+            #[cfg(feature = "profiling")]
+            let _query_execution_scope = query_profile
+                .as_mut()
+                .and_then(crate::profiling::QueryExecutionProfile::scope);
+
+            match inner {
+                EntitySetIteratorInner::Source(source) => source.nth(n),
+                EntitySetIteratorInner::IntersectionSources { driver, filters } => driver
+                    .by_ref()
+                    .filter(|&entity_id| filters.iter().all(|filter| filter.contains(entity_id)))
+                    .nth(n),
+                other => 'item: {
+                    for _ in 0..n {
+                        if other.next_inner().is_none() {
+                            break 'item None;
+                        }
+                    }
+                    break 'item other.next_inner();
                 }
-                return item;
+            }
+        };
+
+        #[cfg(feature = "profiling")]
+        if item.is_none() {
+            if let Some(profile) = query_profile {
+                profile.finish();
             }
         }
-        self.inner.nth_inner(n)
+
+        item
     }
 
     fn for_each<F>(self, mut f: F)
     where
         F: FnMut(Self::Item),
     {
+        #[allow(unused_mut)]
         let EntitySetIterator {
-            inner,
+            mut inner,
             #[cfg(feature = "profiling")]
             query_profile,
         } = self;
         #[cfg(feature = "profiling")]
-        let mut inner = inner;
-        #[cfg(feature = "profiling")]
         if let Some(mut query_profile) = query_profile {
             loop {
-                let item = query_profile.measure(|| inner.next_inner());
+                let item = {
+                    let _query_execution_scope = query_profile.scope();
+                    inner.next_inner()
+                };
                 let Some(item) = item else {
                     query_profile.finish();
                     break;
@@ -427,18 +434,20 @@ impl<'a, E: Entity> Iterator for EntitySetIterator<'a, E> {
     where
         F: FnMut(B, Self::Item) -> B,
     {
+        #[allow(unused_mut)]
         let EntitySetIterator {
-            inner,
+            mut inner,
             #[cfg(feature = "profiling")]
             query_profile,
         } = self;
         #[cfg(feature = "profiling")]
-        let mut inner = inner;
-        #[cfg(feature = "profiling")]
         if let Some(mut query_profile) = query_profile {
             let mut acc = init;
             loop {
-                let item = query_profile.measure(|| inner.next_inner());
+                let item = {
+                    let _query_execution_scope = query_profile.scope();
+                    inner.next_inner()
+                };
                 let Some(item) = item else {
                     query_profile.finish();
                     break;

--- a/src/entity/entity_set/entity_set_iterator.rs
+++ b/src/entity/entity_set/entity_set_iterator.rs
@@ -15,6 +15,8 @@ use crate::entity::entity_set::source_iterator::{PopulationRangeIterator, Source
 use crate::entity::entity_set::source_set::SourceSet;
 use crate::entity::{Entity, EntityId, PopulationIterator};
 use crate::hashing::IndexSet;
+#[cfg(feature = "profiling")]
+use crate::profiling::{QueryExecutionProfile, QueryProfileHandle};
 
 enum EntitySetIteratorInner<'a, E: Entity> {
     Source(SourceIterator<'a, E>),
@@ -216,7 +218,7 @@ impl<'a, E: Entity> EntitySetIteratorInner<'a, E> {
 pub struct EntitySetIterator<'c, E: Entity> {
     inner: EntitySetIteratorInner<'c, E>,
     #[cfg(feature = "profiling")]
-    pub(in crate::entity) query_profile: Option<crate::profiling::QueryExecutionProfile<'c>>,
+    pub(in crate::entity) query_profile: Option<QueryExecutionProfile<'c>>,
 }
 
 impl<'c, E: Entity> EntitySetIterator<'c, E> {
@@ -269,10 +271,7 @@ impl<'c, E: Entity> EntitySetIterator<'c, E> {
 
     #[cfg(feature = "profiling")]
     #[inline]
-    pub(in crate::entity) fn with_query_profile(
-        mut self,
-        profile: crate::profiling::QueryProfileHandle<'c>,
-    ) -> Self {
+    pub(in crate::entity) fn with_query_profile(mut self, profile: QueryProfileHandle<'c>) -> Self {
         self.query_profile = Some(profile.execution());
         self
     }
@@ -280,10 +279,7 @@ impl<'c, E: Entity> EntitySetIterator<'c, E> {
     #[allow(unused_mut)]
     pub(super) fn new(mut set: EntitySet<'c, E>) -> Self {
         #[cfg(feature = "profiling")]
-        let query_profile = set
-            .query_profile
-            .take()
-            .map(crate::profiling::QueryProfileHandle::execution);
+        let query_profile = set.query_profile.take().map(QueryProfileHandle::execution);
         Self {
             inner: EntitySetIteratorInner::from_entity_set(set),
             #[cfg(feature = "profiling")]
@@ -332,7 +328,7 @@ impl<'a, E: Entity> Iterator for EntitySetIterator<'a, E> {
         #[cfg(feature = "profiling")]
         let _query_execution_scope = query_profile
             .as_mut()
-            .and_then(crate::profiling::QueryExecutionProfile::scope);
+            .and_then(QueryExecutionProfile::scope);
 
         match inner {
             EntitySetIteratorInner::Source(source) => source.count(),
@@ -365,7 +361,7 @@ impl<'a, E: Entity> Iterator for EntitySetIterator<'a, E> {
             #[cfg(feature = "profiling")]
             let _query_execution_scope = query_profile
                 .as_mut()
-                .and_then(crate::profiling::QueryExecutionProfile::scope);
+                .and_then(QueryExecutionProfile::scope);
 
             match inner {
                 EntitySetIteratorInner::Source(source) => source.nth(n),

--- a/src/entity/entity_set/source_set.rs
+++ b/src/entity/entity_set/source_set.rs
@@ -306,6 +306,14 @@ impl<'a, E: Entity, P: Property<E>> Iterator for ConcretePropertySource<'a, E, P
         // The population is exhausted.
         None
     }
+
+    #[inline]
+    fn nth(&mut self, n: usize) -> Option<Self::Item> {
+        for _ in 0..n {
+            self.next()?;
+        }
+        self.next()
+    }
 }
 
 /// Represents a concrete source of `EntityId<E>` values used by `EntitySet`.
@@ -532,6 +540,13 @@ mod tests {
             .unwrap()
             .into_iter()
             .collect::<Vec<_>>();
+        {
+            let mut unindexed_iter = SourceSet::<Person>::new::<Age>(Age(2), &context)
+                .unwrap()
+                .into_iter();
+            assert_eq!(unindexed_iter.nth(1), Some(EntityId::new(2)));
+            assert_eq!(unindexed_iter.next(), None);
+        }
 
         context.index_property::<Person, Age>();
         assert!(matches!(

--- a/src/entity/entity_store.rs
+++ b/src/entity/entity_store.rs
@@ -268,6 +268,7 @@ impl EntityStore {
     }
 
     #[must_use]
+    #[inline]
     pub fn get_property_store<E: Entity>(&self) -> &PropertyStore<E> {
         let index = E::id();
         let record = self.items

--- a/src/entity/multi_property.rs
+++ b/src/entity/multi_property.rs
@@ -32,7 +32,6 @@ use std::sync::{LazyLock, Mutex};
 
 #[cfg(feature = "profiling")]
 use crate::entity::property_store::registered_property_name;
-#[cfg(feature = "profiling")]
 use crate::entity::Entity;
 use crate::hashing::{one_shot_128, HashMap, HashValueType};
 use crate::warn;
@@ -51,6 +50,13 @@ struct MultiPropertyId {
 #[cfg(feature = "profiling")]
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
 pub(crate) struct QueryIdentityId(usize);
+
+#[cfg(feature = "profiling")]
+impl QueryIdentityId {
+    pub(crate) const fn from_raw(raw: usize) -> Self {
+        Self(raw)
+    }
+}
 
 #[derive(Clone, Copy, Default)]
 struct QueryShapeRecord {
@@ -199,6 +205,24 @@ pub(crate) fn intern_query_identity<E: Entity>(type_ids: &[TypeId]) -> QueryIden
     registry.labels.push(Box::leak(label.into_boxed_str()));
     registry.shapes.entry(key).or_default().identity = Some(identity);
     identity
+}
+
+/// Returns the raw process-local profiling identity for an entity-scoped query shape.
+///
+/// This function exists for Ixa's exported entity and property macros. The returned value is an
+/// implementation detail and is not stable across processes.
+#[doc(hidden)]
+pub fn intern_query_identity_raw<E: Entity>(type_ids: &[TypeId]) -> usize {
+    #[cfg(feature = "profiling")]
+    {
+        intern_query_identity::<E>(type_ids).0
+    }
+
+    #[cfg(not(feature = "profiling"))]
+    {
+        let _ = type_ids;
+        panic!("query profiling identities require the profiling feature")
+    }
 }
 
 /// Returns the reporting label for a process-local profiling identity.

--- a/src/entity/multi_property.rs
+++ b/src/entity/multi_property.rs
@@ -8,10 +8,10 @@
 //!
 //! To ensure that queries can efficiently find matching indexes, multi-properties that consist
 //! of the same set of component properties are considered equivalent, regardless of their
-//! definition order. Component properties are sorted alphabetically by property name to produce
-//! a canonical identity for that unordered component set. A query with the same component set can
-//! then resolve to the index (if it exists) of an equivalent (multi-)property regardless of the
-//! order client code provides the component values.
+//! definition order. Logical property `TypeId`s are sorted and hashed to produce a canonical
+//! identity for that unordered component set. A query with the same component set can then resolve
+//! to the index (if it exists) of an equivalent (multi-)property regardless of the order client
+//! code provides the component values.
 //!
 //! ## Query Integration
 //!
@@ -30,6 +30,10 @@
 use std::any::TypeId;
 use std::sync::{LazyLock, Mutex};
 
+#[cfg(feature = "profiling")]
+use crate::entity::property_store::registered_property_name;
+#[cfg(feature = "profiling")]
+use crate::entity::Entity;
 use crate::hashing::{one_shot_128, HashMap, HashValueType};
 use crate::warn;
 
@@ -40,17 +44,39 @@ struct MultiPropertyId {
     pub name: &'static str,
 }
 
+/// Process-local identifier for an entity-scoped unordered property set.
+///
+/// The numeric value is an implementation detail and is not stable across
+/// processes.
+#[cfg(feature = "profiling")]
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+pub(crate) struct QueryIdentityId(usize);
+
+#[derive(Clone, Copy, Default)]
+struct QueryShapeRecord {
+    representative: Option<MultiPropertyId>,
+    #[cfg(feature = "profiling")]
+    identity: Option<QueryIdentityId>,
+}
+
+#[derive(Default)]
+struct QueryShapeRegistry {
+    shapes: HashMap<(usize, HashValueType), QueryShapeRecord>,
+    #[cfg(feature = "profiling")]
+    labels: Vec<&'static str>,
+}
+
 enum PreMainDiagnostic {
     Warning(String),
 }
 
-/// A map from an entity-scoped, sorted list of component `TypeId`s to the representative
-/// multi-property ID for that unordered component set.
+/// Metadata for entity-scoped, unordered component-property sets.
 ///
-/// Query tuple lookup uses this to resolve unordered query component sets to the
-/// multi-property index that can satisfy the query.
-static MULTI_PROPERTY_ID_MAP: LazyLock<Mutex<HashMap<(usize, HashValueType), MultiPropertyId>>> =
-    LazyLock::new(|| Mutex::new(HashMap::default()));
+/// Query tuple lookup uses this to resolve a representative multi-property
+/// index. Profiling additionally interns each observed shape to a compact ID
+/// and stores its reporting label here.
+static QUERY_SHAPE_REGISTRY: LazyLock<Mutex<QueryShapeRegistry>> =
+    LazyLock::new(|| Mutex::new(QueryShapeRegistry::default()));
 
 /// A map from an entity-scoped concrete multi-property logical `TypeId` to the representative
 /// multi-property ID for that unordered component set.
@@ -68,15 +94,21 @@ static MULTI_PROPERTY_TYPE_ID_MAP: LazyLock<Mutex<HashMap<(usize, TypeId), Multi
 static PRE_MAIN_DIAGNOSTICS: LazyLock<Mutex<Vec<PreMainDiagnostic>>> =
     LazyLock::new(|| Mutex::new(Vec::new()));
 
+fn query_shape_key(entity_id: usize, type_ids: &[TypeId]) -> (usize, HashValueType) {
+    (entity_id, one_shot_128(&type_ids))
+}
+
 /// Looks up the representative multi-property ID for a sorted list of component `TypeId`s.
 #[must_use]
 pub fn type_ids_to_multi_property_id(entity_id: usize, type_ids: &[TypeId]) -> Option<usize> {
-    let hash = one_shot_128(&type_ids);
-    MULTI_PROPERTY_ID_MAP
+    let key = query_shape_key(entity_id, type_ids);
+    QUERY_SHAPE_REGISTRY
         .lock()
         .unwrap()
-        .get(&(entity_id, hash))
-        .map(|value| value.id)
+        .shapes
+        .get(&key)
+        .and_then(|record| record.representative)
+        .map(|representative| representative.id)
 }
 
 /// Looks up the representative multi-property ID and name for a concrete multi-property
@@ -103,15 +135,15 @@ pub fn register_type_ids_to_multi_property_id(
     id: usize,
     name: &'static str,
 ) -> Option<(usize, &'static str)> {
-    let hash = one_shot_128(&type_ids);
-    let key = (entity_id, hash);
+    let key = query_shape_key(entity_id, type_ids);
     let value = MultiPropertyId { id, name };
     let existing = {
-        let mut map = MULTI_PROPERTY_ID_MAP.lock().unwrap();
-        match map.get(&key).copied() {
+        let mut registry = QUERY_SHAPE_REGISTRY.lock().unwrap();
+        let record = registry.shapes.entry(key).or_default();
+        match record.representative {
             Some(existing) => Some(existing),
             None => {
-                map.insert(key, value);
+                record.representative = Some(value);
                 None
             }
         }
@@ -125,6 +157,62 @@ pub fn register_type_ids_to_multi_property_id(
         .or_insert(representative);
 
     existing.map(|existing| (existing.id, existing.name))
+}
+
+#[cfg(feature = "profiling")]
+fn build_query_identity_label<E: Entity>(type_ids: &[TypeId]) -> String {
+    if type_ids.is_empty() {
+        return format!("{}: All", E::name());
+    }
+
+    let mut names = type_ids
+        .iter()
+        .map(|&type_id| registered_property_name(E::id(), type_id))
+        .collect::<Vec<_>>();
+    names.sort_unstable();
+
+    format!("{}: ({})", E::name(), names.join(", "))
+}
+
+/// Returns the process-local profiling identity for a sorted query shape.
+#[cfg(feature = "profiling")]
+pub(crate) fn intern_query_identity<E: Entity>(type_ids: &[TypeId]) -> QueryIdentityId {
+    let key = query_shape_key(E::id(), type_ids);
+
+    {
+        let registry = QUERY_SHAPE_REGISTRY.lock().unwrap();
+        if let Some(identity) = registry.shapes.get(&key).and_then(|record| record.identity) {
+            return identity;
+        }
+    }
+
+    // Property metadata has its own lock, so build the label without holding
+    // the query-shape registry lock.
+    let label = build_query_identity_label::<E>(type_ids);
+
+    let mut registry = QUERY_SHAPE_REGISTRY.lock().unwrap();
+    if let Some(identity) = registry.shapes.get(&key).and_then(|record| record.identity) {
+        return identity;
+    }
+
+    let identity = QueryIdentityId(registry.labels.len());
+    registry.labels.push(Box::leak(label.into_boxed_str()));
+    registry.shapes.entry(key).or_default().identity = Some(identity);
+    identity
+}
+
+/// Returns the reporting label for a process-local profiling identity.
+#[cfg(feature = "profiling")]
+pub(crate) fn query_identity_label(identity: QueryIdentityId) -> &'static str {
+    QUERY_SHAPE_REGISTRY.lock().unwrap().labels[identity.0]
+}
+
+#[cfg(all(test, feature = "profiling"))]
+pub(crate) fn test_query_identity(label: &'static str) -> QueryIdentityId {
+    let mut registry = QUERY_SHAPE_REGISTRY.lock().unwrap();
+    let identity = QueryIdentityId(registry.labels.len());
+    registry.labels.push(label);
+    identity
 }
 
 #[doc(hidden)]

--- a/src/entity/property.rs
+++ b/src/entity/property.rs
@@ -129,6 +129,15 @@ pub trait Property<E: Entity>: Copy + Debug + PartialEq + 'static {
     #[must_use]
     fn id() -> usize;
 
+    /// Returns the process-local profiling identity for this singleton property query.
+    ///
+    /// This is macro support and is not a stable identifier. Property implementations generated
+    /// by Ixa macros override it with a per-concrete-implementation cache.
+    #[doc(hidden)]
+    fn query_identity_id() -> usize {
+        panic!("Property implementations must be created with an Ixa property macro")
+    }
+
     /// Returns a vector of transitive non-derived dependencies. If the property is not derived, the
     /// Vec will be empty. The dependencies are represented by their `Property<E>::id()` value.
     ///

--- a/src/entity/property_store.rs
+++ b/src/entity/property_store.rs
@@ -75,6 +75,25 @@ where
 static NEXT_PROPERTY_ID: LazyLock<Mutex<HashMap<usize, usize>>> =
     LazyLock::new(|| Mutex::new(HashMap::default()));
 
+/// Entity-scoped names for logical property identities, used to construct
+/// query-profiling labels without query-specific name collection.
+#[cfg(feature = "profiling")]
+static PROPERTY_NAMES: LazyLock<Mutex<HashMap<(usize, TypeId), &'static str>>> =
+    LazyLock::new(|| Mutex::new(HashMap::default()));
+
+#[cfg(feature = "profiling")]
+pub(crate) fn registered_property_name(entity_id: usize, property_type_id: TypeId) -> &'static str {
+    PROPERTY_NAMES
+        .lock()
+        .unwrap()
+        .get(&(entity_id, property_type_id))
+        .unwrap_or_else(|| {
+            panic!(
+                "No registered property name for entity ID {entity_id} and logical property type ID {property_type_id:?}"
+            )
+        })
+}
+
 /// A container struct to hold the (global) metadata for a single property.
 ///
 /// At program startup (before `main()`, using ctors) we compute metadata for all properties
@@ -143,6 +162,19 @@ pub(super) fn get_property_dependents_static<E: Entity>(property_index: usize) -
 pub fn add_to_property_registry<E: Entity, P: Property<E>>() {
     // Ensure the ID of the property type is initialized.
     let property_index = P::id();
+
+    #[cfg(feature = "profiling")]
+    {
+        let key = (E::id(), P::type_id());
+        let mut names = PROPERTY_NAMES.lock().unwrap();
+        if let Some(existing) = names.insert(key, P::name()) {
+            assert_eq!(
+                existing,
+                P::name(),
+                "conflicting names for one logical property identity"
+            );
+        }
+    }
 
     // Registers the property with the entity type.
     register_property_with_entity(

--- a/src/entity/query/mod.rs
+++ b/src/entity/query/mod.rs
@@ -106,6 +106,16 @@ impl<E: Entity, T: QueryInternal<E>> QueryInternal<E> for EntityPropertyTuple<E,
     fn filter_entities(&self, entities: &mut Vec<EntityId<E>>, context: &Context) {
         self.inner.filter_entities(entities, context)
     }
+
+    #[cfg(feature = "profiling")]
+    fn query_profile_label(&self) -> &'static str {
+        self.inner.query_profile_label()
+    }
+
+    #[cfg(feature = "profiling")]
+    fn push_query_property_names(&self, names: &mut Vec<&'static str>) {
+        self.inner.push_query_property_names(names);
+    }
 }
 
 impl<E: Entity, T: PropertyList<E>> PropertyList<E> for EntityPropertyTuple<E, T> {
@@ -195,6 +205,36 @@ pub trait QueryInternal<E: Entity>: 'static {
 
     /// Removes all `EntityId`s from the given vector that do not match this query.
     fn filter_entities(&self, entities: &mut Vec<EntityId<E>>, context: &Context);
+
+    /// Returns a stable profiling identity for this query shape.
+    #[cfg(feature = "profiling")]
+    #[must_use]
+    fn query_profile_label(&self) -> &'static str
+    where
+        Self: Sized,
+    {
+        static REGISTRY: OnceLock<Mutex<HashMap<(TypeId, TypeId), &'static str>>> = OnceLock::new();
+
+        let map = REGISTRY.get_or_init(|| Mutex::new(HashMap::default()));
+        let mut map = map.lock().unwrap();
+        let key = (TypeId::of::<E>(), TypeId::of::<Self>());
+        map.entry(key).or_insert_with(|| {
+            let mut property_names = Vec::new();
+            self.push_query_property_names(&mut property_names);
+            property_names.sort_unstable();
+
+            let label = if property_names.is_empty() {
+                format!("{}: All", E::name())
+            } else {
+                format!("{}: ({})", E::name(), property_names.join(", "))
+            };
+            Box::leak(label.into_boxed_str())
+        })
+    }
+
+    /// Appends property names that identify this query shape.
+    #[cfg(feature = "profiling")]
+    fn push_query_property_names(&self, _names: &mut Vec<&'static str>) {}
 }
 
 /// Values accepted by user-facing query APIs such as
@@ -212,6 +252,8 @@ impl<E: Entity> Query<E> for E {}
 #[cfg(test)]
 mod tests {
 
+    #[cfg(feature = "profiling")]
+    use super::EntityPropertyTuple;
     use super::QueryInternal;
     use crate::prelude::*;
     use crate::{
@@ -296,6 +338,94 @@ mod tests {
         let mut ids = vec![person1, person2];
         <Person as QueryInternal<Person>>::filter_entities(&Person, &mut ids, &context);
         assert_eq!(ids, vec![person1, person2]);
+    }
+
+    #[cfg(feature = "profiling")]
+    #[test]
+    fn empty_query_query_profile_label_is_entity_all() {
+        assert_eq!(
+            <() as QueryInternal<Person>>::query_profile_label(&()),
+            "Person: All"
+        );
+        assert_eq!(
+            <Person as QueryInternal<Person>>::query_profile_label(&Person),
+            "Person: All"
+        );
+    }
+
+    #[cfg(feature = "profiling")]
+    #[test]
+    fn single_property_query_query_profile_label_includes_property_name() {
+        let query = (Age(42),);
+
+        assert_eq!(
+            <(Age,) as QueryInternal<Person>>::query_profile_label(&query),
+            "Person: (Age)"
+        );
+    }
+
+    #[cfg(feature = "profiling")]
+    #[test]
+    fn multi_property_query_query_profile_label_includes_property_names() {
+        let query = (Age(42), County(1));
+
+        assert_eq!(
+            <(Age, County) as QueryInternal<Person>>::query_profile_label(&query),
+            "Person: (Age, County)"
+        );
+
+        let reversed_query = (County(1), Age(42));
+        assert_eq!(
+            <(County, Age) as QueryInternal<Person>>::query_profile_label(&reversed_query),
+            "Person: (Age, County)"
+        );
+    }
+
+    #[cfg(feature = "profiling")]
+    #[test]
+    fn entity_property_tuple_query_profile_label_delegates_to_inner_query() {
+        let query = EntityPropertyTuple::<Person, _>::new((Age(42), County(1)));
+
+        assert_eq!(query.query_profile_label(), "Person: (Age, County)");
+    }
+
+    #[cfg(feature = "profiling")]
+    #[test]
+    fn custom_query_internal_impl_can_use_default_profile_names() {
+        struct CustomQuery;
+
+        impl QueryInternal<Person> for CustomQuery {
+            type QueryParts<'a>
+                = [&'a dyn std::any::Any; 0]
+            where
+                Self: 'a;
+
+            fn get_type_ids(&self) -> Vec<std::any::TypeId> {
+                Vec::new()
+            }
+
+            fn query_parts(&self) -> Self::QueryParts<'_> {
+                []
+            }
+
+            fn new_query_result<'c>(&self, context: &'c Context) -> super::EntitySet<'c, Person> {
+                <() as QueryInternal<Person>>::new_query_result(&(), context)
+            }
+
+            fn match_entity(&self, entity_id: super::EntityId<Person>, context: &Context) -> bool {
+                <() as QueryInternal<Person>>::match_entity(&(), entity_id, context)
+            }
+
+            fn filter_entities(
+                &self,
+                entities: &mut Vec<super::EntityId<Person>>,
+                context: &Context,
+            ) {
+                <() as QueryInternal<Person>>::filter_entities(&(), entities, context);
+            }
+        }
+
+        assert_eq!(CustomQuery.query_profile_label(), "Person: All");
     }
 
     #[test]

--- a/src/entity/query/mod.rs
+++ b/src/entity/query/mod.rs
@@ -6,6 +6,8 @@ use std::sync::{Mutex, OnceLock};
 
 use crate::entity::entity_set::{EntitySet, EntitySetIterator};
 use crate::entity::multi_property::type_ids_to_multi_property_id;
+#[cfg(feature = "profiling")]
+use crate::entity::multi_property::{intern_query_identity, QueryIdentityId};
 use crate::entity::property_list::{PropertyInitializationList, PropertyList};
 use crate::entity::property_store::PropertyStore;
 use crate::entity::Entity;
@@ -83,8 +85,8 @@ impl<E: Entity, T: QueryInternal<E>> QueryInternal<E> for EntityPropertyTuple<E,
         self.inner.get_type_ids()
     }
 
-    fn multi_property_id(&self) -> Option<usize> {
-        self.inner.multi_property_id()
+    fn resolved_query(&self) -> ResolvedQuery {
+        self.inner.resolved_query()
     }
 
     fn is_empty_query(&self) -> bool {
@@ -105,16 +107,6 @@ impl<E: Entity, T: QueryInternal<E>> QueryInternal<E> for EntityPropertyTuple<E,
 
     fn filter_entities(&self, entities: &mut Vec<EntityId<E>>, context: &Context) {
         self.inner.filter_entities(entities, context)
-    }
-
-    #[cfg(feature = "profiling")]
-    fn query_profile_label(&self) -> &'static str {
-        self.inner.query_profile_label()
-    }
-
-    #[cfg(feature = "profiling")]
-    fn push_query_property_names(&self, names: &mut Vec<&'static str>) {
-        self.inner.push_query_property_names(names);
     }
 }
 
@@ -145,6 +137,15 @@ impl<E: Entity, T: PropertyList<E>> PropertyList<E> for EntityPropertyTuple<E, T
 
 impl<E: Entity, PL: PropertyList<E>> PropertyInitializationList<E> for EntityPropertyTuple<E, PL> {}
 
+/// Cached index and profiling resolution for one concrete query type.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[doc(hidden)]
+pub struct ResolvedQuery {
+    pub(crate) index_property_id: Option<usize>,
+    #[cfg(feature = "profiling")]
+    pub(crate) identity: QueryIdentityId,
+}
+
 /// Internal query machinery.
 pub trait QueryInternal<E: Entity>: 'static {
     /// Allocation-free representation of the query parts exposed by this query.
@@ -152,31 +153,50 @@ pub trait QueryInternal<E: Entity>: 'static {
     where
         Self: 'a;
 
-    /// Returns an unordered list of type IDs of the properties in this query.
+    /// Returns an unordered list of registered logical property type IDs for
+    /// this query.
     #[must_use]
     fn get_type_ids(&self) -> Vec<TypeId>;
+
+    /// Resolves the index property for an already sorted query shape without
+    /// consulting the concrete-query cache.
+    fn resolve_index_property_id(&self, type_ids: &[TypeId]) -> Option<usize> {
+        type_ids_to_multi_property_id(E::id(), type_ids)
+    }
+
+    /// Returns the cached index and profiling resolution for this query shape.
+    #[must_use]
+    fn resolved_query(&self) -> ResolvedQuery
+    where
+        Self: Sized,
+    {
+        static REGISTRY: OnceLock<Mutex<HashMap<(usize, TypeId), ResolvedQuery>>> = OnceLock::new();
+
+        let map = REGISTRY.get_or_init(|| Mutex::new(HashMap::default()));
+        let key = (E::id(), TypeId::of::<Self>());
+        if let Some(resolved) = map.lock().unwrap().get(&key).copied() {
+            return resolved;
+        }
+
+        let mut type_ids = self.get_type_ids();
+        type_ids.sort_unstable();
+        let resolved = ResolvedQuery {
+            index_property_id: self.resolve_index_property_id(&type_ids),
+            #[cfg(feature = "profiling")]
+            identity: intern_query_identity::<E>(&type_ids),
+        };
+
+        *map.lock().unwrap().entry(key).or_insert(resolved)
+    }
 
     /// Returns the property ID of the representative multi-property having the properties of
     /// this query, if any.
     #[must_use]
-    fn multi_property_id(&self) -> Option<usize> {
-        #[allow(clippy::type_complexity)]
-        static REGISTRY: OnceLock<Mutex<HashMap<(usize, TypeId), &'static Option<usize>>>> =
-            OnceLock::new();
-
-        let map = REGISTRY.get_or_init(|| Mutex::new(HashMap::default()));
-        let mut map = map.lock().unwrap();
-        let key = (E::id(), TypeId::of::<Self>());
-        let entry = *map.entry(key).or_insert_with(|| {
-            let mut types = self.get_type_ids();
-            types.sort_unstable();
-            Box::leak(Box::new(type_ids_to_multi_property_id(
-                E::id(),
-                types.as_slice(),
-            )))
-        });
-
-        *entry
+    fn multi_property_id(&self) -> Option<usize>
+    where
+        Self: Sized,
+    {
+        self.resolved_query().index_property_id
     }
 
     /// Indicates whether this query matches the entire population for `E`.
@@ -205,36 +225,6 @@ pub trait QueryInternal<E: Entity>: 'static {
 
     /// Removes all `EntityId`s from the given vector that do not match this query.
     fn filter_entities(&self, entities: &mut Vec<EntityId<E>>, context: &Context);
-
-    /// Returns a stable profiling identity for this query shape.
-    #[cfg(feature = "profiling")]
-    #[must_use]
-    fn query_profile_label(&self) -> &'static str
-    where
-        Self: Sized,
-    {
-        static REGISTRY: OnceLock<Mutex<HashMap<(TypeId, TypeId), &'static str>>> = OnceLock::new();
-
-        let map = REGISTRY.get_or_init(|| Mutex::new(HashMap::default()));
-        let mut map = map.lock().unwrap();
-        let key = (TypeId::of::<E>(), TypeId::of::<Self>());
-        map.entry(key).or_insert_with(|| {
-            let mut property_names = Vec::new();
-            self.push_query_property_names(&mut property_names);
-            property_names.sort_unstable();
-
-            let label = if property_names.is_empty() {
-                format!("{}: All", E::name())
-            } else {
-                format!("{}: ({})", E::name(), property_names.join(", "))
-            };
-            Box::leak(label.into_boxed_str())
-        })
-    }
-
-    /// Appends property names that identify this query shape.
-    #[cfg(feature = "profiling")]
-    fn push_query_property_names(&self, _names: &mut Vec<&'static str>) {}
 }
 
 /// Values accepted by user-facing query APIs such as
@@ -251,16 +241,19 @@ impl<E: Entity> Query<E> for E {}
 
 #[cfg(test)]
 mod tests {
-
-    #[cfg(feature = "profiling")]
-    use super::EntityPropertyTuple;
     use super::QueryInternal;
+    #[cfg(feature = "profiling")]
+    use super::{EntityId, EntityPropertyTuple, EntitySet};
+    #[cfg(feature = "profiling")]
+    use crate::entity::multi_property::query_identity_label;
     use crate::prelude::*;
     use crate::{
         define_derived_property, define_entity, define_multi_property, define_property, Context,
     };
 
     define_entity!(Person);
+    #[cfg(feature = "profiling")]
+    define_entity!(Case);
 
     define_property!(struct Age(u8), Person, default_const = Age(0));
     define_property!(struct County(u32), Person, default_const = County(0));
@@ -342,65 +335,85 @@ mod tests {
 
     #[cfg(feature = "profiling")]
     #[test]
-    fn empty_query_query_profile_label_is_entity_all() {
-        assert_eq!(
-            <() as QueryInternal<Person>>::query_profile_label(&()),
-            "Person: All"
-        );
-        assert_eq!(
-            <Person as QueryInternal<Person>>::query_profile_label(&Person),
-            "Person: All"
-        );
+    fn empty_queries_share_entity_all_query_identity() {
+        let empty = <() as QueryInternal<Person>>::resolved_query(&());
+        let entity = <Person as QueryInternal<Person>>::resolved_query(&Person);
+
+        assert_eq!(empty.identity, entity.identity);
+        assert_eq!(query_identity_label(empty.identity), "Person: All");
     }
 
     #[cfg(feature = "profiling")]
     #[test]
-    fn single_property_query_query_profile_label_includes_property_name() {
+    fn entity_type_is_part_of_query_identity() {
+        let person = <Person as QueryInternal<Person>>::resolved_query(&Person);
+        let case = <Case as QueryInternal<Case>>::resolved_query(&Case);
+
+        assert_ne!(person.identity, case.identity);
+    }
+
+    #[cfg(feature = "profiling")]
+    #[test]
+    fn single_property_query_identity_label_includes_property_name() {
         let query = (Age(42),);
+        let resolved = <(Age,) as QueryInternal<Person>>::resolved_query(&query);
 
-        assert_eq!(
-            <(Age,) as QueryInternal<Person>>::query_profile_label(&query),
-            "Person: (Age)"
-        );
+        assert_eq!(query_identity_label(resolved.identity), "Person: (Age)");
     }
 
     #[cfg(feature = "profiling")]
     #[test]
-    fn multi_property_query_query_profile_label_includes_property_names() {
+    fn multi_property_query_identity_ignores_order_and_values() {
         let query = (Age(42), County(1));
+        let resolved = <(Age, County) as QueryInternal<Person>>::resolved_query(&query);
 
         assert_eq!(
-            <(Age, County) as QueryInternal<Person>>::query_profile_label(&query),
+            query_identity_label(resolved.identity),
             "Person: (Age, County)"
         );
 
-        let reversed_query = (County(1), Age(42));
+        let reversed_query = (County(2), Age(20));
+        let reversed = <(County, Age) as QueryInternal<Person>>::resolved_query(&reversed_query);
+        assert_eq!(resolved.identity, reversed.identity);
+        assert_eq!(resolved.index_property_id, reversed.index_property_id);
+    }
+
+    #[cfg(feature = "profiling")]
+    #[test]
+    fn unregistered_multi_property_shape_still_has_an_identity() {
+        let query = (Age(42), Height(70));
+        let resolved = <(Age, Height) as QueryInternal<Person>>::resolved_query(&query);
+
+        assert_eq!(resolved.index_property_id, None);
         assert_eq!(
-            <(County, Age) as QueryInternal<Person>>::query_profile_label(&reversed_query),
-            "Person: (Age, County)"
+            query_identity_label(resolved.identity),
+            "Person: (Age, Height)"
         );
     }
 
     #[cfg(feature = "profiling")]
     #[test]
-    fn entity_property_tuple_query_profile_label_delegates_to_inner_query() {
+    fn entity_property_tuple_delegates_complete_query_resolution() {
         let query = EntityPropertyTuple::<Person, _>::new((Age(42), County(1)));
+        let inner = (Age(20), County(2));
 
-        assert_eq!(query.query_profile_label(), "Person: (Age, County)");
+        assert_eq!(query.resolved_query(), inner.resolved_query());
     }
 
     #[cfg(feature = "profiling")]
     #[test]
     fn custom_query_internal_impl_can_use_default_profile_names() {
+        use std::any::{Any, TypeId};
+
         struct CustomQuery;
 
         impl QueryInternal<Person> for CustomQuery {
             type QueryParts<'a>
-                = [&'a dyn std::any::Any; 0]
+                = [&'a dyn Any; 0]
             where
                 Self: 'a;
 
-            fn get_type_ids(&self) -> Vec<std::any::TypeId> {
+            fn get_type_ids(&self) -> Vec<TypeId> {
                 Vec::new()
             }
 
@@ -408,24 +421,21 @@ mod tests {
                 []
             }
 
-            fn new_query_result<'c>(&self, context: &'c Context) -> super::EntitySet<'c, Person> {
+            fn new_query_result<'c>(&self, context: &'c Context) -> EntitySet<'c, Person> {
                 <() as QueryInternal<Person>>::new_query_result(&(), context)
             }
 
-            fn match_entity(&self, entity_id: super::EntityId<Person>, context: &Context) -> bool {
+            fn match_entity(&self, entity_id: EntityId<Person>, context: &Context) -> bool {
                 <() as QueryInternal<Person>>::match_entity(&(), entity_id, context)
             }
 
-            fn filter_entities(
-                &self,
-                entities: &mut Vec<super::EntityId<Person>>,
-                context: &Context,
-            ) {
+            fn filter_entities(&self, entities: &mut Vec<EntityId<Person>>, context: &Context) {
                 <() as QueryInternal<Person>>::filter_entities(&(), entities, context);
             }
         }
 
-        assert_eq!(CustomQuery.query_profile_label(), "Person: All");
+        let resolved = CustomQuery.resolved_query();
+        assert_eq!(query_identity_label(resolved.identity), "Person: All");
     }
 
     #[test]

--- a/src/entity/query/mod.rs
+++ b/src/entity/query/mod.rs
@@ -339,8 +339,14 @@ mod tests {
         let empty = <() as QueryInternal<Person>>::resolved_query(&());
         let entity = <Person as QueryInternal<Person>>::resolved_query(&Person);
 
+        assert_eq!(empty.index_property_id, None);
+        assert_eq!(entity.index_property_id, None);
         assert_eq!(empty.identity, entity.identity);
         assert_eq!(query_identity_label(empty.identity), "Person: All");
+        assert_eq!(
+            <() as QueryInternal<Person>>::resolved_query(&()).identity,
+            empty.identity
+        );
     }
 
     #[cfg(feature = "profiling")]
@@ -352,13 +358,21 @@ mod tests {
         assert_ne!(person.identity, case.identity);
     }
 
-    #[cfg(feature = "profiling")]
     #[test]
-    fn single_property_query_identity_label_includes_property_name() {
+    fn singleton_query_resolves_direct_property_id() {
         let query = (Age(42),);
         let resolved = <(Age,) as QueryInternal<Person>>::resolved_query(&query);
 
-        assert_eq!(query_identity_label(resolved.identity), "Person: (Age)");
+        assert_eq!(resolved.index_property_id, Some(Age::id()));
+
+        #[cfg(feature = "profiling")]
+        {
+            assert_eq!(
+                resolved.identity,
+                <(Age,) as QueryInternal<Person>>::resolved_query(&(Age(7),)).identity
+            );
+            assert_eq!(query_identity_label(resolved.identity), "Person: (Age)");
+        }
     }
 
     #[cfg(feature = "profiling")]
@@ -435,6 +449,10 @@ mod tests {
         }
 
         let resolved = CustomQuery.resolved_query();
+        assert_eq!(
+            resolved.identity,
+            <Person as QueryInternal<Person>>::resolved_query(&Person).identity
+        );
         assert_eq!(query_identity_label(resolved.identity), "Person: All");
     }
 

--- a/src/entity/query/query_impls.rs
+++ b/src/entity/query/query_impls.rs
@@ -49,6 +49,9 @@ impl<E: Entity> QueryInternal<E> for () {
     fn filter_entities(&self, _entities: &mut Vec<EntityId<E>>, _context: &Context) {
         // Nothing to do.
     }
+
+    #[cfg(feature = "profiling")]
+    fn push_query_property_names(&self, _names: &mut Vec<&'static str>) {}
 }
 
 // An Entity ZST itself is an empty query matching all entities of that type.
@@ -93,6 +96,9 @@ impl<E: Entity> QueryInternal<E> for E {
     fn filter_entities(&self, _entities: &mut Vec<EntityId<E>>, _context: &Context) {
         // Nothing to do.
     }
+
+    #[cfg(feature = "profiling")]
+    fn push_query_property_names(&self, _names: &mut Vec<&'static str>) {}
 }
 
 // Implement the query version with one parameter.
@@ -189,6 +195,11 @@ impl<E: Entity, P1: Property<E>> QueryInternal<E> for (P1,) {
     fn filter_entities(&self, entities: &mut Vec<EntityId<E>>, context: &Context) {
         let property_value_store = context.get_property_value_store::<E, P1>();
         entities.retain(|entity| self.0 == property_value_store.get(*entity));
+    }
+
+    #[cfg(feature = "profiling")]
+    fn push_query_property_names(&self, names: &mut Vec<&'static str>) {
+        names.push(P1::name());
     }
 }
 
@@ -349,6 +360,13 @@ macro_rules! impl_query {
                                 }
                             );
                         }
+                    )*
+                }
+
+                #[cfg(feature = "profiling")]
+                fn push_query_property_names(&self, names: &mut Vec<&'static str>) {
+                    #(
+                        names.push(T~N::name());
                     )*
                 }
             }

--- a/src/entity/query/query_impls.rs
+++ b/src/entity/query/query_impls.rs
@@ -1,4 +1,4 @@
-use std::any::TypeId;
+use std::any::{Any, TypeId};
 
 use seq_macro::seq;
 
@@ -11,16 +11,12 @@ use crate::Context;
 
 impl<E: Entity> QueryInternal<E> for () {
     type QueryParts<'a>
-        = [&'a dyn std::any::Any; 0]
+        = [&'a dyn Any; 0]
     where
         Self: 'a;
 
     fn get_type_ids(&self) -> Vec<TypeId> {
         Vec::new()
-    }
-
-    fn multi_property_id(&self) -> Option<usize> {
-        None
     }
 
     fn is_empty_query(&self) -> bool {
@@ -49,25 +45,18 @@ impl<E: Entity> QueryInternal<E> for () {
     fn filter_entities(&self, _entities: &mut Vec<EntityId<E>>, _context: &Context) {
         // Nothing to do.
     }
-
-    #[cfg(feature = "profiling")]
-    fn push_query_property_names(&self, _names: &mut Vec<&'static str>) {}
 }
 
 // An Entity ZST itself is an empty query matching all entities of that type.
 // This allows `context.sample_entity(Rng, Person)` instead of `context.sample_entity(Rng, ())`.
 impl<E: Entity> QueryInternal<E> for E {
     type QueryParts<'a>
-        = [&'a dyn std::any::Any; 0]
+        = [&'a dyn Any; 0]
     where
         Self: 'a;
 
     fn get_type_ids(&self) -> Vec<TypeId> {
         Vec::new()
-    }
-
-    fn multi_property_id(&self) -> Option<usize> {
-        None
     }
 
     fn is_empty_query(&self) -> bool {
@@ -96,9 +85,6 @@ impl<E: Entity> QueryInternal<E> for E {
     fn filter_entities(&self, _entities: &mut Vec<EntityId<E>>, _context: &Context) {
         // Nothing to do.
     }
-
-    #[cfg(feature = "profiling")]
-    fn push_query_property_names(&self, _names: &mut Vec<&'static str>) {}
 }
 
 // Implement the query version with one parameter.
@@ -112,7 +98,7 @@ impl<E: Entity, P1: Property<E>> QueryInternal<E> for (P1,) {
         vec![P1::type_id()]
     }
 
-    fn multi_property_id(&self) -> Option<usize> {
+    fn resolve_index_property_id(&self, _type_ids: &[TypeId]) -> Option<usize> {
         Some(P1::id())
     }
 
@@ -195,11 +181,6 @@ impl<E: Entity, P1: Property<E>> QueryInternal<E> for (P1,) {
     fn filter_entities(&self, entities: &mut Vec<EntityId<E>>, context: &Context) {
         let property_value_store = context.get_property_value_store::<E, P1>();
         entities.retain(|entity| self.0 == property_value_store.get(*entity));
-    }
-
-    #[cfg(feature = "profiling")]
-    fn push_query_property_names(&self, names: &mut Vec<&'static str>) {
-        names.push(P1::name());
     }
 }
 
@@ -363,12 +344,6 @@ macro_rules! impl_query {
                     )*
                 }
 
-                #[cfg(feature = "profiling")]
-                fn push_query_property_names(&self, names: &mut Vec<&'static str>) {
-                    #(
-                        names.push(T~N::name());
-                    )*
-                }
             }
         });
     }

--- a/src/entity/query/query_impls.rs
+++ b/src/entity/query/query_impls.rs
@@ -4,8 +4,10 @@ use seq_macro::seq;
 
 use crate::entity::entity_set::{EntitySet, EntitySetIterator, SourceSet};
 use crate::entity::index::IndexSetResult;
+#[cfg(feature = "profiling")]
+use crate::entity::multi_property::QueryIdentityId;
 use crate::entity::property::Property;
-use crate::entity::query::QueryInternal;
+use crate::entity::query::{QueryInternal, ResolvedQuery};
 use crate::entity::{ContextEntitiesExt, Entity, EntityId};
 use crate::Context;
 
@@ -17,6 +19,14 @@ impl<E: Entity> QueryInternal<E> for () {
 
     fn get_type_ids(&self) -> Vec<TypeId> {
         Vec::new()
+    }
+
+    fn resolved_query(&self) -> ResolvedQuery {
+        ResolvedQuery {
+            index_property_id: None,
+            #[cfg(feature = "profiling")]
+            identity: QueryIdentityId::from_raw(E::all_query_identity()),
+        }
     }
 
     fn is_empty_query(&self) -> bool {
@@ -59,6 +69,14 @@ impl<E: Entity> QueryInternal<E> for E {
         Vec::new()
     }
 
+    fn resolved_query(&self) -> ResolvedQuery {
+        ResolvedQuery {
+            index_property_id: None,
+            #[cfg(feature = "profiling")]
+            identity: QueryIdentityId::from_raw(E::all_query_identity()),
+        }
+    }
+
     fn is_empty_query(&self) -> bool {
         true
     }
@@ -98,8 +116,12 @@ impl<E: Entity, P1: Property<E>> QueryInternal<E> for (P1,) {
         vec![P1::type_id()]
     }
 
-    fn resolve_index_property_id(&self, _type_ids: &[TypeId]) -> Option<usize> {
-        Some(P1::id())
+    fn resolved_query(&self) -> ResolvedQuery {
+        ResolvedQuery {
+            index_property_id: Some(P1::id()),
+            #[cfg(feature = "profiling")]
+            identity: QueryIdentityId::from_raw(P1::query_identity_id()),
+        }
     }
 
     fn query_parts(&self) -> Self::QueryParts<'_> {

--- a/src/execution_stats.rs
+++ b/src/execution_stats.rs
@@ -12,6 +12,9 @@ use sysinfo::{Pid, ProcessRefreshKind, ProcessesToUpdate, System};
 #[cfg(target_arch = "wasm32")]
 use wasm_bindgen::prelude::*;
 
+#[cfg(feature = "profiling")]
+use crate::profiling::QueryProfiler;
+
 #[cfg(target_arch = "wasm32")]
 #[wasm_bindgen]
 #[must_use]
@@ -48,7 +51,7 @@ const REFRESH_INTERVAL: Duration = Duration::from_secs(1);
 #[cfg_attr(target_arch = "wasm32", allow(dead_code))]
 pub(crate) struct ExecutionProfilingCollector {
     /// Aggregate profiling data for entity queries executed by this context.
-    pub(crate) query_profiler: crate::profiling::QueryProfiler,
+    pub(crate) query_profiler: QueryProfiler,
     /// Simulation start time, used to compute elapsed wall time for the simulation execution
     #[cfg(not(target_arch = "wasm32"))]
     start_time: Instant,
@@ -84,7 +87,7 @@ impl ExecutionProfilingCollector {
         let now = Instant::now();
 
         let mut new_stats = ExecutionProfilingCollector {
-            query_profiler: crate::profiling::QueryProfiler::default(),
+            query_profiler: QueryProfiler::default(),
             start_time: now,
             last_refresh: now,
             start_cpu_time: 0,

--- a/src/execution_stats.rs
+++ b/src/execution_stats.rs
@@ -47,6 +47,8 @@ const REFRESH_INTERVAL: Duration = Duration::from_secs(1);
 #[cfg(feature = "profiling")]
 #[cfg_attr(target_arch = "wasm32", allow(dead_code))]
 pub(crate) struct ExecutionProfilingCollector {
+    /// Aggregate profiling data for entity queries executed by this context.
+    pub(crate) query_profiler: crate::profiling::QueryProfiler,
     /// Simulation start time, used to compute elapsed wall time for the simulation execution
     #[cfg(not(target_arch = "wasm32"))]
     start_time: Instant,
@@ -82,6 +84,7 @@ impl ExecutionProfilingCollector {
         let now = Instant::now();
 
         let mut new_stats = ExecutionProfilingCollector {
+            query_profiler: crate::profiling::QueryProfiler::default(),
             start_time: now,
             last_refresh: now,
             start_cpu_time: 0,

--- a/src/macros/entity_impl.rs
+++ b/src/macros/entity_impl.rs
@@ -54,6 +54,14 @@ macro_rules! impl_entity {
                 $crate::entity::entity_store::initialize_entity_index(&INDEX)
             }
 
+            fn all_query_identity() -> usize {
+                static IDENTITY: std::sync::OnceLock<usize> = std::sync::OnceLock::new();
+
+                *IDENTITY.get_or_init(|| {
+                    $crate::entity::multi_property::intern_query_identity_raw::<Self>(&[])
+                })
+            }
+
             fn as_any(&self) -> &dyn std::any::Any {
                 self
             }

--- a/src/macros/property_impl.rs
+++ b/src/macros/property_impl.rs
@@ -802,6 +802,16 @@ macro_rules! impl_property {
                 $crate::entity::property_store::initialize_property_id::<$entity>(&INDEX)
             }
 
+            fn query_identity_id() -> usize {
+                static IDENTITY: std::sync::OnceLock<usize> = std::sync::OnceLock::new();
+
+                *IDENTITY.get_or_init(|| {
+                    $crate::entity::multi_property::intern_query_identity_raw::<$entity>(&[
+                        <Self as $crate::entity::property::Property<$entity>>::type_id(),
+                    ])
+                })
+            }
+
             fn collect_non_derived_dependencies(result: &mut $crate::HashSet<usize>) {
                 ($collect_deps_fn)(result)
             }

--- a/src/profiling/data.rs
+++ b/src/profiling/data.rs
@@ -1,4 +1,6 @@
 #[cfg(feature = "profiling")]
+use std::cell::RefCell;
+#[cfg(feature = "profiling")]
 use std::sync::{Mutex, MutexGuard, OnceLock};
 use std::time::{Duration, Instant};
 
@@ -44,6 +46,183 @@ pub struct ProfilingData {
     // removing them to avoid a double borrow.
     #[cfg(feature = "profiling")]
     pub(super) computed_statistics: Vec<Option<ComputedStatistic>>,
+}
+
+#[cfg(feature = "profiling")]
+#[derive(Default)]
+pub(crate) struct QueryProfiler {
+    timings: HashMap<&'static str, QueryTiming>,
+}
+
+#[cfg(feature = "profiling")]
+impl QueryProfiler {
+    pub(crate) fn record_query_timing(&mut self, query: &'static str, elapsed: Duration) {
+        if let Some(timing) = self.timings.get_mut(query) {
+            timing.record(elapsed);
+        } else {
+            self.timings.insert(query, QueryTiming::new(elapsed));
+        }
+    }
+
+    pub(crate) fn query_timings_table(&self) -> Vec<QueryTimingRow> {
+        let mut rows = self
+            .timings
+            .iter()
+            .map(|(&query, timing)| QueryTimingRow {
+                query: query.to_string(),
+                count: timing.count,
+                total: timing.total,
+                min: timing.min,
+                max: timing.max,
+            })
+            .collect::<Vec<_>>();
+
+        rows.sort_by(|left, right| {
+            right
+                .total
+                .cmp(&left.total)
+                .then_with(|| left.query.cmp(&right.query))
+        });
+
+        rows
+    }
+
+    #[cfg(test)]
+    pub(crate) fn query_timing(&self, query: &str) -> Option<&QueryTiming> {
+        self.timings.get(query)
+    }
+}
+
+#[cfg(feature = "profiling")]
+#[derive(Clone, Copy)]
+pub(crate) struct QueryProfileHandle<'a> {
+    profiler: &'a RefCell<QueryProfiler>,
+    query: &'static str,
+}
+
+#[cfg(feature = "profiling")]
+impl<'a> QueryProfileHandle<'a> {
+    pub(crate) fn new(profiler: &'a RefCell<QueryProfiler>, query: &'static str) -> Self {
+        Self { profiler, query }
+    }
+
+    pub(crate) fn same_query_as(self, other: Self) -> bool {
+        std::ptr::eq(self.profiler, other.profiler) && self.query == other.query
+    }
+
+    pub(crate) fn record_execution(self, elapsed: Duration) {
+        self.profiler
+            .borrow_mut()
+            .record_query_timing(self.query, elapsed);
+    }
+
+    #[must_use]
+    pub(crate) fn scope(self) -> QueryProfileScope<'a> {
+        QueryProfileScope {
+            profiler: self.profiler,
+            query: self.query,
+            start_time: Instant::now(),
+        }
+    }
+}
+
+#[cfg(feature = "profiling")]
+pub(crate) struct QueryExecutionProfile<'a> {
+    handle: QueryProfileHandle<'a>,
+    elapsed: Duration,
+    started: bool,
+    finished: bool,
+}
+
+#[cfg(feature = "profiling")]
+impl<'a> QueryExecutionProfile<'a> {
+    pub(crate) fn new(handle: QueryProfileHandle<'a>) -> Self {
+        Self {
+            handle,
+            elapsed: Duration::ZERO,
+            started: false,
+            finished: false,
+        }
+    }
+
+    pub(crate) fn measure<T>(&mut self, f: impl FnOnce() -> T) -> T {
+        if self.finished {
+            return f();
+        }
+
+        self.started = true;
+        let start = Instant::now();
+        let result = f();
+        self.elapsed += start.elapsed();
+        result
+    }
+
+    pub(crate) fn finish(&mut self) {
+        if self.started && !self.finished {
+            self.handle.record_execution(self.elapsed);
+            self.finished = true;
+        }
+    }
+}
+
+#[cfg(feature = "profiling")]
+impl Drop for QueryExecutionProfile<'_> {
+    fn drop(&mut self) {
+        self.finish();
+    }
+}
+
+#[cfg(feature = "profiling")]
+pub(crate) struct QueryProfileScope<'a> {
+    profiler: &'a RefCell<QueryProfiler>,
+    query: &'static str,
+    start_time: Instant,
+}
+
+#[cfg(feature = "profiling")]
+impl Drop for QueryProfileScope<'_> {
+    fn drop(&mut self) {
+        QueryProfileHandle::new(self.profiler, self.query)
+            .record_execution(self.start_time.elapsed());
+    }
+}
+
+#[cfg(feature = "profiling")]
+#[derive(Clone, Debug)]
+pub(crate) struct QueryTiming {
+    pub(crate) count: usize,
+    pub(crate) total: Duration,
+    pub(crate) min: Duration,
+    pub(crate) max: Duration,
+}
+
+#[cfg(feature = "profiling")]
+impl QueryTiming {
+    fn new(elapsed: Duration) -> Self {
+        Self {
+            count: 1,
+            total: elapsed,
+            min: elapsed,
+            max: elapsed,
+        }
+    }
+
+    fn record(&mut self, elapsed: Duration) {
+        self.count += 1;
+        self.total += elapsed;
+        self.min = self.min.min(elapsed);
+        self.max = self.max.max(elapsed);
+    }
+}
+
+#[cfg(feature = "profiling")]
+#[derive(Clone, Debug)]
+pub(crate) struct QueryTimingRow {
+    pub(crate) query: String,
+    pub(crate) count: usize,
+    pub(crate) total: Duration,
+    pub(crate) min: Duration,
+    pub(crate) max: Duration,
 }
 
 #[cfg(feature = "profiling")]
@@ -386,5 +565,84 @@ mod tests {
         let expected_percent = duration.as_secs_f64() / elapsed * 100.0;
         // Allow reasonable tolerance for timing variations
         assert!((*percent - expected_percent).abs() < 5.0);
+    }
+
+    #[test]
+    fn query_profiler_first_observation_initializes_record() {
+        let mut profiler = QueryProfiler::default();
+        profiler.record_query_timing("QueryTimingInit: (Age)", Duration::from_micros(10));
+
+        let timing = profiler.query_timing("QueryTimingInit: (Age)").unwrap();
+        assert_eq!(timing.count, 1);
+        assert_eq!(timing.total, Duration::from_micros(10));
+        assert_eq!(timing.min, Duration::from_micros(10));
+        assert_eq!(timing.max, Duration::from_micros(10));
+    }
+
+    #[test]
+    fn query_profiler_later_observations_update_aggregate() {
+        let mut profiler = QueryProfiler::default();
+        profiler.record_query_timing("QueryTimingUpdate: (Age)", Duration::from_micros(10));
+        profiler.record_query_timing("QueryTimingUpdate: (Age)", Duration::from_micros(30));
+        profiler.record_query_timing("QueryTimingUpdate: (Age)", Duration::from_micros(5));
+
+        let timing = profiler.query_timing("QueryTimingUpdate: (Age)").unwrap();
+        assert_eq!(timing.count, 3);
+        assert_eq!(timing.total, Duration::from_micros(45));
+        assert_eq!(timing.min, Duration::from_micros(5));
+        assert_eq!(timing.max, Duration::from_micros(30));
+    }
+
+    #[test]
+    fn query_profiler_table_rows_include_count_total_min_and_max() {
+        let mut profiler = QueryProfiler::default();
+        profiler.record_query_timing("QueryTimingTable: (Age)", Duration::from_millis(10));
+        profiler.record_query_timing("QueryTimingTable: (Age)", Duration::from_millis(30));
+
+        let rows = profiler.query_timings_table();
+        let row = rows
+            .iter()
+            .find(|row| row.query == "QueryTimingTable: (Age)")
+            .unwrap();
+
+        assert_eq!(row.count, 2);
+        assert_eq!(row.total, Duration::from_millis(40));
+        assert_eq!(row.min, Duration::from_millis(10));
+        assert_eq!(row.max, Duration::from_millis(30));
+    }
+
+    #[test]
+    fn query_profiler_same_label_aggregates_into_one_row() {
+        let mut profiler = QueryProfiler::default();
+        profiler.record_query_timing("QueryTimingSame: (Age)", Duration::from_micros(10));
+        profiler.record_query_timing("QueryTimingSame: (Age)", Duration::from_micros(30));
+        profiler.record_query_timing("QueryTimingSame: (Age)", Duration::from_micros(5));
+
+        let timing = profiler.query_timing("QueryTimingSame: (Age)").unwrap();
+        assert_eq!(timing.count, 3);
+        assert_eq!(timing.total, Duration::from_micros(45));
+    }
+
+    #[test]
+    fn query_profiler_table_sorts_by_total_then_label() {
+        let mut profiler = QueryProfiler::default();
+        profiler.record_query_timing("QueryTimingSort: B", Duration::from_micros(20));
+        profiler.record_query_timing("QueryTimingSort: C", Duration::from_micros(10));
+        profiler.record_query_timing("QueryTimingSort: A", Duration::from_micros(20));
+
+        let rows = profiler.query_timings_table();
+        let labels = rows
+            .iter()
+            .map(|row| row.query.as_str())
+            .collect::<Vec<_>>();
+
+        assert_eq!(
+            labels,
+            vec![
+                "QueryTimingSort: A",
+                "QueryTimingSort: B",
+                "QueryTimingSort: C"
+            ]
+        );
     }
 }

--- a/src/profiling/data.rs
+++ b/src/profiling/data.rs
@@ -3,6 +3,8 @@ use std::cell::RefCell;
 #[cfg(feature = "profiling")]
 use std::collections::hash_map::Entry;
 #[cfg(feature = "profiling")]
+use std::ptr::eq;
+#[cfg(feature = "profiling")]
 use std::sync::{Mutex, MutexGuard, OnceLock};
 use std::time::{Duration, Instant};
 
@@ -13,6 +15,8 @@ use super::{
     ComputedStatistic, ComputedValue, CustomStatisticComputer, CustomStatisticPrinter,
     TOTAL_MEASURED,
 };
+#[cfg(feature = "profiling")]
+use crate::entity::multi_property::{query_identity_label, QueryIdentityId};
 use crate::HashMap;
 
 #[cfg(feature = "profiling")]
@@ -52,7 +56,7 @@ pub struct ProfilingData {
 
 /// Aggregate profiling data for all committed executions of one query shape.
 ///
-/// [`QueryProfiler`] stores one value per static query label and updates it
+/// [`QueryProfiler`] stores one value per query identity and updates it
 /// whenever a completed query execution is recorded.
 #[cfg(feature = "profiling")]
 #[derive(Clone, Copy, Debug)]
@@ -84,20 +88,20 @@ impl QueryProfilingData {
 
 /// Context-owned storage for aggregate query-profiling data.
 ///
-/// Recording handles submit completed query labels and elapsed durations to
+/// Recording handles submit completed query identities and elapsed durations to
 /// this collection. Interior mutability permits profiling through query APIs
 /// that borrow the owning context immutably.
 #[cfg(feature = "profiling")]
 #[derive(Default)]
 pub(crate) struct QueryProfiler {
-    timings: RefCell<HashMap<&'static str, QueryProfilingData>>,
+    timings: RefCell<HashMap<QueryIdentityId, QueryProfilingData>>,
 }
 
 #[cfg(feature = "profiling")]
 impl QueryProfiler {
-    fn record(&self, query: &'static str, elapsed: Duration) {
+    fn record(&self, identity: QueryIdentityId, elapsed: Duration) {
         let mut timings = self.timings.borrow_mut();
-        match timings.entry(query) {
+        match timings.entry(identity) {
             Entry::Occupied(mut entry) => entry.get_mut().record(elapsed),
             Entry::Vacant(entry) => {
                 entry.insert(QueryProfilingData::new(elapsed));
@@ -111,7 +115,7 @@ impl QueryProfiler {
         let timings = self.timings.borrow();
         let mut rows = timings
             .iter()
-            .map(|(&query, &data)| (query, data))
+            .map(|(&identity, &data)| (query_identity_label(identity), data))
             .collect::<Vec<_>>();
 
         rows.sort_by(|(left_query, left_data), (right_query, right_data)| {
@@ -124,8 +128,11 @@ impl QueryProfiler {
     }
 
     #[cfg(test)]
-    pub(crate) fn query_profiling_data(&self, query: &str) -> Option<QueryProfilingData> {
-        self.timings.borrow().get(query).copied()
+    pub(crate) fn query_profiling_data(
+        &self,
+        identity: QueryIdentityId,
+    ) -> Option<QueryProfilingData> {
+        self.timings.borrow().get(&identity).copied()
     }
 }
 
@@ -138,21 +145,17 @@ impl QueryProfiler {
 #[derive(Clone, Copy)]
 pub(crate) struct QueryProfileHandle<'a> {
     profiler: &'a QueryProfiler,
-    query: &'static str,
+    identity: QueryIdentityId,
 }
 
 #[cfg(feature = "profiling")]
 impl<'a> QueryProfileHandle<'a> {
-    pub(crate) fn new(profiler: &'a QueryProfiler, query: &'static str) -> Self {
-        Self { profiler, query }
-    }
-
-    pub(crate) fn same_query_as(self, other: Self) -> bool {
-        std::ptr::eq(self.profiler, other.profiler) && self.query == other.query
+    pub(crate) fn new(profiler: &'a QueryProfiler, identity: QueryIdentityId) -> Self {
+        Self { profiler, identity }
     }
 
     fn record(self, elapsed: Duration) {
-        self.profiler.record(self.query, elapsed);
+        self.profiler.record(self.identity, elapsed);
     }
 
     #[must_use]
@@ -167,6 +170,16 @@ impl<'a> QueryProfileHandle<'a> {
         QueryExecutionProfile::new(self)
     }
 }
+
+#[cfg(feature = "profiling")]
+impl PartialEq for QueryProfileHandle<'_> {
+    fn eq(&self, other: &Self) -> bool {
+        eq(self.profiler, other.profiler) && self.identity == other.identity
+    }
+}
+
+#[cfg(feature = "profiling")]
+impl Eq for QueryProfileHandle<'_> {}
 
 /// RAII guard that records one continuously measured query execution.
 ///
@@ -408,6 +421,7 @@ mod tests {
     use std::time::Duration;
 
     use super::*;
+    use crate::entity::multi_property::test_query_identity;
     use crate::profiling::{get_profiling_data, increment_named_count};
 
     #[test]
@@ -591,11 +605,10 @@ mod tests {
     #[test]
     fn query_profiler_first_observation_initializes_record() {
         let profiler = QueryProfiler::default();
-        profiler.record("QueryTimingInit: (Age)", Duration::from_micros(10));
+        let identity = test_query_identity("QueryTimingInit: (Age)");
+        profiler.record(identity, Duration::from_micros(10));
 
-        let data = profiler
-            .query_profiling_data("QueryTimingInit: (Age)")
-            .unwrap();
+        let data = profiler.query_profiling_data(identity).unwrap();
         assert_eq!(data.count, 1);
         assert_eq!(data.total, Duration::from_micros(10));
         assert_eq!(data.min, Duration::from_micros(10));
@@ -605,13 +618,12 @@ mod tests {
     #[test]
     fn query_profiler_later_observations_update_aggregate() {
         let profiler = QueryProfiler::default();
-        profiler.record("QueryTimingUpdate: (Age)", Duration::from_micros(10));
-        profiler.record("QueryTimingUpdate: (Age)", Duration::from_micros(30));
-        profiler.record("QueryTimingUpdate: (Age)", Duration::from_micros(5));
+        let identity = test_query_identity("QueryTimingUpdate: (Age)");
+        profiler.record(identity, Duration::from_micros(10));
+        profiler.record(identity, Duration::from_micros(30));
+        profiler.record(identity, Duration::from_micros(5));
 
-        let data = profiler
-            .query_profiling_data("QueryTimingUpdate: (Age)")
-            .unwrap();
+        let data = profiler.query_profiling_data(identity).unwrap();
         assert_eq!(data.count, 3);
         assert_eq!(data.total, Duration::from_micros(45));
         assert_eq!(data.min, Duration::from_micros(5));
@@ -621,8 +633,9 @@ mod tests {
     #[test]
     fn query_profiler_snapshot_includes_count_total_min_and_max() {
         let profiler = QueryProfiler::default();
-        profiler.record("QueryTimingTable: (Age)", Duration::from_millis(10));
-        profiler.record("QueryTimingTable: (Age)", Duration::from_millis(30));
+        let identity = test_query_identity("QueryTimingTable: (Age)");
+        profiler.record(identity, Duration::from_millis(10));
+        profiler.record(identity, Duration::from_millis(30));
 
         let snapshot = profiler.snapshot();
         let (_, data) = snapshot
@@ -637,15 +650,14 @@ mod tests {
     }
 
     #[test]
-    fn query_profiler_same_label_aggregates_into_one_row() {
+    fn query_profiler_same_identity_aggregates_into_one_row() {
         let profiler = QueryProfiler::default();
-        profiler.record("QueryTimingSame: (Age)", Duration::from_micros(10));
-        profiler.record("QueryTimingSame: (Age)", Duration::from_micros(30));
-        profiler.record("QueryTimingSame: (Age)", Duration::from_micros(5));
+        let identity = test_query_identity("QueryTimingSame: (Age)");
+        profiler.record(identity, Duration::from_micros(10));
+        profiler.record(identity, Duration::from_micros(30));
+        profiler.record(identity, Duration::from_micros(5));
 
-        let data = profiler
-            .query_profiling_data("QueryTimingSame: (Age)")
-            .unwrap();
+        let data = profiler.query_profiling_data(identity).unwrap();
         assert_eq!(data.count, 3);
         assert_eq!(data.total, Duration::from_micros(45));
     }
@@ -653,9 +665,12 @@ mod tests {
     #[test]
     fn query_profiler_snapshot_sorts_by_total_then_label() {
         let profiler = QueryProfiler::default();
-        profiler.record("QueryTimingSort: B", Duration::from_micros(20));
-        profiler.record("QueryTimingSort: C", Duration::from_micros(10));
-        profiler.record("QueryTimingSort: A", Duration::from_micros(20));
+        let b = test_query_identity("QueryTimingSort: B");
+        let c = test_query_identity("QueryTimingSort: C");
+        let a = test_query_identity("QueryTimingSort: A");
+        profiler.record(b, Duration::from_micros(20));
+        profiler.record(c, Duration::from_micros(10));
+        profiler.record(a, Duration::from_micros(20));
 
         let snapshot = profiler.snapshot();
         let labels = snapshot.iter().map(|(query, _)| *query).collect::<Vec<_>>();
@@ -673,71 +688,83 @@ mod tests {
     #[test]
     fn query_profile_scope_records_on_drop() {
         let profiler = QueryProfiler::default();
+        let identity = test_query_identity("QueryProfileScope: (Age)");
         {
-            let _scope = QueryProfileHandle::new(&profiler, "QueryProfileScope: (Age)").scope();
+            let _scope = QueryProfileHandle::new(&profiler, identity).scope();
         }
 
-        let data = profiler
-            .query_profiling_data("QueryProfileScope: (Age)")
-            .unwrap();
+        let data = profiler.query_profiling_data(identity).unwrap();
         assert_eq!(data.count, 1);
+    }
+
+    #[test]
+    fn query_profile_handle_equality_uses_profiler_and_identity() {
+        fn requires_eq<T: Eq>(_value: T) {}
+
+        let first_profiler = QueryProfiler::default();
+        let second_profiler = QueryProfiler::default();
+        let first_identity = test_query_identity("QueryHandleEquality: A");
+        let second_identity = test_query_identity("QueryHandleEquality: B");
+
+        let first = QueryProfileHandle::new(&first_profiler, first_identity);
+        let same = QueryProfileHandle::new(&first_profiler, first_identity);
+        let different_identity = QueryProfileHandle::new(&first_profiler, second_identity);
+        let different_profiler = QueryProfileHandle::new(&second_profiler, first_identity);
+
+        assert!(first == same);
+        assert!(first != different_identity);
+        assert!(first != different_profiler);
+        requires_eq(first);
     }
 
     #[test]
     fn query_execution_scopes_accumulate_into_one_observation() {
         let profiler = QueryProfiler::default();
+        let identity = test_query_identity("QueryExecutionScopes: (Age)");
         {
-            let mut execution =
-                QueryProfileHandle::new(&profiler, "QueryExecutionScopes: (Age)").execution();
+            let mut execution = QueryProfileHandle::new(&profiler, identity).execution();
             drop(execution.scope());
             drop(execution.scope());
         }
 
-        let data = profiler
-            .query_profiling_data("QueryExecutionScopes: (Age)")
-            .unwrap();
+        let data = profiler.query_profiling_data(identity).unwrap();
         assert_eq!(data.count, 1);
     }
 
     #[test]
     fn unused_query_execution_records_nothing() {
         let profiler = QueryProfiler::default();
-        drop(QueryProfileHandle::new(&profiler, "UnusedQueryExecution: (Age)").execution());
+        let identity = test_query_identity("UnusedQueryExecution: (Age)");
+        drop(QueryProfileHandle::new(&profiler, identity).execution());
 
-        assert!(profiler
-            .query_profiling_data("UnusedQueryExecution: (Age)")
-            .is_none());
+        assert!(profiler.query_profiling_data(identity).is_none());
     }
 
     #[test]
     fn explicitly_finished_query_execution_records_only_once() {
         let profiler = QueryProfiler::default();
+        let identity = test_query_identity("FinishedQueryExecution: (Age)");
         {
-            let mut execution =
-                QueryProfileHandle::new(&profiler, "FinishedQueryExecution: (Age)").execution();
+            let mut execution = QueryProfileHandle::new(&profiler, identity).execution();
             drop(execution.scope());
             execution.finish();
         }
 
-        let data = profiler
-            .query_profiling_data("FinishedQueryExecution: (Age)")
-            .unwrap();
+        let data = profiler.query_profiling_data(identity).unwrap();
         assert_eq!(data.count, 1);
     }
 
     #[test]
     fn finished_query_execution_cannot_open_another_scope() {
         let profiler = QueryProfiler::default();
-        let mut execution =
-            QueryProfileHandle::new(&profiler, "NoScopeAfterFinish: (Age)").execution();
+        let identity = test_query_identity("NoScopeAfterFinish: (Age)");
+        let mut execution = QueryProfileHandle::new(&profiler, identity).execution();
         drop(execution.scope());
         execution.finish();
 
         assert!(execution.scope().is_none());
         drop(execution);
-        let data = profiler
-            .query_profiling_data("NoScopeAfterFinish: (Age)")
-            .unwrap();
+        let data = profiler.query_profiling_data(identity).unwrap();
         assert_eq!(data.count, 1);
     }
 
@@ -746,17 +773,15 @@ mod tests {
         use std::panic::{catch_unwind, AssertUnwindSafe};
 
         let profiler = QueryProfiler::default();
+        let identity = test_query_identity("PanickingQueryExecution: (Age)");
         let result = catch_unwind(AssertUnwindSafe(|| {
-            let mut execution =
-                QueryProfileHandle::new(&profiler, "PanickingQueryExecution: (Age)").execution();
+            let mut execution = QueryProfileHandle::new(&profiler, identity).execution();
             let _scope = execution.scope();
             panic!("end the measured work slice");
         }));
 
         assert!(result.is_err());
-        let data = profiler
-            .query_profiling_data("PanickingQueryExecution: (Age)")
-            .unwrap();
+        let data = profiler.query_profiling_data(identity).unwrap();
         assert_eq!(data.count, 1);
     }
 }

--- a/src/profiling/data.rs
+++ b/src/profiling/data.rs
@@ -1,6 +1,8 @@
 #[cfg(feature = "profiling")]
 use std::cell::RefCell;
 #[cfg(feature = "profiling")]
+use std::collections::hash_map::Entry;
+#[cfg(feature = "profiling")]
 use std::sync::{Mutex, MutexGuard, OnceLock};
 use std::time::{Duration, Instant};
 
@@ -48,148 +50,13 @@ pub struct ProfilingData {
     pub(super) computed_statistics: Vec<Option<ComputedStatistic>>,
 }
 
+/// Aggregate profiling data for all committed executions of one query shape.
+///
+/// [`QueryProfiler`] stores one value per static query label and updates it
+/// whenever a completed query execution is recorded.
 #[cfg(feature = "profiling")]
-#[derive(Default)]
-pub(crate) struct QueryProfiler {
-    timings: HashMap<&'static str, QueryTiming>,
-}
-
-#[cfg(feature = "profiling")]
-impl QueryProfiler {
-    pub(crate) fn record_query_timing(&mut self, query: &'static str, elapsed: Duration) {
-        if let Some(timing) = self.timings.get_mut(query) {
-            timing.record(elapsed);
-        } else {
-            self.timings.insert(query, QueryTiming::new(elapsed));
-        }
-    }
-
-    pub(crate) fn query_timings_table(&self) -> Vec<QueryTimingRow> {
-        let mut rows = self
-            .timings
-            .iter()
-            .map(|(&query, timing)| QueryTimingRow {
-                query: query.to_string(),
-                count: timing.count,
-                total: timing.total,
-                min: timing.min,
-                max: timing.max,
-            })
-            .collect::<Vec<_>>();
-
-        rows.sort_by(|left, right| {
-            right
-                .total
-                .cmp(&left.total)
-                .then_with(|| left.query.cmp(&right.query))
-        });
-
-        rows
-    }
-
-    #[cfg(test)]
-    pub(crate) fn query_timing(&self, query: &str) -> Option<&QueryTiming> {
-        self.timings.get(query)
-    }
-}
-
-#[cfg(feature = "profiling")]
-#[derive(Clone, Copy)]
-pub(crate) struct QueryProfileHandle<'a> {
-    profiler: &'a RefCell<QueryProfiler>,
-    query: &'static str,
-}
-
-#[cfg(feature = "profiling")]
-impl<'a> QueryProfileHandle<'a> {
-    pub(crate) fn new(profiler: &'a RefCell<QueryProfiler>, query: &'static str) -> Self {
-        Self { profiler, query }
-    }
-
-    pub(crate) fn same_query_as(self, other: Self) -> bool {
-        std::ptr::eq(self.profiler, other.profiler) && self.query == other.query
-    }
-
-    pub(crate) fn record_execution(self, elapsed: Duration) {
-        self.profiler
-            .borrow_mut()
-            .record_query_timing(self.query, elapsed);
-    }
-
-    #[must_use]
-    pub(crate) fn scope(self) -> QueryProfileScope<'a> {
-        QueryProfileScope {
-            profiler: self.profiler,
-            query: self.query,
-            start_time: Instant::now(),
-        }
-    }
-}
-
-#[cfg(feature = "profiling")]
-pub(crate) struct QueryExecutionProfile<'a> {
-    handle: QueryProfileHandle<'a>,
-    elapsed: Duration,
-    started: bool,
-    finished: bool,
-}
-
-#[cfg(feature = "profiling")]
-impl<'a> QueryExecutionProfile<'a> {
-    pub(crate) fn new(handle: QueryProfileHandle<'a>) -> Self {
-        Self {
-            handle,
-            elapsed: Duration::ZERO,
-            started: false,
-            finished: false,
-        }
-    }
-
-    pub(crate) fn measure<T>(&mut self, f: impl FnOnce() -> T) -> T {
-        if self.finished {
-            return f();
-        }
-
-        self.started = true;
-        let start = Instant::now();
-        let result = f();
-        self.elapsed += start.elapsed();
-        result
-    }
-
-    pub(crate) fn finish(&mut self) {
-        if self.started && !self.finished {
-            self.handle.record_execution(self.elapsed);
-            self.finished = true;
-        }
-    }
-}
-
-#[cfg(feature = "profiling")]
-impl Drop for QueryExecutionProfile<'_> {
-    fn drop(&mut self) {
-        self.finish();
-    }
-}
-
-#[cfg(feature = "profiling")]
-pub(crate) struct QueryProfileScope<'a> {
-    profiler: &'a RefCell<QueryProfiler>,
-    query: &'static str,
-    start_time: Instant,
-}
-
-#[cfg(feature = "profiling")]
-impl Drop for QueryProfileScope<'_> {
-    fn drop(&mut self) {
-        QueryProfileHandle::new(self.profiler, self.query)
-            .record_execution(self.start_time.elapsed());
-    }
-}
-
-#[cfg(feature = "profiling")]
-#[derive(Clone, Debug)]
-pub(crate) struct QueryTiming {
+#[derive(Clone, Copy, Debug)]
+pub(crate) struct QueryProfilingData {
     pub(crate) count: usize,
     pub(crate) total: Duration,
     pub(crate) min: Duration,
@@ -197,7 +64,7 @@ pub(crate) struct QueryTiming {
 }
 
 #[cfg(feature = "profiling")]
-impl QueryTiming {
+impl QueryProfilingData {
     fn new(elapsed: Duration) -> Self {
         Self {
             count: 1,
@@ -215,14 +82,168 @@ impl QueryTiming {
     }
 }
 
+/// Context-owned storage for aggregate query-profiling data.
+///
+/// Recording handles submit completed query labels and elapsed durations to
+/// this collection. Interior mutability permits profiling through query APIs
+/// that borrow the owning context immutably.
 #[cfg(feature = "profiling")]
-#[derive(Clone, Debug)]
-pub(crate) struct QueryTimingRow {
-    pub(crate) query: String,
-    pub(crate) count: usize,
-    pub(crate) total: Duration,
-    pub(crate) min: Duration,
-    pub(crate) max: Duration,
+#[derive(Default)]
+pub(crate) struct QueryProfiler {
+    timings: RefCell<HashMap<&'static str, QueryProfilingData>>,
+}
+
+#[cfg(feature = "profiling")]
+impl QueryProfiler {
+    fn record(&self, query: &'static str, elapsed: Duration) {
+        let mut timings = self.timings.borrow_mut();
+        match timings.entry(query) {
+            Entry::Occupied(mut entry) => entry.get_mut().record(elapsed),
+            Entry::Vacant(entry) => {
+                entry.insert(QueryProfilingData::new(elapsed));
+            }
+        }
+    }
+
+    /// Returns `(query label, aggregate profiling data)` pairs sorted by
+    /// descending total duration and then ascending query label.
+    pub(crate) fn snapshot(&self) -> Vec<(&'static str, QueryProfilingData)> {
+        let timings = self.timings.borrow();
+        let mut rows = timings
+            .iter()
+            .map(|(&query, &data)| (query, data))
+            .collect::<Vec<_>>();
+
+        rows.sort_by(|(left_query, left_data), (right_query, right_data)| {
+            right_data
+                .total
+                .cmp(&left_data.total)
+                .then_with(|| left_query.cmp(right_query))
+        });
+        rows
+    }
+
+    #[cfg(test)]
+    pub(crate) fn query_profiling_data(&self, query: &str) -> Option<QueryProfilingData> {
+        self.timings.borrow().get(query).copied()
+    }
+}
+
+/// Copyable recording destination for one query shape in one context.
+///
+/// Carrying this handle does not record an execution. Contiguous timing scopes
+/// and discontinuous execution profiles use it to commit completed elapsed
+/// durations to the owning [`QueryProfiler`].
+#[cfg(feature = "profiling")]
+#[derive(Clone, Copy)]
+pub(crate) struct QueryProfileHandle<'a> {
+    profiler: &'a QueryProfiler,
+    query: &'static str,
+}
+
+#[cfg(feature = "profiling")]
+impl<'a> QueryProfileHandle<'a> {
+    pub(crate) fn new(profiler: &'a QueryProfiler, query: &'static str) -> Self {
+        Self { profiler, query }
+    }
+
+    pub(crate) fn same_query_as(self, other: Self) -> bool {
+        std::ptr::eq(self.profiler, other.profiler) && self.query == other.query
+    }
+
+    fn record(self, elapsed: Duration) {
+        self.profiler.record(self.query, elapsed);
+    }
+
+    #[must_use]
+    pub(crate) fn scope(self) -> QueryProfileScope<'a> {
+        QueryProfileScope {
+            handle: self,
+            start_time: Instant::now(),
+        }
+    }
+
+    pub(crate) fn execution(self) -> QueryExecutionProfile<'a> {
+        QueryExecutionProfile::new(self)
+    }
+}
+
+/// RAII guard that records one continuously measured query execution.
+///
+/// The guard starts timing when constructed and commits one elapsed duration
+/// through its [`QueryProfileHandle`] when dropped.
+#[cfg(feature = "profiling")]
+pub(crate) struct QueryProfileScope<'a> {
+    handle: QueryProfileHandle<'a>,
+    start_time: Instant,
+}
+
+#[cfg(feature = "profiling")]
+impl Drop for QueryProfileScope<'_> {
+    fn drop(&mut self) {
+        self.handle.record(self.start_time.elapsed());
+    }
+}
+
+/// Accumulates discontinuous query work for one lazy iterator execution.
+///
+/// Each [`QueryExecutionScope`] adds one elapsed work slice. [`Self::finish`]
+/// or `Drop` commits the accumulated duration once; an execution that never
+/// opened a work scope records nothing.
+#[cfg(feature = "profiling")]
+pub(crate) struct QueryExecutionProfile<'a> {
+    handle: Option<QueryProfileHandle<'a>>,
+    elapsed: Option<Duration>,
+}
+
+#[cfg(feature = "profiling")]
+impl<'a> QueryExecutionProfile<'a> {
+    fn new(handle: QueryProfileHandle<'a>) -> Self {
+        Self {
+            handle: Some(handle),
+            elapsed: None,
+        }
+    }
+
+    #[must_use]
+    pub(crate) fn scope(&mut self) -> Option<QueryExecutionScope<'_, 'a>> {
+        self.handle.as_ref()?;
+        self.elapsed.get_or_insert(Duration::ZERO);
+        Some(QueryExecutionScope {
+            execution: self,
+            start_time: Instant::now(),
+        })
+    }
+
+    pub(crate) fn finish(&mut self) {
+        if let (Some(handle), Some(elapsed)) = (self.handle.take(), self.elapsed.take()) {
+            handle.record(elapsed);
+        }
+    }
+}
+
+#[cfg(feature = "profiling")]
+impl Drop for QueryExecutionProfile<'_> {
+    fn drop(&mut self) {
+        self.finish();
+    }
+}
+
+/// RAII guard for one timed work slice in a discontinuous query execution.
+///
+/// Dropping the guard adds the slice's elapsed duration to its
+/// [`QueryExecutionProfile`]. It does not commit an aggregate observation.
+#[cfg(feature = "profiling")]
+pub(crate) struct QueryExecutionScope<'execution, 'context> {
+    execution: &'execution mut QueryExecutionProfile<'context>,
+    start_time: Instant,
+}
+
+#[cfg(feature = "profiling")]
+impl Drop for QueryExecutionScope<'_, '_> {
+    fn drop(&mut self) {
+        *self.execution.elapsed.get_or_insert(Duration::ZERO) += self.start_time.elapsed();
+    }
 }
 
 #[cfg(feature = "profiling")]
@@ -569,72 +590,75 @@ mod tests {
 
     #[test]
     fn query_profiler_first_observation_initializes_record() {
-        let mut profiler = QueryProfiler::default();
-        profiler.record_query_timing("QueryTimingInit: (Age)", Duration::from_micros(10));
+        let profiler = QueryProfiler::default();
+        profiler.record("QueryTimingInit: (Age)", Duration::from_micros(10));
 
-        let timing = profiler.query_timing("QueryTimingInit: (Age)").unwrap();
-        assert_eq!(timing.count, 1);
-        assert_eq!(timing.total, Duration::from_micros(10));
-        assert_eq!(timing.min, Duration::from_micros(10));
-        assert_eq!(timing.max, Duration::from_micros(10));
+        let data = profiler
+            .query_profiling_data("QueryTimingInit: (Age)")
+            .unwrap();
+        assert_eq!(data.count, 1);
+        assert_eq!(data.total, Duration::from_micros(10));
+        assert_eq!(data.min, Duration::from_micros(10));
+        assert_eq!(data.max, Duration::from_micros(10));
     }
 
     #[test]
     fn query_profiler_later_observations_update_aggregate() {
-        let mut profiler = QueryProfiler::default();
-        profiler.record_query_timing("QueryTimingUpdate: (Age)", Duration::from_micros(10));
-        profiler.record_query_timing("QueryTimingUpdate: (Age)", Duration::from_micros(30));
-        profiler.record_query_timing("QueryTimingUpdate: (Age)", Duration::from_micros(5));
+        let profiler = QueryProfiler::default();
+        profiler.record("QueryTimingUpdate: (Age)", Duration::from_micros(10));
+        profiler.record("QueryTimingUpdate: (Age)", Duration::from_micros(30));
+        profiler.record("QueryTimingUpdate: (Age)", Duration::from_micros(5));
 
-        let timing = profiler.query_timing("QueryTimingUpdate: (Age)").unwrap();
-        assert_eq!(timing.count, 3);
-        assert_eq!(timing.total, Duration::from_micros(45));
-        assert_eq!(timing.min, Duration::from_micros(5));
-        assert_eq!(timing.max, Duration::from_micros(30));
+        let data = profiler
+            .query_profiling_data("QueryTimingUpdate: (Age)")
+            .unwrap();
+        assert_eq!(data.count, 3);
+        assert_eq!(data.total, Duration::from_micros(45));
+        assert_eq!(data.min, Duration::from_micros(5));
+        assert_eq!(data.max, Duration::from_micros(30));
     }
 
     #[test]
-    fn query_profiler_table_rows_include_count_total_min_and_max() {
-        let mut profiler = QueryProfiler::default();
-        profiler.record_query_timing("QueryTimingTable: (Age)", Duration::from_millis(10));
-        profiler.record_query_timing("QueryTimingTable: (Age)", Duration::from_millis(30));
+    fn query_profiler_snapshot_includes_count_total_min_and_max() {
+        let profiler = QueryProfiler::default();
+        profiler.record("QueryTimingTable: (Age)", Duration::from_millis(10));
+        profiler.record("QueryTimingTable: (Age)", Duration::from_millis(30));
 
-        let rows = profiler.query_timings_table();
-        let row = rows
+        let snapshot = profiler.snapshot();
+        let (_, data) = snapshot
             .iter()
-            .find(|row| row.query == "QueryTimingTable: (Age)")
+            .find(|(query, _)| *query == "QueryTimingTable: (Age)")
             .unwrap();
 
-        assert_eq!(row.count, 2);
-        assert_eq!(row.total, Duration::from_millis(40));
-        assert_eq!(row.min, Duration::from_millis(10));
-        assert_eq!(row.max, Duration::from_millis(30));
+        assert_eq!(data.count, 2);
+        assert_eq!(data.total, Duration::from_millis(40));
+        assert_eq!(data.min, Duration::from_millis(10));
+        assert_eq!(data.max, Duration::from_millis(30));
     }
 
     #[test]
     fn query_profiler_same_label_aggregates_into_one_row() {
-        let mut profiler = QueryProfiler::default();
-        profiler.record_query_timing("QueryTimingSame: (Age)", Duration::from_micros(10));
-        profiler.record_query_timing("QueryTimingSame: (Age)", Duration::from_micros(30));
-        profiler.record_query_timing("QueryTimingSame: (Age)", Duration::from_micros(5));
+        let profiler = QueryProfiler::default();
+        profiler.record("QueryTimingSame: (Age)", Duration::from_micros(10));
+        profiler.record("QueryTimingSame: (Age)", Duration::from_micros(30));
+        profiler.record("QueryTimingSame: (Age)", Duration::from_micros(5));
 
-        let timing = profiler.query_timing("QueryTimingSame: (Age)").unwrap();
-        assert_eq!(timing.count, 3);
-        assert_eq!(timing.total, Duration::from_micros(45));
+        let data = profiler
+            .query_profiling_data("QueryTimingSame: (Age)")
+            .unwrap();
+        assert_eq!(data.count, 3);
+        assert_eq!(data.total, Duration::from_micros(45));
     }
 
     #[test]
-    fn query_profiler_table_sorts_by_total_then_label() {
-        let mut profiler = QueryProfiler::default();
-        profiler.record_query_timing("QueryTimingSort: B", Duration::from_micros(20));
-        profiler.record_query_timing("QueryTimingSort: C", Duration::from_micros(10));
-        profiler.record_query_timing("QueryTimingSort: A", Duration::from_micros(20));
+    fn query_profiler_snapshot_sorts_by_total_then_label() {
+        let profiler = QueryProfiler::default();
+        profiler.record("QueryTimingSort: B", Duration::from_micros(20));
+        profiler.record("QueryTimingSort: C", Duration::from_micros(10));
+        profiler.record("QueryTimingSort: A", Duration::from_micros(20));
 
-        let rows = profiler.query_timings_table();
-        let labels = rows
-            .iter()
-            .map(|row| row.query.as_str())
-            .collect::<Vec<_>>();
+        let snapshot = profiler.snapshot();
+        let labels = snapshot.iter().map(|(query, _)| *query).collect::<Vec<_>>();
 
         assert_eq!(
             labels,
@@ -644,5 +668,95 @@ mod tests {
                 "QueryTimingSort: C"
             ]
         );
+    }
+
+    #[test]
+    fn query_profile_scope_records_on_drop() {
+        let profiler = QueryProfiler::default();
+        {
+            let _scope = QueryProfileHandle::new(&profiler, "QueryProfileScope: (Age)").scope();
+        }
+
+        let data = profiler
+            .query_profiling_data("QueryProfileScope: (Age)")
+            .unwrap();
+        assert_eq!(data.count, 1);
+    }
+
+    #[test]
+    fn query_execution_scopes_accumulate_into_one_observation() {
+        let profiler = QueryProfiler::default();
+        {
+            let mut execution =
+                QueryProfileHandle::new(&profiler, "QueryExecutionScopes: (Age)").execution();
+            drop(execution.scope());
+            drop(execution.scope());
+        }
+
+        let data = profiler
+            .query_profiling_data("QueryExecutionScopes: (Age)")
+            .unwrap();
+        assert_eq!(data.count, 1);
+    }
+
+    #[test]
+    fn unused_query_execution_records_nothing() {
+        let profiler = QueryProfiler::default();
+        drop(QueryProfileHandle::new(&profiler, "UnusedQueryExecution: (Age)").execution());
+
+        assert!(profiler
+            .query_profiling_data("UnusedQueryExecution: (Age)")
+            .is_none());
+    }
+
+    #[test]
+    fn explicitly_finished_query_execution_records_only_once() {
+        let profiler = QueryProfiler::default();
+        {
+            let mut execution =
+                QueryProfileHandle::new(&profiler, "FinishedQueryExecution: (Age)").execution();
+            drop(execution.scope());
+            execution.finish();
+        }
+
+        let data = profiler
+            .query_profiling_data("FinishedQueryExecution: (Age)")
+            .unwrap();
+        assert_eq!(data.count, 1);
+    }
+
+    #[test]
+    fn finished_query_execution_cannot_open_another_scope() {
+        let profiler = QueryProfiler::default();
+        let mut execution =
+            QueryProfileHandle::new(&profiler, "NoScopeAfterFinish: (Age)").execution();
+        drop(execution.scope());
+        execution.finish();
+
+        assert!(execution.scope().is_none());
+        drop(execution);
+        let data = profiler
+            .query_profiling_data("NoScopeAfterFinish: (Age)")
+            .unwrap();
+        assert_eq!(data.count, 1);
+    }
+
+    #[test]
+    fn panicking_query_execution_scope_records_elapsed_work() {
+        use std::panic::{catch_unwind, AssertUnwindSafe};
+
+        let profiler = QueryProfiler::default();
+        let result = catch_unwind(AssertUnwindSafe(|| {
+            let mut execution =
+                QueryProfileHandle::new(&profiler, "PanickingQueryExecution: (Age)").execution();
+            let _scope = execution.scope();
+            panic!("end the measured work slice");
+        }));
+
+        assert!(result.is_err());
+        let data = profiler
+            .query_profiling_data("PanickingQueryExecution: (Age)")
+            .unwrap();
+        assert_eq!(data.count, 1);
     }
 }

--- a/src/profiling/display.rs
+++ b/src/profiling/display.rs
@@ -2,7 +2,10 @@
 use humantime::format_duration;
 
 #[cfg(feature = "profiling")]
-use super::{profiling_data, ProfilingData, NAMED_COUNTS_HEADERS, NAMED_SPANS_HEADERS};
+use super::{
+    profiling_data, ProfilingData, QueryTimingRow, NAMED_COUNTS_HEADERS, NAMED_SPANS_HEADERS,
+    QUERY_TIMINGS_HEADERS,
+};
 
 /// Prints all collected profiling data.
 #[cfg(feature = "profiling")]
@@ -84,6 +87,34 @@ pub fn print_named_spans() {
 #[cfg(not(feature = "profiling"))]
 pub fn print_named_spans() {}
 
+#[cfg(feature = "profiling")]
+pub(crate) fn print_query_timings(rows: &[QueryTimingRow]) {
+    if rows.is_empty() {
+        return;
+    }
+
+    let mut formatted_rows = vec![
+        // Header row
+        QUERY_TIMINGS_HEADERS
+            .iter()
+            .map(|s| (*s).to_string())
+            .collect(),
+    ];
+
+    formatted_rows.extend(rows.iter().map(|row| {
+        vec![
+            row.query.clone(),
+            format_with_commas(row.count),
+            format_duration(row.total).to_string(),
+            format_duration(row.min).to_string(),
+            format_duration(row.max).to_string(),
+        ]
+    }));
+
+    println!();
+    print_formatted_table(&formatted_rows);
+}
+
 /// Prints the forecast efficiency.
 #[cfg(feature = "profiling")]
 pub fn print_computed_statistics() {
@@ -146,7 +177,7 @@ pub fn print_formatted_table(rows: &[Vec<String>]) {
     println!();
 
     // Print separator
-    let total_width: usize = col_widths.iter().map(|w| *w + 1).sum::<usize>() + 2;
+    let total_width: usize = col_widths.iter().map(|w| *w + 2).sum();
     println!("{}", "-".repeat(total_width));
 
     // Print data rows
@@ -227,6 +258,7 @@ mod tests {
 
     use crate::profiling::display::{
         format_with_commas, format_with_commas_f64, print_named_counts, print_named_spans,
+        print_query_timings,
     };
     use crate::profiling::*;
 
@@ -380,6 +412,28 @@ mod tests {
                 .insert("rendering", (Duration::from_secs(2), 30));
         }
         print_named_spans();
+    }
+
+    #[test]
+    fn print_query_timings_outputs_expected_format() {
+        let rows = vec![
+            QueryTimingRow {
+                query: "DisplayQueryTimings: (Age)".to_string(),
+                count: 2,
+                total: Duration::from_micros(40),
+                min: Duration::from_micros(10),
+                max: Duration::from_micros(30),
+            },
+            QueryTimingRow {
+                query: "DisplayQueryTimings: (County)".to_string(),
+                count: 1,
+                total: Duration::from_micros(20),
+                min: Duration::from_micros(20),
+                max: Duration::from_micros(20),
+            },
+        ];
+
+        print_query_timings(&rows);
     }
 
     #[test]

--- a/src/profiling/display.rs
+++ b/src/profiling/display.rs
@@ -3,7 +3,7 @@ use humantime::format_duration;
 
 #[cfg(feature = "profiling")]
 use super::{
-    profiling_data, ProfilingData, QueryTimingRow, NAMED_COUNTS_HEADERS, NAMED_SPANS_HEADERS,
+    profiling_data, ProfilingData, QueryProfilingData, NAMED_COUNTS_HEADERS, NAMED_SPANS_HEADERS,
     QUERY_TIMINGS_HEADERS,
 };
 
@@ -88,7 +88,7 @@ pub fn print_named_spans() {
 pub fn print_named_spans() {}
 
 #[cfg(feature = "profiling")]
-pub(crate) fn print_query_timings(rows: &[QueryTimingRow]) {
+pub(crate) fn print_query_timings(rows: &[(&'static str, QueryProfilingData)]) {
     if rows.is_empty() {
         return;
     }
@@ -101,13 +101,13 @@ pub(crate) fn print_query_timings(rows: &[QueryTimingRow]) {
             .collect(),
     ];
 
-    formatted_rows.extend(rows.iter().map(|row| {
+    formatted_rows.extend(rows.iter().map(|(query, data)| {
         vec![
-            row.query.clone(),
-            format_with_commas(row.count),
-            format_duration(row.total).to_string(),
-            format_duration(row.min).to_string(),
-            format_duration(row.max).to_string(),
+            (*query).to_string(),
+            format_with_commas(data.count),
+            format_duration(data.total).to_string(),
+            format_duration(data.min).to_string(),
+            format_duration(data.max).to_string(),
         ]
     }));
 
@@ -417,20 +417,24 @@ mod tests {
     #[test]
     fn print_query_timings_outputs_expected_format() {
         let rows = vec![
-            QueryTimingRow {
-                query: "DisplayQueryTimings: (Age)".to_string(),
-                count: 2,
-                total: Duration::from_micros(40),
-                min: Duration::from_micros(10),
-                max: Duration::from_micros(30),
-            },
-            QueryTimingRow {
-                query: "DisplayQueryTimings: (County)".to_string(),
-                count: 1,
-                total: Duration::from_micros(20),
-                min: Duration::from_micros(20),
-                max: Duration::from_micros(20),
-            },
+            (
+                "DisplayQueryTimings: (Age)",
+                QueryProfilingData {
+                    count: 2,
+                    total: Duration::from_micros(40),
+                    min: Duration::from_micros(10),
+                    max: Duration::from_micros(30),
+                },
+            ),
+            (
+                "DisplayQueryTimings: (County)",
+                QueryProfilingData {
+                    count: 1,
+                    total: Duration::from_micros(20),
+                    min: Duration::from_micros(20),
+                    max: Duration::from_micros(20),
+                },
+            ),
         ];
 
         print_query_timings(&rows);

--- a/src/profiling/file.rs
+++ b/src/profiling/file.rs
@@ -12,6 +12,8 @@ use serde::{Serialize, Serializer};
 use super::computed_statistic::{ComputedStatistic, ComputedValue};
 #[cfg(feature = "profiling")]
 use super::profiling_data;
+#[cfg(feature = "profiling")]
+use super::QueryTimingRow;
 use crate::execution_stats::ExecutionStatistics;
 use crate::HashMap;
 
@@ -70,11 +72,22 @@ struct CountRecord {
 
 #[cfg(feature = "profiling")]
 #[derive(Serialize)]
+struct QueryTimingRecord {
+    query: String,
+    count: usize,
+    total: SerializableDuration,
+    min: SerializableDuration,
+    max: SerializableDuration,
+}
+
+#[cfg(feature = "profiling")]
+#[derive(Serialize)]
 struct ProfilingDataRecord {
     date_time: SystemTime,
     execution_statistics: SerializableExecutionStatistics,
     named_counts: Vec<CountRecord>,
     named_spans: Vec<SpanRecord>,
+    query_timings: Vec<QueryTimingRecord>,
     computed_statistics: HashMap<&'static str, ComputedStatisticRecord>,
 }
 
@@ -89,6 +102,7 @@ struct ComputedStatisticRecord {
 pub fn write_profiling_data_to_file<P: AsRef<Path>>(
     file_path: P,
     execution_statistics: ExecutionStatistics,
+    query_timings: &[QueryTimingRow],
 ) -> std::io::Result<()> {
     let mut container = profiling_data();
     let named_spans_data = container.get_named_spans_table();
@@ -108,6 +122,16 @@ pub fn write_profiling_data_to_file<P: AsRef<Path>>(
             label,
             count,
             rate_per_second,
+        })
+        .collect();
+    let query_timings_data = query_timings
+        .iter()
+        .map(|row| QueryTimingRecord {
+            query: row.query.clone(),
+            count: row.count,
+            total: SerializableDuration(row.total),
+            min: SerializableDuration(row.min),
+            max: SerializableDuration(row.max),
         })
         .collect();
 
@@ -140,6 +164,7 @@ pub fn write_profiling_data_to_file<P: AsRef<Path>>(
         execution_statistics: execution_statistics.into(),
         named_counts: named_counts_data,
         named_spans: named_spans_data,
+        query_timings: query_timings_data,
         computed_statistics,
     };
 
@@ -167,9 +192,7 @@ mod tests {
     use tempfile::TempDir;
 
     use super::*;
-    use crate::profiling::{
-        add_computed_statistic, get_profiling_data, increment_named_count, open_span,
-    };
+    use crate::profiling::{add_computed_statistic, increment_named_count, open_span};
 
     #[test]
     fn test_write_profiling_data_to_file() {
@@ -199,7 +222,7 @@ mod tests {
             wall_time: Duration::from_secs(2),
         };
 
-        write_profiling_data_to_file(&file_path, exec_stats).expect("Failed to write file");
+        write_profiling_data_to_file(&file_path, exec_stats, &[]).expect("Failed to write file");
 
         assert!(file_path.exists());
 
@@ -212,6 +235,7 @@ mod tests {
         assert!(json["execution_statistics"].is_object());
         assert!(json["named_counts"].is_array());
         assert!(json["named_spans"].is_array());
+        assert!(json["query_timings"].is_array());
         assert!(json["computed_statistics"].is_object());
         assert_eq!(
             json["execution_statistics"]["max_memory_usage"],
@@ -241,6 +265,46 @@ mod tests {
     }
 
     #[test]
+    fn test_write_profiling_data_includes_query_timings() {
+        let rows = vec![QueryTimingRow {
+            query: "FileQueryTiming: (Age)".to_string(),
+            count: 2,
+            total: Duration::from_micros(40),
+            min: Duration::from_micros(10),
+            max: Duration::from_micros(30),
+        }];
+
+        let temp_dir = TempDir::new().unwrap();
+        let file_path = temp_dir.path().join("query_timing_test.json");
+
+        let exec_stats = ExecutionStatistics {
+            max_memory_usage: 0,
+            max_plans_in_flight: 0,
+            max_plan_queue_memory_in_use: 0,
+            cpu_time: Duration::from_secs(0),
+            wall_time: Duration::from_secs(0),
+        };
+
+        write_profiling_data_to_file(&file_path, exec_stats, &rows).expect("Failed to write file");
+
+        let content = fs::read_to_string(&file_path).expect("Failed to read file");
+        let json: serde_json::Value = serde_json::from_str(&content).expect("Invalid JSON");
+        let query_timings = json["query_timings"].as_array().unwrap();
+        let timing = query_timings
+            .iter()
+            .find(|row| row["query"] == "FileQueryTiming: (Age)")
+            .expect("FileQueryTiming: (Age) not found");
+
+        assert_eq!(timing["count"], 2);
+        assert!((timing["total"].as_f64().unwrap() - 0.00004).abs() < 0.000001);
+        assert!((timing["min"].as_f64().unwrap() - 0.00001).abs() < 0.000001);
+        assert!((timing["max"].as_f64().unwrap() - 0.00003).abs() < 0.000001);
+        assert!(timing.get("indexed").is_none());
+        assert!(timing.get("mean").is_none());
+        assert!(timing.get("percent_runtime").is_none());
+    }
+
+    #[test]
     fn test_json_serialization_format() {
         // Avoid clearing global profiling data
 
@@ -255,7 +319,7 @@ mod tests {
             wall_time: Duration::from_secs_f64(2.5),
         };
 
-        write_profiling_data_to_file(&file_path, exec_stats).expect("Failed to write file");
+        write_profiling_data_to_file(&file_path, exec_stats, &[]).expect("Failed to write file");
 
         let content = fs::read_to_string(&file_path).expect("Failed to read file");
         let json: serde_json::Value = serde_json::from_str(&content).expect("Invalid JSON");

--- a/src/profiling/file.rs
+++ b/src/profiling/file.rs
@@ -189,6 +189,7 @@ mod tests {
     use std::fs;
     use std::time::Duration;
 
+    use serde_json::{from_str, Value};
     use tempfile::TempDir;
 
     use super::*;
@@ -227,7 +228,7 @@ mod tests {
         assert!(file_path.exists());
 
         let content = fs::read_to_string(&file_path).expect("Failed to read file");
-        let json: serde_json::Value = serde_json::from_str(&content).expect("Invalid JSON");
+        let json: Value = from_str(&content).expect("Invalid JSON");
 
         assert!(json["date_time"].is_object());
         assert!(json["date_time"]["secs_since_epoch"].is_number());
@@ -290,7 +291,7 @@ mod tests {
         write_profiling_data_to_file(&file_path, exec_stats, &rows).expect("Failed to write file");
 
         let content = fs::read_to_string(&file_path).expect("Failed to read file");
-        let json: serde_json::Value = serde_json::from_str(&content).expect("Invalid JSON");
+        let json: Value = from_str(&content).expect("Invalid JSON");
         let query_timings = json["query_timings"].as_array().unwrap();
         let timing = query_timings
             .iter()
@@ -324,7 +325,7 @@ mod tests {
         write_profiling_data_to_file(&file_path, exec_stats, &[]).expect("Failed to write file");
 
         let content = fs::read_to_string(&file_path).expect("Failed to read file");
-        let json: serde_json::Value = serde_json::from_str(&content).expect("Invalid JSON");
+        let json: Value = from_str(&content).expect("Invalid JSON");
 
         let cpu_time = json["execution_statistics"]["cpu_time"].as_f64().unwrap();
         assert!((cpu_time - 1.5).abs() < 0.01);

--- a/src/profiling/file.rs
+++ b/src/profiling/file.rs
@@ -13,7 +13,7 @@ use super::computed_statistic::{ComputedStatistic, ComputedValue};
 #[cfg(feature = "profiling")]
 use super::profiling_data;
 #[cfg(feature = "profiling")]
-use super::QueryTimingRow;
+use super::QueryProfilingData;
 use crate::execution_stats::ExecutionStatistics;
 use crate::HashMap;
 
@@ -102,7 +102,7 @@ struct ComputedStatisticRecord {
 pub fn write_profiling_data_to_file<P: AsRef<Path>>(
     file_path: P,
     execution_statistics: ExecutionStatistics,
-    query_timings: &[QueryTimingRow],
+    query_timings: &[(&'static str, QueryProfilingData)],
 ) -> std::io::Result<()> {
     let mut container = profiling_data();
     let named_spans_data = container.get_named_spans_table();
@@ -126,12 +126,12 @@ pub fn write_profiling_data_to_file<P: AsRef<Path>>(
         .collect();
     let query_timings_data = query_timings
         .iter()
-        .map(|row| QueryTimingRecord {
-            query: row.query.clone(),
-            count: row.count,
-            total: SerializableDuration(row.total),
-            min: SerializableDuration(row.min),
-            max: SerializableDuration(row.max),
+        .map(|(query, data)| QueryTimingRecord {
+            query: (*query).to_string(),
+            count: data.count,
+            total: SerializableDuration(data.total),
+            min: SerializableDuration(data.min),
+            max: SerializableDuration(data.max),
         })
         .collect();
 
@@ -266,13 +266,15 @@ mod tests {
 
     #[test]
     fn test_write_profiling_data_includes_query_timings() {
-        let rows = vec![QueryTimingRow {
-            query: "FileQueryTiming: (Age)".to_string(),
-            count: 2,
-            total: Duration::from_micros(40),
-            min: Duration::from_micros(10),
-            max: Duration::from_micros(30),
-        }];
+        let rows = vec![(
+            "FileQueryTiming: (Age)",
+            QueryProfilingData {
+                count: 2,
+                total: Duration::from_micros(40),
+                min: Duration::from_micros(10),
+                max: Duration::from_micros(30),
+            },
+        )];
 
         let temp_dir = TempDir::new().unwrap();
         let file_path = temp_dir.path().join("query_timing_test.json");

--- a/src/profiling/mod.rs
+++ b/src/profiling/mod.rs
@@ -5,6 +5,7 @@
 //! - Event counting – track how often named events occur during a run.
 //! - Rate calculation – compute rates (events per second) since the first count.
 //! - Span timing – measure time intervals with automatic closing on drop.
+//! - Query timing – aggregate entity query runtime by query shape.
 //! - Coverage – report how much of total runtime is covered by any span via a special
 //!   "Total Measured" span.
 //! - Computed statistics – define custom, derived metrics over collected data.
@@ -24,6 +25,10 @@
 //! get_contact                           1035   1ms 135us 202ns      0.43%
 //! schedule_next_forecasted_infection    1286  22ms 329us 102ns      8.44%
 //! Total Measured                        1385  23ms 897us 146ns      9.03%
+//!
+//! Query                    Count        Total          Min          Max
+//! --------------------------------------------------------------------
+//! Person: (Age, County)      150   12ms 340us   10us 120ns  250us 450ns
 //!
 //! Event Label                     Count  Rate (per sec)
 //! -----------------------------------------------------
@@ -76,8 +81,8 @@
 //! print_profiling_data();
 //! ```
 //! Prints spans, counts, and any computed statistics via the functions
-//! `print_named_spans()`, `print_named_counts()`, `print_computed_statistics()`,
-//! which you can use individually if you prefer.
+//! `print_named_spans()`, `print_named_counts()`, and `print_computed_statistics()`, which
+//! you can use individually if you prefer. Context-level reporting also includes query timings.
 //!
 //! Writing results to JSON together with execution statistics:
 //! ```rust,ignore
@@ -87,7 +92,8 @@
 //! fn finalize(mut context: Context) {
 //!     // Ensure Params::profiling_data_path is set, and report options specify
 //!     // output_dir/file_prefix/overwrite. This writes a pretty JSON file with:
-//!     //   date_time, execution_statistics, named_counts, named_spans, computed_statistics
+//!     //   date_time, execution_statistics, named_counts, named_spans,
+//!     //   query_timings, computed_statistics
 //!     context.write_profiling_data();
 //! }
 //! ```
@@ -187,6 +193,8 @@ const TOTAL_MEASURED: &str = "Total Measured";
 const NAMED_SPANS_HEADERS: &[&str] = &["Span Label", "Count", "Duration", "% runtime"];
 #[cfg(feature = "profiling")]
 const NAMED_COUNTS_HEADERS: &[&str] = &["Event Label", "Count", "Rate (per sec)"];
+#[cfg(feature = "profiling")]
+const QUERY_TIMINGS_HEADERS: &[&str] = &["Query", "Count", "Total", "Min", "Max"];
 
 pub struct Span {
     #[cfg(feature = "profiling")]

--- a/src/profiling/reporting.rs
+++ b/src/profiling/reporting.rs
@@ -1,6 +1,7 @@
 use std::path::Path;
 
 use super::file::write_profiling_data_to_file;
+use crate::execution_stats::ExecutionStatistics;
 use crate::{error, Context, ContextReportExt};
 
 /// Trait extension for [`Context`] providing profiling capabilities.
@@ -10,46 +11,90 @@ pub trait ProfilingContextExt: ContextReportExt {
     /// If `include_profiling_data` is true, also prints the global profiling data
     /// (spans, counts, and computed statistics).
     fn print_execution_statistics(&mut self, include_profiling_data: bool) {
-        let stats = self.get_execution_statistics();
-        crate::execution_stats::print_execution_statistics(&stats);
-
-        if include_profiling_data {
-            super::print_profiling_data();
-        }
+        print_execution_statistics(self, include_profiling_data);
     }
 
     /// Writes the execution statistics for the context and all profiling data
     /// to a JSON file.
     fn write_profiling_data(&mut self) {
-        let (mut prefix, directory, overwrite) = {
-            let report_options = self.report_options();
-            (
-                report_options.file_prefix.clone(),
-                report_options.output_dir.clone(),
-                report_options.overwrite,
-            )
-        };
-
-        let execution_statistics = self.get_execution_statistics();
-        // Default filename when not provided via parameters: write under report options
-        // using the current file prefix.
-        prefix.push_str("profiling.json");
-        let profiling_data_path = directory.join(prefix);
-        let profiling_data_path = Path::new(&profiling_data_path);
-
-        if !overwrite && profiling_data_path.exists() {
-            error!(
-                "profiling output file already exists: {}",
-                profiling_data_path.display()
-            );
-            return;
-        }
-
-        write_profiling_data_to_file(profiling_data_path, execution_statistics)
-            .expect("could not write profiling data to file");
+        #[cfg(feature = "profiling")]
+        write_profiling_output(self, |path, statistics| {
+            write_profiling_data_to_file(path, statistics, &[])
+        });
+        #[cfg(not(feature = "profiling"))]
+        write_profiling_output(self, |path, statistics| {
+            write_profiling_data_to_file(path, statistics)
+        });
     }
 }
-impl ProfilingContextExt for Context {}
+
+impl ProfilingContextExt for Context {
+    fn print_execution_statistics(&mut self, include_profiling_data: bool) {
+        print_execution_statistics(self, include_profiling_data);
+        #[cfg(feature = "profiling")]
+        {
+            if include_profiling_data {
+                super::print_query_timings(&self.query_timings_table());
+            }
+        }
+    }
+
+    fn write_profiling_data(&mut self) {
+        #[cfg(feature = "profiling")]
+        {
+            let query_timings = self.query_timings_table();
+            write_profiling_output(self, |path, statistics| {
+                write_profiling_data_to_file(path, statistics, &query_timings)
+            });
+        }
+        #[cfg(not(feature = "profiling"))]
+        write_profiling_output(self, |path, statistics| {
+            write_profiling_data_to_file(path, statistics)
+        });
+    }
+}
+
+fn print_execution_statistics<C: ContextReportExt>(context: &mut C, include_profiling_data: bool) {
+    let stats = context.get_execution_statistics();
+    crate::execution_stats::print_execution_statistics(&stats);
+
+    if include_profiling_data {
+        super::print_profiling_data();
+    }
+}
+
+fn write_profiling_output<C, F>(context: &mut C, write: F)
+where
+    C: ContextReportExt,
+    F: FnOnce(&Path, ExecutionStatistics) -> std::io::Result<()>,
+{
+    let (mut prefix, directory, overwrite) = {
+        let report_options = context.report_options();
+        (
+            report_options.file_prefix.clone(),
+            report_options.output_dir.clone(),
+            report_options.overwrite,
+        )
+    };
+
+    let execution_statistics = context.get_execution_statistics();
+    // Default filename when not provided via parameters: write under report options
+    // using the current file prefix.
+    prefix.push_str("profiling.json");
+    let profiling_data_path = directory.join(prefix);
+    let profiling_data_path = Path::new(&profiling_data_path);
+
+    if !overwrite && profiling_data_path.exists() {
+        error!(
+            "profiling output file already exists: {}",
+            profiling_data_path.display()
+        );
+        return;
+    }
+
+    write(profiling_data_path, execution_statistics)
+        .expect("could not write profiling data to file");
+}
 
 #[cfg(all(test, feature = "profiling"))]
 mod profiling_tests {

--- a/src/profiling/reporting.rs
+++ b/src/profiling/reporting.rs
@@ -1,7 +1,11 @@
+use std::io::Result as IoResult;
 use std::path::Path;
 
 use super::file::write_profiling_data_to_file;
-use crate::execution_stats::ExecutionStatistics;
+use super::print_profiling_data;
+#[cfg(feature = "profiling")]
+use super::print_query_timings;
+use crate::execution_stats::{print_execution_statistics as print_statistics, ExecutionStatistics};
 use crate::{error, Context, ContextReportExt};
 
 /// Trait extension for [`Context`] providing profiling capabilities.
@@ -34,7 +38,7 @@ impl ProfilingContextExt for Context {
         #[cfg(feature = "profiling")]
         {
             if include_profiling_data {
-                super::print_query_timings(&self.query_profiling_snapshot());
+                print_query_timings(&self.query_profiling_snapshot());
             }
         }
     }
@@ -56,17 +60,17 @@ impl ProfilingContextExt for Context {
 
 fn print_execution_statistics<C: ContextReportExt>(context: &mut C, include_profiling_data: bool) {
     let stats = context.get_execution_statistics();
-    crate::execution_stats::print_execution_statistics(&stats);
+    print_statistics(&stats);
 
     if include_profiling_data {
-        super::print_profiling_data();
+        print_profiling_data();
     }
 }
 
 fn write_profiling_output<C, F>(context: &mut C, write: F)
 where
     C: ContextReportExt,
-    F: FnOnce(&Path, ExecutionStatistics) -> std::io::Result<()>,
+    F: FnOnce(&Path, ExecutionStatistics) -> IoResult<()>,
 {
     let (mut prefix, directory, overwrite) = {
         let report_options = context.report_options();

--- a/src/profiling/reporting.rs
+++ b/src/profiling/reporting.rs
@@ -34,7 +34,7 @@ impl ProfilingContextExt for Context {
         #[cfg(feature = "profiling")]
         {
             if include_profiling_data {
-                super::print_query_timings(&self.query_timings_table());
+                super::print_query_timings(&self.query_profiling_snapshot());
             }
         }
     }
@@ -42,7 +42,7 @@ impl ProfilingContextExt for Context {
     fn write_profiling_data(&mut self) {
         #[cfg(feature = "profiling")]
         {
-            let query_timings = self.query_timings_table();
+            let query_timings = self.query_profiling_snapshot();
             write_profiling_output(self, |path, statistics| {
                 write_profiling_data_to_file(path, statistics, &query_timings)
             });


### PR DESCRIPTION
This PR builds upon the work of #966 and supersedes it. In individual commit order, the major changes relative to #966 are:

- It uses RAII guards instead of the `query_profiling_scope.measure(| | { /* thing to measure */ })` pattern (and removes the factored-out helpers that supported this pattern). This simplifies code structure, keeps the feature less invasive on non-"profiling" feature builds, and makes the code more panic-safe.
- It reuses the canonical query-shape resolution already used to locate query indexes, removing the redundant `&str`-keyed registry. It introduces `QueryIdentityId` as a handle to a single (profiler, query shape) identity, the key needed to accumulate the profiling data in `Context`-specific storage.
- Benchmarking uncovered performance regressions even when the "profiling" feature is disabled. The reasons and fixes are:
  - We accidentally clobbered a fast path for empty, singleton, and "all" queries, which I restored.
  - The surrounding code changes made it harder for Rust / LLVM to inline some functions for mysterious reasons. Adding a few `#[inline]` annotations fixed it.

I also rebased onto `main` and cleaned up some LLM-flavored structural and stylistic issues. This PR does not otherwise change the public semantics of the feature implemented in #966. 

A copy+paste of the feature description from #966 follows.

---

## Summary

  Adds query profiling under the `profiling` feature, with timing statistics aggregated per `Context` and query shape.

  - Records timings across eager query APIs, lazy `EntitySetIterator` execution, and `EntitySet` terminal and sampling operations.
  - Groups equivalent queries by entity type and unordered property names; property order and values do not affect query identity.
  - Reports timings in the profiling console output and the `query_timings` array in profiling JSON.
  - Keeps profiling-only types and helpers out of builds where the feature is disabled.

  ## Execution semantics

  `Count` represents **consumed query executions**:

  - Each eager query operation or `EntitySet` terminal operation records one execution.
  - An iterator records one execution after performing query work, regardless of whether it is consumed through `next`, `count`, `nth`, `for_each`, or `fold`.
  - Creating and dropping an unused iterator records nothing.
  - Dropping a partially consumed iterator records one execution containing only the work completed before the drop.
  - Repeated `next` calls after exhaustion do not create additional executions.
  - User callback time in `for_each` and `fold` is excluded.

  Iterator timing is accumulated with RAII and committed once on exhaustion or drop. This gives `count`, `min`, and `max` a consistent unit: one consumed query execution.

  ## Query identity and set algebra

  A query identity consists of the entity type and its sorted property names. For example, queries for `Age(10), Alive(true)` and `Alive(false), Age(20)` share a timing row.

  Set algebra uses a single-unique-origin attribution policy:

  - A profiled set combined with an unprofiled set retains the profiled identity.
  - Two profiled sets with the same identity retain that identity.
  - Two profiled sets with different identities clear profiling attribution rather than charging the composed work to an arbitrary query.

  ## Example console output

  ```text
Query                       Count       Total       Min         Max
------------------------------------------------------------------
Person: (Age, County)           3  42us 100ns  8us 50ns  20us 400ns
Person: (Age)                   1   7us 300ns  7us 300ns   7us 300ns
  ```

  ## Example JSON output

  ```json
{
  "query_timings": [
    {
      "query": "Person: (Age, County)",
      "count": 3,
      "total": 0.0000421,
      "min": 0.00000805,
      "max": 0.0000204
    },
    {
      "query": "Person: (Age)",
      "count": 1,
      "total": 0.0000073,
      "min": 0.0000073,
      "max": 0.0000073
    }
  ]
}
  ```