### PR TITLE
perf: specialize nth for unindexed property sources

### DIFF
--- a/src/entity/entity_set/source_set.rs
+++ b/src/entity/entity_set/source_set.rs
@@ -306,6 +306,14 @@ impl<'a, E: Entity, P: Property<E>> Iterator for ConcretePropertySource<'a, E, P
         // The population is exhausted.
         None
     }
+
+    #[inline]
+    fn nth(&mut self, n: usize) -> Option<Self::Item> {
+        for _ in 0..n {
+            self.next()?;
+        }
+        self.next()
+    }
 }
 
 /// Represents a concrete source of `EntityId<E>` values used by `EntitySet`.
@@ -532,6 +540,13 @@ mod tests {
             .unwrap()
             .into_iter()
             .collect::<Vec<_>>();
+        {
+            let mut unindexed_iter = SourceSet::<Person>::new::<Age>(Age(2), &context)
+                .unwrap()
+                .into_iter();
+            assert_eq!(unindexed_iter.nth(1), Some(EntityId::new(2)));
+            assert_eq!(unindexed_iter.next(), None);
+        }
 
         context.index_property::<Person, Age>();
         assert!(matches!(


### PR DESCRIPTION
  ## Summary

  - Implement ConcretePropertySource::nth directly.
  - Keep EntitySetIterator::nth unchanged.
  - Add test coverage for skipping through an unindexed property source.

  ## Motivation

  Unindexed single-property sampling uses Algorithm L, which repeatedly calls
  Iterator::nth. Relying on the default trait implementation produced a
  codegen-sensitive regression in the 10,000-entity benchmark.

  Specializing nth on ConcretePropertySource preserves the same behavior while
  stabilizing the hot path.

  ## Benchmark results

   Revision      10k median    Change from main    100k change from main
   main            4.931 µs 
   Before fix      6.557 µs              +33.0%                    -2.4%
   After fix       4.940 µs               +0.2%                    -1.3%

  The fix recovers over 99% of the lost 10k performance while retaining the 100k
  improvement.