### PR TITLE
fix: support profiling on wasm32

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -79,7 +79,7 @@ default = ["logging"]
 
 logging = ["log4rs", "fern", "wasm-bindgen", "web-sys"]
 
-profiling = ["dep:sysinfo", "dep:bytesize"]
+profiling = ["dep:sysinfo", "dep:bytesize", "wasm-bindgen", "web-sys"]
 
 # Only used to write `cli-usage.md` from clap-generated docs.
 write_cli_usage = ["clap-markdown"]

--- a/integration-tests/ixa-wasm-tests/Cargo.toml
+++ b/integration-tests/ixa-wasm-tests/Cargo.toml
@@ -20,7 +20,7 @@ js-sys = "^0.3.77"
 console_error_panic_hook = "0.1.7"
 
 # Explicitly use the Ixa in this same project.
-ixa = { path = "../../", default-features = false, features = ["logging"] }
+ixa = { path = "../../", default-features = false, features = ["logging", "profiling"] }
 rand_distr.workspace = true
 serde.workspace = true
 

--- a/integration-tests/ixa-wasm-tests/src/lib.rs
+++ b/integration-tests/ixa-wasm-tests/src/lib.rs
@@ -1,5 +1,6 @@
 use ixa::log::{debug, error, info, set_log_level, warn};
 use ixa::prelude::*;
+use ixa::profiling::{increment_named_count, open_span, ProfilingContextExt};
 use ixa::LevelFilter;
 use js_sys::Promise;
 use wasm_bindgen::prelude::*;
@@ -50,7 +51,11 @@ pub fn run_simulation() -> Promise {
         // Actually run the simulation
         let mut context = Context::new();
         initialize(&mut context);
-        context.execute();
+        increment_named_count("wasm_simulation");
+        {
+            let _span = open_span("wasm_simulation");
+            context.execute();
+        }
 
         let end = performance.now();
         let elapsed = end - start;
@@ -64,6 +69,17 @@ pub fn run_simulation() -> Promise {
 
         Ok(JsValue::from_str(&result))
     })
+}
+
+#[wasm_bindgen]
+pub fn run_query_profiling() -> usize {
+    let mut context = Context::new();
+    people::init(&mut context);
+    let count = context
+        .query_result_iterator(with!(people::Person, people::InfectionStatus::S))
+        .count();
+    context.print_execution_statistics(true);
+    count
 }
 
 // Simulates a panic by returning a rejected promise instead of triggering a

--- a/integration-tests/ixa-wasm-tests/tests/run-model.test.js
+++ b/integration-tests/ixa-wasm-tests/tests/run-model.test.js
@@ -65,6 +65,54 @@ test('simulation completes successfully in a web worker', async ({ page }) => {
     expect(result).toContain('Simulation complete');
 });
 
+test('query profiling prints in the browser and a web worker', async ({ page }) => {
+    const profilingOutput = [];
+    page.on('console', message => {
+        const text = message.text();
+        if (!(text.includes('Query') && text.includes('Count')) &&
+            !text.includes('Person: (InfectionStatus)')) {
+            return;
+        }
+
+        profilingOutput.push(text);
+        // eslint-disable-next-line no-console
+        console.log(text);
+    });
+
+    await page.goto('http://localhost:8080');
+
+    const browserResult = await page.evaluate(async () => {
+        const wasm = await window.setupWasm();
+        return wasm.run_query_profiling();
+    });
+
+    const workerResult = await page.evaluate(async () => {
+        return new Promise((resolve, reject) => {
+            const worker = new Worker('/worker.js', { type: 'module' });
+            worker.onmessage = (e) => {
+                worker.terminate();
+                if (e.data.status === 'ok') {
+                    resolve(e.data.result);
+                } else {
+                    reject(new Error(e.data.message));
+                }
+            };
+            worker.onerror = (e) => {
+                worker.terminate();
+                reject(new Error(e.message));
+            };
+            worker.postMessage('query-profiling');
+        });
+    });
+
+    expect(browserResult).toBe(100);
+    expect(workerResult).toBe(100);
+    const headers = profilingOutput.filter(line => line.includes('Query') && line.includes('Count'));
+    const rows = profilingOutput.filter(line => line.includes('Person: (InfectionStatus)'));
+    expect(headers).toHaveLength(2);
+    expect(rows).toHaveLength(2);
+});
+
 test('real wasm panic emits console error', async ({ page }) => {
     const consoleMessages = [];
     page.on('console', msg => consoleMessages.push(msg.text()));

--- a/integration-tests/ixa-wasm-tests/worker.js
+++ b/integration-tests/ixa-wasm-tests/worker.js
@@ -1,9 +1,11 @@
-self.onmessage = async function () {
+self.onmessage = async function (event) {
     try {
         const wasm = await import("/pkg/ixa_wasm_tests.js");
         await wasm.default();
         wasm.setup_error_hook();
-        const result = await wasm.run_simulation();
+        const result = event.data === "query-profiling"
+            ? wasm.run_query_profiling()
+            : await wasm.run_simulation();
         self.postMessage({ status: "ok", result });
     } catch (e) {
         self.postMessage({ status: "error", message: e.message || String(e) });

--- a/mise.toml
+++ b/mise.toml
@@ -95,7 +95,7 @@ run = '''
 [tasks.'test:wasm']
 description = "Run wasm integration tests"
 dir = "integration-tests/ixa-wasm-tests"
-depends = ["wasm:pnpm", "wasm:compile"]
+depends = ["wasm:pnpm", "wasm:check-profiling", "wasm:compile"]
 run = "pnpm exec playwright test"
 
 [tasks.'test:features']
@@ -126,6 +126,12 @@ dir = "integration-tests/ixa-wasm-tests"
 run = ["mise run rust:version", "wasm-pack build --target web"]
 sources = ["src/*.rs", "Cargo.toml"]
 outputs = "pkg"
+
+[tasks.'wasm:check-profiling']
+run = [
+  "mise run rust:version",
+  "cargo check --package ixa --target wasm32-unknown-unknown --no-default-features --features profiling",
+]
 
 [tasks.'bench']
 description = "Run all benchmarks"

--- a/src/execution_stats.rs
+++ b/src/execution_stats.rs
@@ -8,7 +8,7 @@ use serde_derive::Serialize;
 #[cfg(feature = "profiling")]
 use sysinfo::{Pid, ProcessRefreshKind, ProcessesToUpdate, System};
 #[cfg(target_arch = "wasm32")]
-use wasm_bindgen::prelude::*;
+use wasm_bindgen::{JsCast, JsValue};
 
 #[cfg(feature = "profiling")]
 use crate::profiling::QueryProfiler;
@@ -51,16 +51,6 @@ impl ProfilingInstant {
 
         Duration::from_secs_f64(elapsed_milliseconds / 1000.0)
     }
-}
-
-#[cfg(target_arch = "wasm32")]
-#[wasm_bindgen]
-#[must_use]
-/// Returns a high-resolution monotonic timestamp in milliseconds.
-///
-/// This works in both Window and Web Worker contexts.
-pub fn get_high_res_time() -> f64 {
-    ProfilingInstant::now().0
 }
 
 /// A container struct for computed final statistics.

--- a/src/execution_stats.rs
+++ b/src/execution_stats.rs
@@ -1,6 +1,4 @@
 use std::time::Duration;
-#[cfg(not(target_arch = "wasm32"))]
-use std::time::Instant;
 
 use humantime::format_duration;
 use log::info;
@@ -15,21 +13,54 @@ use wasm_bindgen::prelude::*;
 #[cfg(feature = "profiling")]
 use crate::profiling::QueryProfiler;
 
+/// A monotonic timestamp used to measure profiling intervals.
+///
+/// Only `now()` and `elapsed()` are part of the portable API shared by native
+/// and WASM targets.
+#[cfg(not(target_arch = "wasm32"))]
+pub type ProfilingInstant = std::time::Instant;
+
+/// A monotonic timestamp used to measure profiling intervals.
+///
+/// Only `now()` and `elapsed()` are part of the portable API shared by native
+/// and WASM targets.
+#[cfg(target_arch = "wasm32")]
+#[derive(Clone, Copy, Debug, PartialEq, PartialOrd)]
+pub struct ProfilingInstant(f64);
+
+#[cfg(target_arch = "wasm32")]
+impl ProfilingInstant {
+    #[must_use]
+    pub fn now() -> Self {
+        use web_sys::js_sys::Reflect;
+
+        let global = web_sys::js_sys::global();
+        let performance = Reflect::get(&global, &"performance".into())
+            .ok()
+            .and_then(|value: JsValue| value.dyn_into::<web_sys::Performance>().ok());
+
+        Self(performance.map_or(0.0, |performance| performance.now()))
+    }
+
+    #[must_use]
+    pub fn elapsed(&self) -> Duration {
+        let elapsed_milliseconds = Self::now().0 - self.0;
+        if !elapsed_milliseconds.is_finite() || elapsed_milliseconds <= 0.0 {
+            return Duration::ZERO;
+        }
+
+        Duration::from_secs_f64(elapsed_milliseconds / 1000.0)
+    }
+}
+
 #[cfg(target_arch = "wasm32")]
 #[wasm_bindgen]
 #[must_use]
-/// The `wasm` target does not support `std::time::Instant::now()`.
-/// Works in both Window and Web Worker contexts.
+/// Returns a high-resolution monotonic timestamp in milliseconds.
+///
+/// This works in both Window and Web Worker contexts.
 pub fn get_high_res_time() -> f64 {
-    use web_sys::js_sys::Reflect;
-    let global = web_sys::js_sys::global();
-    let performance = Reflect::get(&global, &"performance".into())
-        .ok()
-        .and_then(|v: JsValue| v.dyn_into::<web_sys::Performance>().ok());
-    match performance {
-        Some(perf) => perf.now(),
-        None => 0.0,
-    }
+    ProfilingInstant::now().0
 }
 
 /// A container struct for computed final statistics.
@@ -53,16 +84,10 @@ pub(crate) struct ExecutionProfilingCollector {
     /// Aggregate profiling data for entity queries executed by this context.
     pub(crate) query_profiler: QueryProfiler,
     /// Simulation start time, used to compute elapsed wall time for the simulation execution
-    #[cfg(not(target_arch = "wasm32"))]
-    start_time: Instant,
-    #[cfg(target_arch = "wasm32")]
-    start_time: f64,
+    start_time: ProfilingInstant,
     /// We keep track of the last time we refreshed so that client code doesn't have to and can
     /// just call `ExecutionProfilingCollector::refresh` in its event loop.
-    #[cfg(not(target_arch = "wasm32"))]
-    last_refresh: Instant,
-    #[cfg(target_arch = "wasm32")]
-    last_refresh: f64,
+    last_refresh: ProfilingInstant,
     /// The accumulated CPU time of the process in CPU-milliseconds at simulation start, used
     /// to compute the CPU time of the simulation execution
     start_cpu_time: u64,
@@ -81,10 +106,7 @@ impl ExecutionProfilingCollector {
     #[must_use]
     pub fn new() -> ExecutionProfilingCollector {
         let process_id = sysinfo::get_current_pid().ok();
-        #[cfg(target_arch = "wasm32")]
-        let now = get_high_res_time();
-        #[cfg(not(target_arch = "wasm32"))]
-        let now = Instant::now();
+        let now = ProfilingInstant::now();
 
         let mut new_stats = ExecutionProfilingCollector {
             query_profiler: QueryProfiler::default(),
@@ -118,7 +140,7 @@ impl ExecutionProfilingCollector {
         #[cfg(not(target_arch = "wasm32"))]
         if self.last_refresh.elapsed() >= REFRESH_INTERVAL {
             self.poll_memory();
-            self.last_refresh = Instant::now();
+            self.last_refresh = ProfilingInstant::now();
         }
     }
 
@@ -181,13 +203,7 @@ impl ExecutionProfilingCollector {
 
         // Convert to `Duration`s in preparation for formatting
         let cpu_time = Duration::from_millis(cpu_time_millis);
-        #[cfg(target_arch = "wasm32")]
-        let wall_time = get_high_res_time() - self.start_time;
-        #[cfg(not(target_arch = "wasm32"))]
         let wall_time = self.start_time.elapsed();
-
-        #[cfg(target_arch = "wasm32")]
-        let wall_time = Duration::from_millis(wall_time as u64);
 
         ExecutionStatistics {
             max_memory_usage: self.max_memory_usage,
@@ -201,22 +217,16 @@ impl ExecutionProfilingCollector {
 
 #[cfg(not(feature = "profiling"))]
 pub(crate) struct ExecutionProfilingCollector {
-    #[cfg(not(target_arch = "wasm32"))]
-    start_time: Instant,
-    #[cfg(target_arch = "wasm32")]
-    start_time: f64,
+    start_time: ProfilingInstant,
 }
 
 #[cfg(not(feature = "profiling"))]
 impl ExecutionProfilingCollector {
     #[must_use]
     pub fn new() -> ExecutionProfilingCollector {
-        #[cfg(target_arch = "wasm32")]
-        let now = get_high_res_time();
-        #[cfg(not(target_arch = "wasm32"))]
-        let now = Instant::now();
-
-        ExecutionProfilingCollector { start_time: now }
+        ExecutionProfilingCollector {
+            start_time: ProfilingInstant::now(),
+        }
     }
 
     #[inline]
@@ -224,13 +234,7 @@ impl ExecutionProfilingCollector {
 
     #[must_use]
     pub fn compute_final_statistics(&mut self) -> ExecutionStatistics {
-        #[cfg(target_arch = "wasm32")]
-        let wall_time = get_high_res_time() - self.start_time;
-        #[cfg(not(target_arch = "wasm32"))]
         let wall_time = self.start_time.elapsed();
-
-        #[cfg(target_arch = "wasm32")]
-        let wall_time = Duration::from_millis(wall_time as u64);
 
         ExecutionStatistics {
             max_memory_usage: 0,
@@ -350,7 +354,7 @@ mod tests {
 
         // Burn ~30ms CPU time. Likely will be < 30ms, as this thread will not have 100% of CPU
         // during 30ms wall time.
-        let start = Instant::now();
+        let start = ProfilingInstant::now();
         while start.elapsed().as_millis() < 30u128 {
             std::hint::black_box(0); // Prevent optimization
         }
@@ -358,7 +362,7 @@ mod tests {
         let cpu_time_1 = collector.cpu_time();
 
         // Burn ~50ms CPU time
-        let start = Instant::now();
+        let start = ProfilingInstant::now();
         while start.elapsed().as_millis() < 50u128 {
             std::hint::black_box(0); // Prevent optimization
         }

--- a/src/profiling/data.rs
+++ b/src/profiling/data.rs
@@ -6,9 +6,11 @@ use std::collections::hash_map::Entry;
 use std::ptr::eq;
 #[cfg(feature = "profiling")]
 use std::sync::{Mutex, MutexGuard, OnceLock};
-use std::time::{Duration, Instant};
+use std::time::Duration;
 
 use super::computed_statistic::ComputableType;
+#[cfg(feature = "profiling")]
+use super::ProfilingInstant;
 use super::Span;
 #[cfg(feature = "profiling")]
 use super::{
@@ -33,7 +35,8 @@ pub(super) fn profiling_data() -> MutexGuard<'static, ProfilingData> {
 
 #[derive(Default)]
 pub struct ProfilingData {
-    pub start_time: Option<Instant>,
+    #[cfg(feature = "profiling")]
+    pub start_time: Option<ProfilingInstant>,
     pub counts: HashMap<&'static str, usize>,
     // We store span counts with the span duration, because they are updated when
     // the spans are and displayed with the spans rather than with the other counts.
@@ -47,7 +50,7 @@ pub struct ProfilingData {
     #[cfg(feature = "profiling")]
     pub(super) open_span_count: usize,
     #[cfg(feature = "profiling")]
-    pub(super) coverage: Option<Instant>,
+    pub(super) coverage: Option<ProfilingInstant>,
     // Custom computed statistics. They are wrapped in an `Option` to allow for temporarily
     // removing them to avoid a double borrow.
     #[cfg(feature = "profiling")]
@@ -162,7 +165,7 @@ impl<'a> QueryProfileHandle<'a> {
     pub(crate) fn scope(self) -> QueryProfileScope<'a> {
         QueryProfileScope {
             handle: self,
-            start_time: Instant::now(),
+            start_time: ProfilingInstant::now(),
         }
     }
 
@@ -188,7 +191,7 @@ impl Eq for QueryProfileHandle<'_> {}
 #[cfg(feature = "profiling")]
 pub(crate) struct QueryProfileScope<'a> {
     handle: QueryProfileHandle<'a>,
-    start_time: Instant,
+    start_time: ProfilingInstant,
 }
 
 #[cfg(feature = "profiling")]
@@ -224,7 +227,7 @@ impl<'a> QueryExecutionProfile<'a> {
         self.elapsed.get_or_insert(Duration::ZERO);
         Some(QueryExecutionScope {
             execution: self,
-            start_time: Instant::now(),
+            start_time: ProfilingInstant::now(),
         })
     }
 
@@ -249,7 +252,7 @@ impl Drop for QueryExecutionProfile<'_> {
 #[cfg(feature = "profiling")]
 pub(crate) struct QueryExecutionScope<'execution, 'context> {
     execution: &'execution mut QueryExecutionProfile<'context>,
-    start_time: Instant,
+    start_time: ProfilingInstant,
 }
 
 #[cfg(feature = "profiling")]
@@ -277,7 +280,7 @@ impl ProfilingData {
 
     fn init_start_time(&mut self) {
         if self.start_time.is_none() {
-            self.start_time = Some(Instant::now());
+            self.start_time = Some(ProfilingInstant::now());
         }
     }
 
@@ -285,7 +288,7 @@ impl ProfilingData {
         self.init_start_time();
         if self.open_span_count == 0 {
             // Start recording coverage time.
-            self.coverage = Some(Instant::now());
+            self.coverage = Some(ProfilingInstant::now());
         }
         self.open_span_count += 1;
         Span::new(label)
@@ -531,7 +534,7 @@ mod tests {
             start_time.elapsed().as_secs_f64()
         } else {
             // If profiling hasn't started yet, rate will be based on init at first increment,
-            // so approximate by measuring from the first increment call using a local Instant.
+            // so approximate the elapsed time from the first increment call.
             // In practice, this path should rarely trigger.
             0.1
         };

--- a/src/profiling/display.rs
+++ b/src/profiling/display.rs
@@ -172,7 +172,11 @@ pub fn print_formatted_table(rows: &[Vec<String>]) {
 
     // Print separator
     let total_width: usize = col_widths.iter().map(|w| *w + 2).sum();
-    print_table_line(&"-".repeat(total_width));
+    let separator = "-".repeat(total_width);
+    #[cfg(target_arch = "wasm32")]
+    web_sys::console::log_1(&separator.into());
+    #[cfg(not(target_arch = "wasm32"))]
+    println!("{separator}");
 
     // Print data rows
     for row in &rows[1..] {
@@ -190,16 +194,9 @@ fn print_formatted_row(row: &[String], col_widths: &[usize]) {
             write!(&mut line, "{:>width$} ", cell, width = col_widths[i] + 1).unwrap();
         }
     }
-    print_table_line(&line);
-}
-
-#[cfg(all(feature = "profiling", target_arch = "wasm32"))]
-fn print_table_line(line: &str) {
+    #[cfg(target_arch = "wasm32")]
     web_sys::console::log_1(&line.into());
-}
-
-#[cfg(all(feature = "profiling", not(target_arch = "wasm32")))]
-fn print_table_line(line: &str) {
+    #[cfg(not(target_arch = "wasm32"))]
     println!("{line}");
 }
 

--- a/src/profiling/display.rs
+++ b/src/profiling/display.rs
@@ -185,11 +185,9 @@ fn print_formatted_row(row: &[String], col_widths: &[usize]) {
     let mut line = String::new();
     for (i, cell) in row.iter().enumerate() {
         if i == 0 {
-            write!(&mut line, "{:<width$} ", cell, width = col_widths[i] + 1)
-                .expect("writing to a String cannot fail");
+            write!(&mut line, "{:<width$} ", cell, width = col_widths[i] + 1).unwrap();
         } else {
-            write!(&mut line, "{:>width$} ", cell, width = col_widths[i] + 1)
-                .expect("writing to a String cannot fail");
+            write!(&mut line, "{:>width$} ", cell, width = col_widths[i] + 1).unwrap();
         }
     }
     print_table_line(&line);

--- a/src/profiling/display.rs
+++ b/src/profiling/display.rs
@@ -1,4 +1,7 @@
 #[cfg(feature = "profiling")]
+use std::fmt::Write;
+
+#[cfg(feature = "profiling")]
 use humantime::format_duration;
 
 #[cfg(feature = "profiling")]
@@ -165,33 +168,41 @@ pub fn print_formatted_table(rows: &[Vec<String>]) {
         }
     }
 
-    // Print header row
-    let header = &rows[0];
-    for (i, cell) in header.iter().enumerate() {
-        if i == 0 {
-            print!("{:<width$} ", cell, width = col_widths[i] + 1);
-        } else {
-            print!("{:>width$} ", cell, width = col_widths[i] + 1);
-        }
-    }
-    println!();
+    print_formatted_row(&rows[0], &col_widths);
 
     // Print separator
     let total_width: usize = col_widths.iter().map(|w| *w + 2).sum();
-    println!("{}", "-".repeat(total_width));
+    print_table_line(&"-".repeat(total_width));
 
     // Print data rows
     for row in &rows[1..] {
-        // First column left-aligned, rest right-aligned
-        for (i, cell) in row.iter().enumerate() {
-            if i == 0 {
-                print!("{:<width$} ", cell, width = col_widths[i] + 1);
-            } else {
-                print!("{:>width$} ", cell, width = col_widths[i] + 1);
-            }
-        }
-        println!();
+        print_formatted_row(row, &col_widths);
     }
+}
+
+#[cfg(feature = "profiling")]
+fn print_formatted_row(row: &[String], col_widths: &[usize]) {
+    let mut line = String::new();
+    for (i, cell) in row.iter().enumerate() {
+        if i == 0 {
+            write!(&mut line, "{:<width$} ", cell, width = col_widths[i] + 1)
+                .expect("writing to a String cannot fail");
+        } else {
+            write!(&mut line, "{:>width$} ", cell, width = col_widths[i] + 1)
+                .expect("writing to a String cannot fail");
+        }
+    }
+    print_table_line(&line);
+}
+
+#[cfg(all(feature = "profiling", target_arch = "wasm32"))]
+fn print_table_line(line: &str) {
+    web_sys::console::log_1(&line.into());
+}
+
+#[cfg(all(feature = "profiling", not(target_arch = "wasm32")))]
+fn print_table_line(line: &str) {
+    println!("{line}");
 }
 
 /// Formats an integer with thousands separator.

--- a/src/profiling/mod.rs
+++ b/src/profiling/mod.rs
@@ -169,48 +169,13 @@ mod reporting;
 
 use std::path::Path;
 
-#[cfg(all(feature = "profiling", target_arch = "wasm32"))]
-use crate::execution_stats::get_high_res_time;
-
-/// A monotonic timestamp used to measure profiling intervals.
-///
-/// Only `now()` and `elapsed()` are part of the portable API shared by native
-/// and WASM targets.
-#[cfg(all(feature = "profiling", not(target_arch = "wasm32")))]
-pub type ProfilingInstant = std::time::Instant;
-
-/// A monotonic timestamp used to measure profiling intervals.
-///
-/// Only `now()` and `elapsed()` are part of the portable API shared by native
-/// and WASM targets.
-#[cfg(all(feature = "profiling", target_arch = "wasm32"))]
-#[derive(Clone, Copy, Debug, PartialEq, PartialOrd)]
-pub struct ProfilingInstant(f64);
-
-#[cfg(all(feature = "profiling", target_arch = "wasm32"))]
-impl ProfilingInstant {
-    #[must_use]
-    pub fn now() -> Self {
-        Self(get_high_res_time())
-    }
-
-    #[must_use]
-    pub fn elapsed(&self) -> std::time::Duration {
-        let elapsed_milliseconds = get_high_res_time() - self.0;
-        if !elapsed_milliseconds.is_finite() || elapsed_milliseconds <= 0.0 {
-            return std::time::Duration::ZERO;
-        }
-
-        std::time::Duration::from_secs_f64(elapsed_milliseconds / 1000.0)
-    }
-}
-
 pub use computed_statistic::*;
 pub use data::*;
 pub use display::*;
 use file::write_profiling_data_to_file;
 pub use reporting::*;
 
+pub use crate::execution_stats::ProfilingInstant;
 use crate::{error, Context, ContextReportExt};
 
 #[cfg(all(test, feature = "profiling"))]

--- a/src/profiling/mod.rs
+++ b/src/profiling/mod.rs
@@ -168,8 +168,42 @@ mod file;
 mod reporting;
 
 use std::path::Path;
-#[cfg(feature = "profiling")]
-use std::time::Instant;
+
+#[cfg(all(feature = "profiling", target_arch = "wasm32"))]
+use crate::execution_stats::get_high_res_time;
+
+/// A monotonic timestamp used to measure profiling intervals.
+///
+/// Only `now()` and `elapsed()` are part of the portable API shared by native
+/// and WASM targets.
+#[cfg(all(feature = "profiling", not(target_arch = "wasm32")))]
+pub type ProfilingInstant = std::time::Instant;
+
+/// A monotonic timestamp used to measure profiling intervals.
+///
+/// Only `now()` and `elapsed()` are part of the portable API shared by native
+/// and WASM targets.
+#[cfg(all(feature = "profiling", target_arch = "wasm32"))]
+#[derive(Clone, Copy, Debug, PartialEq, PartialOrd)]
+pub struct ProfilingInstant(f64);
+
+#[cfg(all(feature = "profiling", target_arch = "wasm32"))]
+impl ProfilingInstant {
+    #[must_use]
+    pub fn now() -> Self {
+        Self(get_high_res_time())
+    }
+
+    #[must_use]
+    pub fn elapsed(&self) -> std::time::Duration {
+        let elapsed_milliseconds = get_high_res_time() - self.0;
+        if !elapsed_milliseconds.is_finite() || elapsed_milliseconds <= 0.0 {
+            return std::time::Duration::ZERO;
+        }
+
+        std::time::Duration::from_secs_f64(elapsed_milliseconds / 1000.0)
+    }
+}
 
 pub use computed_statistic::*;
 pub use data::*;
@@ -200,7 +234,7 @@ pub struct Span {
     #[cfg(feature = "profiling")]
     label: &'static str,
     #[cfg(feature = "profiling")]
-    start_time: Instant,
+    start_time: ProfilingInstant,
 }
 
 impl Span {
@@ -209,7 +243,7 @@ impl Span {
             #[cfg(feature = "profiling")]
             label,
             #[cfg(feature = "profiling")]
-            start_time: Instant::now(),
+            start_time: ProfilingInstant::now(),
         }
     }
 }


### PR DESCRIPTION
• ## Summary

  Fixes #1035 by enabling profiling on `wasm32-unknown-unknown`.

  ## Changes

  - Add a portable `ProfilingInstant` abstraction:
    - Uses `std::time::Instant` on native targets.
    - Uses `performance.now()` on WASM.
  - Use `ProfilingInstant` across query profiling and execution statistics.
  - Support timing in both browser windows and Web Workers.
  - Preserve the existing `get_high_res_time()` WASM export.
  - Print profiling tables to the browser console.
  - Enable profiling in the WASM integration-test crate.
  - Test query profiling in both the browser and a Web Worker.
  - Add a CI check for the WASM profiling feature combination.