### PR TITLE
test: add isolated wasm feature runtime coverage

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -77,9 +77,9 @@ authors.workspace = true
 [features]
 default = ["logging"]
 
-logging = ["log4rs", "fern", "wasm-bindgen", "web-sys"]
+logging = ["log4rs", "fern"]
 
-profiling = ["dep:sysinfo", "dep:bytesize", "wasm-bindgen", "web-sys"]
+profiling = ["dep:sysinfo", "dep:bytesize"]
 
 # Only used to write `cli-usage.md` from clap-generated docs.
 write_cli_usage = ["clap-markdown"]
@@ -120,9 +120,8 @@ log4rs = { workspace = true, optional = true }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 fern = { workspace = true, optional = true }
-# Required here only to enable the js backend:
-wasm-bindgen = { workspace = true, optional = true }
-web-sys = { workspace = true, optional = true, features = ["console", "Performance", "Window"] }
+wasm-bindgen.workspace = true
+web-sys = { workspace = true, features = ["console", "Performance", "Window"] }
 
 [dev-dependencies]
 anyhow.workspace = true

--- a/integration-tests/ixa-wasm-tests/Cargo.toml
+++ b/integration-tests/ixa-wasm-tests/Cargo.toml
@@ -12,6 +12,11 @@ authors.workspace = true
 [lib]
 crate-type = ["cdylib"]
 
+[features]
+default = ["logging", "profiling"]
+logging = ["ixa/logging"]
+profiling = ["ixa/profiling"]
+
 [dependencies]
 wasm-bindgen = "0.2"
 wasm-bindgen-futures = "0.4"
@@ -20,7 +25,7 @@ js-sys = "^0.3.77"
 console_error_panic_hook = "0.1.7"
 
 # Explicitly use the Ixa in this same project.
-ixa = { path = "../../", default-features = false, features = ["logging", "profiling"] }
+ixa = { path = "../../", default-features = false }
 rand_distr.workspace = true
 serde.workspace = true
 

--- a/integration-tests/ixa-wasm-tests/src/lib.rs
+++ b/integration-tests/ixa-wasm-tests/src/lib.rs
@@ -1,6 +1,9 @@
+#[cfg(feature = "logging")]
 use ixa::log::{debug, error, info, set_log_level, warn};
 use ixa::prelude::*;
+#[cfg(feature = "profiling")]
 use ixa::profiling::{increment_named_count, open_span, ProfilingContextExt};
+#[cfg(feature = "logging")]
 use ixa::LevelFilter;
 use js_sys::Promise;
 use wasm_bindgen::prelude::*;
@@ -45,32 +48,40 @@ pub fn run_simulation() -> Promise {
             .ok_or("performance not available")?;
         let start = performance.now();
 
-        // Logging
+        #[cfg(feature = "logging")]
         set_log_level(LevelFilter::Trace);
 
         // Actually run the simulation
         let mut context = Context::new();
         initialize(&mut context);
-        increment_named_count("wasm_simulation");
+
+        #[cfg(feature = "profiling")]
         {
+            increment_named_count("wasm_simulation");
             let _span = open_span("wasm_simulation");
             context.execute();
         }
+        #[cfg(not(feature = "profiling"))]
+        context.execute();
 
         let end = performance.now();
         let elapsed = end - start;
 
         let result = format!("Simulation complete in {:.2} ms", elapsed);
 
-        debug!("This is a debug message.");
-        info!("This is an info message.");
-        warn!("This is a warning message.");
-        error!("This is an error message.");
+        #[cfg(feature = "logging")]
+        {
+            debug!("This is a debug message.");
+            info!("This is an info message.");
+            warn!("This is a warning message.");
+            error!("This is an error message.");
+        }
 
         Ok(JsValue::from_str(&result))
     })
 }
 
+#[cfg(feature = "profiling")]
 #[wasm_bindgen]
 pub fn run_query_profiling() -> usize {
     let mut context = Context::new();

--- a/integration-tests/ixa-wasm-tests/test-harness.html
+++ b/integration-tests/ixa-wasm-tests/test-harness.html
@@ -1,0 +1,8 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8" />
+    <title>Ixa WASM Test Harness</title>
+</head>
+<body></body>
+</html>

--- a/integration-tests/ixa-wasm-tests/tests/run-model.test.js
+++ b/integration-tests/ixa-wasm-tests/tests/run-model.test.js
@@ -2,8 +2,8 @@ const { test, expect } = require('@playwright/test');
 
 test.beforeEach(async ({ page }) => {
     await page.addInitScript(async () => {
-        window.setupWasm = async () => {
-            const wasm = await import('/pkg/ixa_wasm_tests.js');
+        window.setupWasm = async (packagePath = '/pkg/ixa_wasm_tests.js') => {
+            const wasm = await import(packagePath);
             await wasm.default();
             wasm.setup_error_hook();
             return wasm;
@@ -20,6 +20,49 @@ test('simulation completes successfully', async ({ page }) => {
     });
 
     expect(result).toContain('Simulation complete');
+});
+
+test('logging works with only the logging feature enabled', async ({ page }) => {
+    const loggingOutput = [];
+    page.on('console', message => {
+        const text = message.text();
+        if (text.includes('This is a')) {
+            loggingOutput.push(text);
+        }
+    });
+
+    await page.goto('http://localhost:8080');
+
+    const result = await page.evaluate(async () => {
+        const wasm = await window.setupWasm('/pkg/logging/ixa_wasm_tests.js');
+        return wasm.run_simulation();
+    });
+
+    expect(result).toContain('Simulation complete');
+    for (const message of [
+        'This is a debug message.',
+        'This is an info message.',
+        'This is a warning message.',
+        'This is an error message.',
+    ]) {
+        expect(loggingOutput.some(line => line.includes(message))).toBeTruthy();
+    }
+});
+
+test('profiling works with only the profiling feature enabled', async ({ page }) => {
+    const profilingOutput = [];
+    page.on('console', message => profilingOutput.push(message.text()));
+
+    await page.goto('http://localhost:8080');
+
+    const result = await page.evaluate(async () => {
+        const wasm = await window.setupWasm('/pkg/profiling/ixa_wasm_tests.js');
+        return wasm.run_query_profiling();
+    });
+
+    expect(result).toBe(100);
+    expect(profilingOutput.some(line => line.includes('Query') && line.includes('Count'))).toBeTruthy();
+    expect(profilingOutput.some(line => line.includes('Person: (InfectionStatus)'))).toBeTruthy();
 });
 
 test('simulation error (simulated panic) as expected', async ({ page }) => {

--- a/integration-tests/ixa-wasm-tests/tests/run-model.test.js
+++ b/integration-tests/ixa-wasm-tests/tests/run-model.test.js
@@ -1,5 +1,8 @@
 const { test, expect } = require('@playwright/test');
 
+const TEST_PAGE = 'http://localhost:8080/test-harness.html';
+const CONSOLE_EVENT_TIMEOUT_MS = 5_000;
+
 test.beforeEach(async ({ page }) => {
     await page.addInitScript(async () => {
         window.setupWasm = async (packagePath = '/pkg/ixa_wasm_tests.js') => {
@@ -11,8 +14,20 @@ test.beforeEach(async ({ page }) => {
     });
 });
 
+const waitForProfilingTable = page => Promise.all([
+    page.waitForEvent('console', {
+        predicate: message =>
+            message.text().includes('Query') && message.text().includes('Count'),
+        timeout: CONSOLE_EVENT_TIMEOUT_MS,
+    }),
+    page.waitForEvent('console', {
+        predicate: message => message.text().includes('Person: (InfectionStatus)'),
+        timeout: CONSOLE_EVENT_TIMEOUT_MS,
+    }),
+]);
+
 test('simulation completes successfully', async ({ page }) => {
-    await page.goto('http://localhost:8080');
+    await page.goto(TEST_PAGE);
 
     const result = await page.evaluate(async () => {
         let wasm = await window.setupWasm();
@@ -23,50 +38,48 @@ test('simulation completes successfully', async ({ page }) => {
 });
 
 test('logging works with only the logging feature enabled', async ({ page }) => {
-    const loggingOutput = [];
-    page.on('console', message => {
-        const text = message.text();
-        if (text.includes('This is a')) {
-            loggingOutput.push(text);
-        }
-    });
+    await page.goto(TEST_PAGE);
 
-    await page.goto('http://localhost:8080');
-
-    const result = await page.evaluate(async () => {
-        const wasm = await window.setupWasm('/pkg/logging/ixa_wasm_tests.js');
-        return wasm.run_simulation();
-    });
-
-    expect(result).toContain('Simulation complete');
-    for (const message of [
+    const expectedMessages = [
         'This is a debug message.',
         'This is an info message.',
         'This is a warning message.',
         'This is an error message.',
-    ]) {
-        expect(loggingOutput.some(line => line.includes(message))).toBeTruthy();
-    }
+    ];
+    const loggingOutput = Promise.all(expectedMessages.map(expectedMessage =>
+        page.waitForEvent('console', {
+            predicate: message => message.text().includes(expectedMessage),
+            timeout: CONSOLE_EVENT_TIMEOUT_MS,
+        })
+    ));
+    const [result] = await Promise.all([
+        page.evaluate(async () => {
+            const wasm = await window.setupWasm('/pkg/logging/ixa_wasm_tests.js');
+            return wasm.run_simulation();
+        }),
+        loggingOutput,
+    ]);
+
+    expect(result).toContain('Simulation complete');
 });
 
 test('profiling works with only the profiling feature enabled', async ({ page }) => {
-    const profilingOutput = [];
-    page.on('console', message => profilingOutput.push(message.text()));
+    await page.goto(TEST_PAGE);
 
-    await page.goto('http://localhost:8080');
-
-    const result = await page.evaluate(async () => {
-        const wasm = await window.setupWasm('/pkg/profiling/ixa_wasm_tests.js');
-        return wasm.run_query_profiling();
-    });
+    const profilingOutput = waitForProfilingTable(page);
+    const [result] = await Promise.all([
+        page.evaluate(async () => {
+            const wasm = await window.setupWasm('/pkg/profiling/ixa_wasm_tests.js');
+            return wasm.run_query_profiling();
+        }),
+        profilingOutput,
+    ]);
 
     expect(result).toBe(100);
-    expect(profilingOutput.some(line => line.includes('Query') && line.includes('Count'))).toBeTruthy();
-    expect(profilingOutput.some(line => line.includes('Person: (InfectionStatus)'))).toBeTruthy();
 });
 
 test('simulation error (simulated panic) as expected', async ({ page }) => {
-    await page.goto('http://localhost:8080');
+    await page.goto(TEST_PAGE);
 
     const result = await page.evaluate(async () => {
         let wasm = await window.setupWasm();
@@ -84,7 +97,7 @@ test('simulation error (simulated panic) as expected', async ({ page }) => {
 });
 
 test('simulation completes successfully in a web worker', async ({ page }) => {
-    await page.goto('http://localhost:8080');
+    await page.goto(TEST_PAGE);
 
     const result = await page.evaluate(async () => {
         return new Promise((resolve, reject) => {
@@ -109,51 +122,50 @@ test('simulation completes successfully in a web worker', async ({ page }) => {
 });
 
 test('query profiling prints in the browser and a web worker', async ({ page }) => {
-    const profilingOutput = [];
-    page.on('console', message => {
-        const text = message.text();
-        if (!(text.includes('Query') && text.includes('Count')) &&
-            !text.includes('Person: (InfectionStatus)')) {
-            return;
-        }
+    await page.goto(TEST_PAGE);
 
-        profilingOutput.push(text);
-        // eslint-disable-next-line no-console
-        console.log(text);
-    });
+    const browserOutput = waitForProfilingTable(page);
+    const [browserResult] = await Promise.all([
+        page.evaluate(async () => {
+            const wasm = await window.setupWasm();
+            return wasm.run_query_profiling();
+        }),
+        browserOutput,
+    ]);
 
-    await page.goto('http://localhost:8080');
-
-    const browserResult = await page.evaluate(async () => {
-        const wasm = await window.setupWasm();
-        return wasm.run_query_profiling();
-    });
-
-    const workerResult = await page.evaluate(async () => {
-        return new Promise((resolve, reject) => {
-            const worker = new Worker('/worker.js', { type: 'module' });
+    const workerController = await page.evaluateHandle(() => {
+        const worker = new Worker('/worker.js', { type: 'module' });
+        const result = new Promise((resolve, reject) => {
             worker.onmessage = (e) => {
-                worker.terminate();
                 if (e.data.status === 'ok') {
                     resolve(e.data.result);
                 } else {
                     reject(new Error(e.data.message));
                 }
             };
-            worker.onerror = (e) => {
-                worker.terminate();
-                reject(new Error(e.message));
-            };
-            worker.postMessage('query-profiling');
+            worker.onerror = (e) => reject(new Error(e.message));
         });
+
+        return { worker, result };
     });
+    const workerOutput = waitForProfilingTable(page);
+    let workerResult;
+
+    try {
+        [workerResult] = await Promise.all([
+            workerController.evaluate(({ worker, result }) => {
+                worker.postMessage('query-profiling');
+                return result;
+            }),
+            workerOutput,
+        ]);
+    } finally {
+        await workerController.evaluate(({ worker }) => worker.terminate());
+        await workerController.dispose();
+    }
 
     expect(browserResult).toBe(100);
     expect(workerResult).toBe(100);
-    const headers = profilingOutput.filter(line => line.includes('Query') && line.includes('Count'));
-    const rows = profilingOutput.filter(line => line.includes('Person: (InfectionStatus)'));
-    expect(headers).toHaveLength(2);
-    expect(rows).toHaveLength(2);
 });
 
 test('real wasm panic emits console error', async ({ page }) => {
@@ -162,7 +174,7 @@ test('real wasm panic emits console error', async ({ page }) => {
     const pageErrors = [];
     page.on('pageerror', err => pageErrors.push(err.message));
 
-    await page.goto('http://localhost:8080');
+    await page.goto(TEST_PAGE);
 
     // Trigger the panic synchronously (not awaited) so the panic hook
     // can output to console before the promise rejection is handled.

--- a/mise.toml
+++ b/mise.toml
@@ -95,7 +95,7 @@ run = '''
 [tasks.'test:wasm']
 description = "Run wasm integration tests"
 dir = "integration-tests/ixa-wasm-tests"
-depends = ["wasm:pnpm", "wasm:check-profiling", "wasm:compile"]
+depends = ["wasm:pnpm", "wasm:check-features", "wasm:compile"]
 run = "pnpm exec playwright test"
 
 [tasks.'test:features']
@@ -123,13 +123,19 @@ outputs = 'node_modules/.pnpm/lock.yaml'
 
 [tasks.'wasm:compile']
 dir = "integration-tests/ixa-wasm-tests"
-run = ["mise run rust:version", "wasm-pack build --target web"]
-sources = ["src/*.rs", "Cargo.toml"]
-outputs = "pkg"
-
-[tasks.'wasm:check-profiling']
 run = [
   "mise run rust:version",
+  "wasm-pack build --target web",
+  "wasm-pack build --target web --out-dir pkg/logging --no-default-features --features logging",
+  "wasm-pack build --target web --out-dir pkg/profiling --no-default-features --features profiling",
+]
+sources = ["src/*.rs", "Cargo.toml"]
+outputs = ["pkg/ixa_wasm_tests.js", "pkg/logging/ixa_wasm_tests.js", "pkg/profiling/ixa_wasm_tests.js"]
+
+[tasks.'wasm:check-features']
+run = [
+  "mise run rust:version",
+  "cargo check --package ixa --target wasm32-unknown-unknown --no-default-features --features logging",
   "cargo check --package ixa --target wasm32-unknown-unknown --no-default-features --features profiling",
 ]
 

--- a/mise.toml
+++ b/mise.toml
@@ -137,6 +137,7 @@ run = [
   "mise run rust:version",
   "cargo check --package ixa --target wasm32-unknown-unknown --no-default-features --features logging",
   "cargo check --package ixa --target wasm32-unknown-unknown --no-default-features --features profiling",
+  "cargo check --manifest-path integration-tests/ixa-wasm-tests/Cargo.toml --target wasm32-unknown-unknown --no-default-features",
 ]
 
 [tasks.'bench']


### PR DESCRIPTION
## Summary

  - Generalize the WASM feature check to cover both `logging` and `profiling`.
  - Build logging-only and profiling-only WASM integration artifacts.
  - Add Playwright tests that verify each feature works at runtime in the browser.
  - Retain the existing combined-feature browser and Web Worker coverage.

  Closes #1036.